### PR TITLE
fix: remove unnecessary go-autorest dep in Go dep

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -563,7 +563,7 @@
     "protobuf/field_mask",
   ]
   pruneopts = "NUT"
-  revision = "989357319d63150615221e52d4addd4b7933fd91"
+  revision = "621ef7fb66c1288c79ce6bdba008e0068b34e12f"
 
 [[projects]]
   digest = "1:1ec4bc6f7cbf98268fafafea40cdeb5ff5d4914cc9b9ef615fbbfc1ac43c0622"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -101,7 +101,3 @@
 [[override]]
   name = "github.com/Azure/azure-sdk-for-go"
   version = "v21.4.0"
-
-[[override]]
-  name = "github.com/Azure/go-autorest"
-  version = "v11.5.1"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
remove unnecessary go-autorest dep in Go dep
https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/93 introduces an unnecessary go dep config, now remove it

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
none
```
