### PR TITLE
Fail ControllerPublishVolume when volume doesn't exist

### DIFF
--- a/pkg/azuredisk/azuredisk.go
+++ b/pkg/azuredisk/azuredisk.go
@@ -17,6 +17,7 @@ limitations under the License.
 package azuredisk
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
@@ -125,4 +126,23 @@ func getResourceGroupFromDiskURI(diskURI string) (string, error) {
 		return "", fmt.Errorf("invalid disk URI: %s", diskURI)
 	}
 	return fields[4], nil
+}
+
+func (d *Driver) checkDiskExists(ctx context.Context, diskURI string) error {
+	diskName, err := getDiskName(diskURI)
+	if err != nil {
+		return err
+	}
+
+	resourceGroup, err := getResourceGroupFromDiskURI(diskURI)
+	if err != nil {
+		return err
+	}
+
+	_, err = d.cloud.DisksClient.Get(ctx, resourceGroup, diskName)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
Signed off by: Priyanshu Khandelwal masquerade0097@gmail.com
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Fix the following Sanity test failure 

```
[Fail] Controller Service ControllerPublishVolume [It] should fail when the volume does not exist 
/home/priyanshu/work/src/github.com/csi-driver/azuredisk-csi-driver/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/controller.go:883
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Addresses #46 

**Special notes for your reviewer**:


**Release note**:
```
Fail ControllerPublishVolume when volume does not exist
```
