### PR TITLE
feat: enable prometheus metrics in deployment

### DIFF
--- a/deploy/csi-azuredisk-controller.yaml
+++ b/deploy/csi-azuredisk-controller.yaml
@@ -85,6 +85,9 @@ spec:
             - containerPort: 9602
               name: healthz
               protocol: TCP
+            - containerPort: 10252
+              name: metrics
+              protocol: TCP
           livenessProbe:
             failureThreshold: 5
             httpGet:
@@ -117,3 +120,16 @@ spec:
         - name: msi
           hostPath:
             path: /var/lib/waagent/ManagedIdentity-Settings
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: csi-azuredisk-controller
+  namespace: kube-system
+spec:
+  selector:
+    app: csi-azuredisk-controller
+  ports:
+  - port: 10252
+    targetPort: 10252
+  type: ClusterIP

--- a/pkg/azurediskplugin/main.go
+++ b/pkg/azurediskplugin/main.go
@@ -38,7 +38,7 @@ var (
 	endpoint       = flag.String("endpoint", "unix://tmp/csi.sock", "CSI endpoint")
 	nodeID         = flag.String("nodeid", "", "node id")
 	version        = flag.Bool("version", false, "Print the version and exit.")
-	metricsAddress = flag.String("metrics-address", "127.0.0.1:10252", "export the metrics")
+	metricsAddress = flag.String("metrics-address", "0.0.0.0:10252", "export the metrics")
 )
 
 func main() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: enable prometheus metrics in deployment

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
```
$ kubectl get svc -n kube-system | grep azuredisk
csi-azuredisk-controller   ClusterIP   10.0.207.216   <none>        10252/TCP       8s

# make sure you are now in the vnet with current k8s cluster
$ curl http://10.0.207.216:10252/metrics

$ curl http://10.0.207.216:10252/metrics | grep cloudprovider | grep -e sum -e count 0cloudprovider_azure_api_request_duration_seconds_sum{request="disks_create_or_update",resource_group="mc_andy-virtualnode_andy-virtualnode_eastus2",source="",subscription_id="..."} 5.655316338
cloudprovider_azure_api_request_duration_seconds_count{request="disks_create_or_update",resource_group="mc_andy-virtualnode_andy-virtualnode_eastus2",source="",subscription_id="..."} 1
cloudprovider_azure_api_request_duration_seconds_sum{request="disks_get",resource_group="mc_andy-virtualnode_andy-virtualnode_eastus2",source="",subscription_id="..."} 0.09935221000000001
cloudprovider_azure_api_request_duration_seconds_count{request="disks_get",resource_group="mc_andy-virtualnode_andy-virtualnode_eastus2",source="",subscription_id="..."} 2
cloudprovider_azure_api_request_duration_seconds_sum{request="vm_create_or_update",resource_group="mc_andy-virtualnode_andy-virtualnode_eastus2",source="attach_disk",subscription_id="..."} 35.480765035
cloudprovider_azure_api_request_duration_seconds_count{request="vm_create_or_update",resource_group="mc_andy-virtualnode_andy-virtualnode_eastus2",source="attach_disk",subscription_id="..."} 1
cloudprovider_azure_api_request_duration_seconds_sum{request="vm_create_or_update",resource_group="mc_andy-virtualnode_andy-virtualnode_eastus2",source="detach_disk",subscription_id="..."} 25.511212182
cloudprovider_azure_api_request_duration_seconds_count{request="vm_create_or_update",resource_group="mc_andy-virtualnode_andy-virtualnode_eastus2",source="detach_disk",subscription_id="..."} 1
cloudprovider_azure_api_request_duration_seconds_sum{request="vm_get",resource_group="mc_andy-virtualnode_andy-virtualnode_eastus2",source="",subscription_id="..."} 0.329327292
cloudprovider_azure_api_request_duration_seconds_count{request="vm_get",resource_group="mc_andy-virtualnode_andy-virtualnode_eastus2",source="",subscription_id="..."} 3
```

**Release note**:
```
feat: enable prometheus metrics in deployment
```

cc @ZeroMagic 