### PR TITLE
feat: add azure disk WriteAccelerator support

### DIFF
--- a/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-driver.yaml
+++ b/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-driver.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: true
-  volumeLifecycleModes:
+  volumeLifecycleModes:  # added in Kubernetes 1.16
     - Persistent

--- a/deploy/csi-azuredisk-driver.yaml
+++ b/deploy/csi-azuredisk-driver.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: true
-  volumeLifecycleModes:
+  volumeLifecycleModes:  # added in Kubernetes 1.16
     - Persistent

--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -17,6 +17,7 @@ DiskIOPSReadWrite | [UltraSSD disk](https://docs.microsoft.com/en-us/azure/virtu
 DiskMBpsReadWrite | [UltraSSD disk](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/disks-ultra-ssd) Throughput Capability | 1~2000 | No | `100`
 tags | azure disk [tags](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources) | tag format: 'foo=aaa,bar=bbb' | No | ""
 diskEncryptionSetID | ResourceId of the disk encryption set to use for [enabling encryption at rest](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/disk-encryption) | format: `/subscriptions/{subs-id}/resourceGroups/{rg-name}/providers/Microsoft.Compute/diskEncryptionSets/{diskEncryptionSet-name}` | No | ""
+writeAcceleratorEnabled | Write Accelerator on Azure Disks [https://docs.microsoft.com/azure/virtual-machines/windows/how-to-enable-write-accelerator) | `true`, `false` | No | ""
 
  - Static Provisioning(use existing azure disk)
   > get a quick example [here](../deploy/example/pv-azuredisk-csi.yaml)

--- a/pkg/azuredisk/azuredisk.go
+++ b/pkg/azuredisk/azuredisk.go
@@ -63,7 +63,7 @@ const (
 	// see https://docs.microsoft.com/en-us/rest/api/compute/disks/createorupdate#create-a-managed-disk-from-an-existing-managed-disk-in-the-same-or-different-subscription.
 	managedDiskPath = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/%s"
 
-	devicePath = "devicePath"
+	LUN = "LUN"
 )
 
 var (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR:
  - did a cleanup with `getDevicePathWithLUN` func
  - adds azure disk WriteAccelerator support
added a new parameter(`writeAcceleratorEnabled` case insensitive) in azure disk storage class, for static provisioning, user needs to add a new tag(`writeacceleratorenabled` case **sensitive**) on azure disk before using as disk PV.

```
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: ssd
provisioner: kubernetes.io/azure-disk
parameters:
  skuname: Premium_LRS
  writeAcceleratorEnabled: "true"
```

 - background
For high performance applications, like databases, using Write Accelerator on disks where the database log is stored can improve performance. If customers are already using M or Mv2 VM types, they can use Write Accelerator at no additional costs.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #276

**Special notes for your reviewer**:
original k/k PR: https://github.com/kubernetes/kubernetes/pull/87945

**Release note**:
```
feat: add azure disk WriteAccelerator support
```
