### PR TITLE
fix error when 2 pods mount same disk pvc on the same node

### DIFF
--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -91,8 +91,14 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	}
 
 	if !notMnt {
-		msg := fmt.Sprintf("target %q is not a valid mount point", target)
-		return nil, status.Error(codes.InvalidArgument, msg)
+		klog.V(2).Infof("target %q is already a valid mount point(device path: %v), skip format and mount", target, devicePath)
+		// todo: check who is mounted here. No error if its us
+		/*
+			1) Target Path MUST be the vol referenced by vol ID
+			2) VolumeCapability MUST match
+			3) Readonly MUST match
+		*/
+		return &csi.NodeStageVolumeResponse{}, nil
 	}
 	// Get fsType that the volume will be formatted with
 	fsType := getFStype(req.GetVolumeContext())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When 2 pods mount same disk pvc on the same node, there will be error like error:
```
target "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-de4f7c7d-5c76-11e9-9ea8-000d3a269e74/globalmount" is not a valid mount point
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #73

**Special notes for your reviewer**:


**Release note**:
```
fix error when 2 pods mount same disk pvc on the same node
```
