### PR TITLE
 fix: use KubeRegistry instead of prometheus default registry

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -11,7 +11,7 @@ Quick start instructions for the setup and configuration of azuredisk CSI driver
 ```console
 $ cd $GOPATH/src/sigs.k8s.io/azuredisk-csi-driver/charts/latest
 $ helm package azuredisk-csi-driver
-$ helm install -n azuredisk-csi-driver azuredisk-csi-driver-latest.tgz --namespace kube-system
+$ helm install azuredisk-csi-driver azuredisk-csi-driver-latest.tgz --namespace kube-system
 ```
 
 ## Uninstall

--- a/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
+++ b/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
@@ -69,9 +69,13 @@ spec:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(KUBE_NODE_NAME)"
+            - "--metrics-address=0.0.0.0:{{ .Values.node.metricsPort }}"
           ports:
             - containerPort: 29603
               name: healthz
+              protocol: TCP
+            - containerPort: {{ .Values.node.metricsPort }}
+              name: metrics
               protocol: TCP
           livenessProbe:
             failureThreshold: 5

--- a/charts/latest/azuredisk-csi-driver/values.yaml
+++ b/charts/latest/azuredisk-csi-driver/values.yaml
@@ -45,5 +45,8 @@ rbac:
 controller:
   replicas: 2
 
+node:
+  metricsPort: 29605
+
 snapshotController:
   replicas: 1

--- a/deploy/csi-azuredisk-node.yaml
+++ b/deploy/csi-azuredisk-node.yaml
@@ -69,9 +69,13 @@ spec:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(KUBE_NODE_NAME)"
+            - "--metrics-address=0.0.0.0:29605"
           ports:
             - containerPort: 29603
               name: healthz
+              protocol: TCP
+            - containerPort: 29605
+              name: metrics
               protocol: TCP
           livenessProbe:
             failureThreshold: 5

--- a/pkg/azurediskplugin/main.go
+++ b/pkg/azurediskplugin/main.go
@@ -27,7 +27,7 @@ import (
 
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk"
 
-	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog"
 )
 
@@ -93,7 +93,7 @@ func serve(ctx context.Context, l net.Listener, serveFunc func(net.Listener) err
 
 func serveMetrics(l net.Listener) error {
 	m := http.NewServeMux()
-	m.Handle("/metrics", promhttp.Handler())
+	m.Handle("/metrics", legacyregistry.Handler()) //nolint, because azure cloud provider uses legacyregistry currently
 	return trapClosedConnErr(http.Serve(l, m))
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind flake

**What this PR does / why we need it**:
After refactored, azure cloud provider uses the Kube registry to export metrics. We should register the handler associated with the Kube registry, instead of that is built-in in the Prometheus default registry.
https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go#L39-L47


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #280 

**Special notes for your reviewer**:


**Release note**:
```

```
