### PR TITLE
Keep helm chart in sync with manifests in deploy folder

### DIFF
--- a/deploy/csi-azuredisk-node.yaml
+++ b/deploy/csi-azuredisk-node.yaml
@@ -22,7 +22,7 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-          image: quay.io/k8scsi/livenessprobe:v1.0.2
+          image: quay.io/k8scsi/livenessprobe:v1.1.0
           args:
             - --csi-address=/csi/csi.sock
             - --connection-timeout=3s

--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -23,3 +23,4 @@ ${PKG_ROOT}/hack/verify-govet.sh
 ${PKG_ROOT}/hack/verify-golint.sh
 ${PKG_ROOT}/hack/verify-dep.sh
 ${PKG_ROOT}/hack/verify-boilerplate.sh
+${PKG_ROOT}/hack/verify-helm-chart.sh

--- a/hack/verify-helm-chart.sh
+++ b/hack/verify-helm-chart.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+readonly PKG_ROOT="$(git rev-parse --show-toplevel)"
+
+function get_image_from_helm_chart() {
+  local -r image_name="${1}"
+  image_repository="$(cat ${PKG_ROOT}/charts/latest/azuredisk-csi-driver/values.yaml | yq -r .image.${image_name}.repository)"
+  image_tag="$(cat ${PKG_ROOT}/charts/latest/azuredisk-csi-driver/values.yaml | yq -r .image.${image_name}.tag)"
+  echo "${image_repository}:${image_tag}"
+}
+
+function validate_image() {
+  local -r expected_image="${1}"
+  local -r image="${2}"
+
+  if [[ "${expected_image}" != "${image}" ]]; then
+    echo "Expected ${expected_image}, but got ${image} in helm chart"
+    exit 1
+  fi
+}
+
+echo "Comparing image version between helm chart and manifests in deploy folder"
+
+# jq-equivalent for yaml
+pip install yq
+
+# Extract images from csi-azuredisk-controller.yaml
+expected_csi_provisioner_image="$(cat ${PKG_ROOT}/deploy/csi-azuredisk-controller.yaml | yq -r .spec.template.spec.containers[0].image | head -n 1)"
+expected_csi_attacher_image="$(cat ${PKG_ROOT}/deploy/csi-azuredisk-controller.yaml | yq -r .spec.template.spec.containers[1].image | head -n 1)"
+expected_cluster_driver_registrar_image="$(cat ${PKG_ROOT}/deploy/csi-azuredisk-controller.yaml | yq -r .spec.template.spec.containers[2].image | head -n 1)"
+expected_csi_snapshotter_image="$(cat ${PKG_ROOT}/deploy/csi-azuredisk-controller.yaml | yq -r .spec.template.spec.containers[3].image | head -n 1)"
+expected_liveness_probe_image="$(cat ${PKG_ROOT}/deploy/csi-azuredisk-controller.yaml | yq -r .spec.template.spec.containers[4].image | head -n 1)"
+expected_azuredisk_image="$(cat ${PKG_ROOT}/deploy/csi-azuredisk-controller.yaml | yq -r .spec.template.spec.containers[5].image | head -n 1)"
+
+csi_provisioner_image="$(get_image_from_helm_chart "csiProvisioner")"
+validate_image "${expected_csi_provisioner_image}" "${csi_provisioner_image}"
+
+csi_attacher_image="$(get_image_from_helm_chart "csiAttacher")"
+validate_image "${expected_csi_attacher_image}" "${csi_attacher_image}"
+
+cluster_driver_registrar_image="$(get_image_from_helm_chart "clusterDriverRegistrar")"
+validate_image "${expected_cluster_driver_registrar_image}" "${cluster_driver_registrar_image}"
+
+csi_snapshotter_image="$(get_image_from_helm_chart "csiSnapshotter")"
+validate_image "${expected_csi_snapshotter_image}" "${csi_snapshotter_image}"
+
+liveness_probe_image="$(get_image_from_helm_chart "livenessProbe")"
+validate_image "${expected_liveness_probe_image}" "${liveness_probe_image}"
+
+azuredisk_image="$(get_image_from_helm_chart "azuredisk")"
+validate_image "${expected_azuredisk_image}" "${azuredisk_image}"
+
+# Extract images from csi-azuredisk-node.yaml
+expected_liveness_probe_image="$(cat ${PKG_ROOT}/deploy/csi-azuredisk-node.yaml | yq -r .spec.template.spec.containers[0].image | head -n 1)"
+expected_node_driver_registrar="$(cat ${PKG_ROOT}/deploy/csi-azuredisk-node.yaml | yq -r .spec.template.spec.containers[1].image | head -n 1)"
+expected_azuredisk_image="$(cat ${PKG_ROOT}/deploy/csi-azuredisk-node.yaml | yq -r .spec.template.spec.containers[2].image | head -n 1)"
+
+validate_image "${expected_liveness_probe_image}" "${liveness_probe_image}"
+
+node_driver_registrar="$(get_image_from_helm_chart "nodeDriverRegistrar")"
+validate_image "${expected_node_driver_registrar}" "${node_driver_registrar}"
+
+validate_image "${expected_azuredisk_image}" "${azuredisk_image}"
+
+echo "Images in deploy/ matches those in the latest helm chart."


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature
> /kind flake

/kind test

**What this PR does / why we need it**:
Added a check in `pull-azuredisk-csi-driver-verify` that will compare image version in helm chart with manifests in the deploy folder, and return an exit code 1 if a mismatch is found.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #203 
Fixes #197

**Special notes for your reviewer**:


**Release note**:
```

```
