### PR TITLE
fix DeleteVolume sanity test for invalid volumeId

### DIFF
--- a/pkg/azuredisk/azuredisk.go
+++ b/pkg/azuredisk/azuredisk.go
@@ -35,8 +35,10 @@ const (
 )
 
 var (
-	managedDiskPathRE   = regexp.MustCompile(`.*/subscriptions/(?:.*)/resourceGroups/(?:.*)/providers/Microsoft.Compute/disks/(.+)`)
-	unmanagedDiskPathRE = regexp.MustCompile(`http(?:.*)://(?:.*)/vhds/(.+)`)
+	managedDiskPathRE       = regexp.MustCompile(`.*/subscriptions/(?:.*)/resourceGroups/(?:.*)/providers/Microsoft.Compute/disks/(.+)`)
+	unmanagedDiskPathRE     = regexp.MustCompile(`http(?:.*)://(?:.*)/vhds/(.+)`)
+	diskURISupportedManaged = []string{"/subscriptions/{sub-id}/resourcegroups/{group-name}/providers/microsoft.compute/disks/{disk-id}"}
+	diskURISupportedBlob    = []string{"https://{account-name}.blob.core.windows.net/{container-name}/{disk-name}.vhd"}
 )
 
 // Driver implements all interfaces of CSI drivers
@@ -134,6 +136,20 @@ func (d *Driver) checkDiskExists(ctx context.Context, diskURI string) error {
 	_, err = d.cloud.DisksClient.Get(ctx, resourceGroup, diskName)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (d *Driver) validateDiskURI(diskURI string) error {
+	if isManagedDisk(diskURI) {
+		if strings.Index(diskURI, "/subscriptions/") != 0 {
+			return fmt.Errorf("Inavlid DiskURI: %v, correct format: %v", diskURI, diskURISupportedManaged)
+		}
+	} else {
+		if strings.Index(diskURI, "https://") != 0 {
+			return fmt.Errorf("Inavlid DiskURI: %v, correct format: %v", diskURI, diskURISupportedBlob)
+		}
 	}
 
 	return nil

--- a/pkg/azuredisk/azuredisk.go
+++ b/pkg/azuredisk/azuredisk.go
@@ -141,7 +141,7 @@ func (d *Driver) checkDiskExists(ctx context.Context, diskURI string) error {
 	return nil
 }
 
-func (d *Driver) validateDiskURI(diskURI string) error {
+func isValidDiskURI(diskURI string) error {
 	if isManagedDisk(diskURI) {
 		if strings.Index(diskURI, "/subscriptions/") != 0 {
 			return fmt.Errorf("Inavlid DiskURI: %v, correct format: %v", diskURI, diskURISupportedManaged)

--- a/pkg/azuredisk/azuredisk_test.go
+++ b/pkg/azuredisk/azuredisk_test.go
@@ -129,3 +129,41 @@ func TestGetResourceGroupFromDiskURI(t *testing.T) {
 		}
 	}
 }
+
+func TestIsValidDiskURI(t *testing.T) {
+	supportedManagedDiskURI := diskURISupportedManaged
+	supportedBlobDiskURI := diskURISupportedBlob
+
+	tests := []struct {
+		diskURI     string
+		expectError error
+	}{
+		{
+			diskURI:     "/subscriptions/b9d2281e/resourceGroups/test-resource/providers/Microsoft.Compute/disks/pvc-disk-dynamic-9e102c53",
+			expectError: nil,
+		},
+		{
+			diskURI:     "resourceGroups/test-resource/providers/Microsoft.Compute/disks/pvc-disk-dynamic-9e102c53",
+			expectError: fmt.Errorf("Inavlid DiskURI: resourceGroups/test-resource/providers/Microsoft.Compute/disks/pvc-disk-dynamic-9e102c53, correct format: %v", supportedManagedDiskURI),
+		},
+		{
+			diskURI:     "https://test-saccount.blob.core.windows.net/container/pvc-disk-dynamic-9e102c53-593d-11e9-934e-705a0f18a318.vhd",
+			expectError: nil,
+		},
+		{
+			diskURI:     "test.com",
+			expectError: fmt.Errorf("Inavlid DiskURI: test.com, correct format: %v", supportedManagedDiskURI),
+		},
+		{
+			diskURI:     "http://test-saccount.blob.core.windows.net/container/pvc-disk-dynamic-9e102c53-593d-11e9-934e-705a0f18a318.vhd",
+			expectError: fmt.Errorf("Inavlid DiskURI: http://test-saccount.blob.core.windows.net/container/pvc-disk-dynamic-9e102c53-593d-11e9-934e-705a0f18a318.vhd, correct format: %v", supportedBlobDiskURI),
+		},
+	}
+
+	for _, test := range tests {
+		err := isValidDiskURI(test.diskURI)
+		if !reflect.DeepEqual(err, test.expectError) {
+			t.Errorf("DiskURI: %q, isValidDiskURI err: %q, expected1: %q", test.diskURI, err, test.expectError)
+		}
+	}
+}

--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -249,6 +249,12 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 
 	klog.V(2).Infof("deleting azure disk(%s)", diskURI)
 	if isManagedDisk(diskURI) {
+		_, err := getResourceGroupFromDiskURI(diskURI)
+		if err != nil {
+			klog.Errorf("getResourceGroupFromDiskURI(%s) in DeleteVolume failed with error: %v", err)
+			return &csi.DeleteVolumeResponse{}, nil
+		}
+
 		if err := d.cloud.DeleteManagedDisk(diskURI); err != nil {
 			return &csi.DeleteVolumeResponse{}, err
 		}

--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -247,7 +247,7 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 	}
 	diskURI := req.VolumeId
 
-	if err := d.validateDiskURI(diskURI); err != nil {
+	if err := isValidDiskURI(diskURI); err != nil {
 		klog.Errorf("validateDiskURI(%s) in DeleteVolume failed with error: %v", diskURI, err)
 		return &csi.DeleteVolumeResponse{}, nil
 	}

--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -247,14 +247,13 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 	}
 	diskURI := req.VolumeId
 
+	if err := d.validateDiskURI(diskURI); err != nil {
+		klog.Errorf("validateDiskURI(%s) in DeleteVolume failed with error: %v", diskURI, err)
+		return &csi.DeleteVolumeResponse{}, nil
+	}
+
 	klog.V(2).Infof("deleting azure disk(%s)", diskURI)
 	if isManagedDisk(diskURI) {
-		_, err := getResourceGroupFromDiskURI(diskURI)
-		if err != nil {
-			klog.Errorf("getResourceGroupFromDiskURI(%s) in DeleteVolume failed with error: %v", err)
-			return &csi.DeleteVolumeResponse{}, nil
-		}
-
 		if err := d.cloud.DeleteManagedDisk(diskURI); err != nil {
 			return &csi.DeleteVolumeResponse{}, err
 		}


### PR DESCRIPTION
**What type of PR is this?**


 /kind bug

**What this PR does / why we need it**:
Fixes the following failure in sanity testing - 
```
[Fail] Controller Service DeleteVolume [It] should succeed when an invalid volume id is used 
/home/priyanshu/work/src/github.com/csi-driver/azuredisk-csi-driver/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/controller.go:543
```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
fix DeleteVolume sanity test for invalid volumeId
```
