### PR TITLE
docs fix: use correct path to check volume contents

### DIFF
--- a/deploy/example/snapshot/README.md
+++ b/deploy/example/snapshot/README.md
@@ -16,7 +16,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi
 ### Check the Source PVC
 
 ```console
-$ kubectl exec nginx-azuredisk -- ls /mnt/disk
+$ kubectl exec nginx-azuredisk -- ls /mnt/azuredisk
 lost+found
 outfile
 ```
@@ -69,7 +69,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi
 ### Check Sample Data
 
 ```console
-$ kubectl exec nginx-restored -- ls /mnt/disk
+$ kubectl exec nginx-restored -- ls /mnt/azuredisk
 lost+found
 outfile
 ```


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design

/kind documentation

> /kind test
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fix commands in snapshots example to use correct path when checking volume contents

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

See correct mountPaths: 

https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/master/deploy/example/nginx-pod-azuredisk.yaml#L18
https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/master/deploy/example/snapshot/nginx-pod-restored-snapshot.yaml#L17


**Release note**:
```

```
