### PR TITLE
[WIP]fix: use storageClass to prepare e2e disk

### DIFF
--- a/test/e2e/driver/azuredisk_csi_driver.go
+++ b/test/e2e/driver/azuredisk_csi_driver.go
@@ -42,7 +42,7 @@ func InitAzureDiskCSIDriver() PVTestDriver {
 func (d *azureDiskCSIDriver) GetDynamicProvisionStorageClass(parameters map[string]string, mountOptions []string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, bindingMode *storagev1.VolumeBindingMode, allowedTopologyValues []string, namespace string) *storagev1.StorageClass {
 	provisioner := d.driverName
 	generateName := fmt.Sprintf("%s-%s-dynamic-sc-", namespace, provisioner)
-	return getStorageClass(generateName, provisioner, parameters, mountOptions, reclaimPolicy, bindingMode, nil)
+	return GetStorageClass(generateName, provisioner, parameters, mountOptions, reclaimPolicy, bindingMode, nil)
 }
 
 func (d *azureDiskCSIDriver) GetVolumeSnapshotClass(namespace string) *v1alpha1.VolumeSnapshotClass {

--- a/test/e2e/driver/driver.go
+++ b/test/e2e/driver/driver.go
@@ -50,7 +50,7 @@ type VolumeSnapshotTestDriver interface {
 	GetVolumeSnapshotClass(namespace string) *v1alpha1.VolumeSnapshotClass
 }
 
-func getStorageClass(
+func GetStorageClass(
 	generateName string,
 	provisioner string,
 	parameters map[string]string,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In order to just use kubernetes client to create volume, we need to use storageClass to prepare disk.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #140 

**Special notes for your reviewer**:


**Release note**:
```
use storageClass to prepare e2e disk
```
