### PR TITLE
Enable MSI option for VMAS cluster

### DIFF
--- a/test/e2e/manifest/multi-az.json
+++ b/test/e2e/manifest/multi-az.json
@@ -7,7 +7,6 @@
             "orchestratorRelease": "1.16",
             "kubernetesConfig": {
                 "useCloudControllerManager": true,
-                "customCcmImage": "mcr.microsoft.com/k8s/core/azure-cloud-controller-manager:v0.3.0",
                 "networkPolicy": "none",
                 "cloudProviderRateLimitQPS": 6,
                 "cloudProviderRateLimitBucket": 20,

--- a/test/e2e/manifest/single-az.json
+++ b/test/e2e/manifest/single-az.json
@@ -6,8 +6,8 @@
             "orchestratorType": "Kubernetes",
             "orchestratorRelease": "1.16",
             "kubernetesConfig": {
+                "useManagedIdentity": true,
                 "useCloudControllerManager": true,
-                "customCcmImage": "mcr.microsoft.com/k8s/core/azure-cloud-controller-manager:v0.3.0",
                 "networkPolicy": "none",
                 "cloudProviderRateLimitQPS": 6,
                 "cloudProviderRateLimitBucket": 20,
@@ -57,10 +57,6 @@
                     }
                 ]
             }
-        },
-        "servicePrincipalProfile": {
-            "clientID": "{clientID}",
-            "secret": "{secret}"
         }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Extracted changes from #261 so that e2e test in #261 can be run on a VMAS cluster with MSI enabled after this PR is merged

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #256

**Special notes for your reviewer**:
/assign @andyzhangx 

**Release note**:
```

```
