### PR TITLE
fix: return the default MaxVolumesPerNode

### DIFF
--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -293,7 +293,8 @@ func (d *Driver) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (
 
 	instanceType, err := instances.InstanceType(context.TODO(), types.NodeName(d.NodeID))
 	if err != nil {
-		return nil, status.Error(codes.Internal, "Failed to get instance type from Azure cloud provider, nodeName: "+d.NodeID)
+		klog.Warningf("Failed to get instance type from Azure cloud provider, nodeName: %v, error: %v", d.NodeID, err)
+		instanceType = ""
 	}
 
 	if vmSizeList == nil {
@@ -313,7 +314,7 @@ func (d *Driver) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (
 }
 
 func getMaxDataDiskCount(instanceType string, sizeList *[]compute.VirtualMachineSize) int64 {
-	if sizeList == nil {
+	if instanceType == "" || sizeList == nil {
 		return defaultAzureVolumeLimit
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug
> /kind failing-test

**What this PR does / why we need it**:
When we can't get instance type, it should be set "". 
Then the function will return defaultAzureVolumeLimit.

```
[Fail] Node Service NodeGetInfo [It] should return approproate values
/root/go/src/github.com/kubernetes-sigs/azuredisk-csi-driver/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/node.go:146

[Fail] Node Service [It] should work
/root/go/src/github.com/kubernetes-sigs/azuredisk-csi-driver/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/node.go:375
```
With the PR, these two failures will be fixed.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #46 

**Special notes for your reviewer**:


**Release note**:
```
fix: return the default MaxVolumesPerNode
```
