### PR TITLE
fix: change imagePullPolicy to IfNotPresent

### DIFF
--- a/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
+++ b/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
@@ -39,7 +39,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -61,7 +60,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
           - mountPath: /csi
             name: socket-dir

--- a/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
+++ b/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
@@ -17,9 +17,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
+      tolerations:
+        - operator: "Exists"
       containers:
         - name: liveness-probe
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/charts/latest/azuredisk-csi-driver/values.yaml
+++ b/charts/latest/azuredisk-csi-driver/values.yaml
@@ -2,39 +2,39 @@ image:
   azuredisk:
     repository: mcr.microsoft.com/k8s/csi/azuredisk-csi
     tag: latest
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   csiProvisioner:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner
     tag: v1.5.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   csiAttacher:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-attacher
     tag: v1.2.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   clusterDriverRegistrar:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-cluster-driver-registrar
     tag: v1.0.1
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   csiSnapshotter:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter
     tag: v2.0.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   csiResizer:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-resizer
     tag: v0.3.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   livenessProbe:
     repository: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe
     tag: v1.1.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   nodeDriverRegistrar:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar
-    tag: v1.1.0
-    pullPolicy: Always
+    tag: v1.2.0
+    pullPolicy: IfNotPresent
   csiSnapshotController:
     repository: mcr.microsoft.com/oss/kubernetes-csi/snapshot-controller
     tag: v2.0.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
 
 serviceAccount:
   create: true

--- a/charts/v0.2.0/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
+++ b/charts/v0.2.0/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
@@ -28,7 +28,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -41,7 +40,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
           - mountPath: /csi
             name: socket-dir

--- a/charts/v0.2.0/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
+++ b/charts/v0.2.0/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
@@ -19,7 +19,6 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: liveness-probe
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/charts/v0.2.0/azuredisk-csi-driver/values.yaml
+++ b/charts/v0.2.0/azuredisk-csi-driver/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: mcr.microsoft.com/k8s/csi/azuredisk-csi
   tag: v0.2.0-alpha
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 serviceAccount:
   create: true

--- a/charts/v0.3.0/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
+++ b/charts/v0.3.0/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
@@ -28,7 +28,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -41,7 +40,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
           - mountPath: /csi
             name: socket-dir

--- a/charts/v0.3.0/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
+++ b/charts/v0.3.0/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
@@ -19,7 +19,6 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: liveness-probe
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/charts/v0.3.0/azuredisk-csi-driver/values.yaml
+++ b/charts/v0.3.0/azuredisk-csi-driver/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: mcr.microsoft.com/k8s/csi/azuredisk-csi
   tag: v0.3.0
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 serviceAccount:
   create: true

--- a/charts/v0.4.0/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
+++ b/charts/v0.4.0/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
@@ -28,7 +28,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -41,7 +40,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
           - mountPath: /csi
             name: socket-dir

--- a/charts/v0.4.0/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
+++ b/charts/v0.4.0/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
@@ -19,7 +19,6 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: liveness-probe
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/charts/v0.4.0/azuredisk-csi-driver/values.yaml
+++ b/charts/v0.4.0/azuredisk-csi-driver/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: mcr.microsoft.com/k8s/csi/azuredisk-csi
   tag: v0.4.0
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 serviceAccount:
   create: true

--- a/charts/v0.5.0/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
+++ b/charts/v0.5.0/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
@@ -33,7 +33,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -48,7 +47,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
           - mountPath: /csi
             name: socket-dir

--- a/charts/v0.5.0/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
+++ b/charts/v0.5.0/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
@@ -19,7 +19,6 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: liveness-probe
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/charts/v0.5.0/azuredisk-csi-driver/values.yaml
+++ b/charts/v0.5.0/azuredisk-csi-driver/values.yaml
@@ -2,35 +2,35 @@ image:
   azuredisk:
     repository: mcr.microsoft.com/k8s/csi/azuredisk-csi
     tag: v0.5.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   csiProvisioner:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner
     tag: v1.4.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   csiAttacher:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-attacher
     tag: v1.2.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   clusterDriverRegistrar:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-cluster-driver-registrar
     tag: v1.0.1
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   csiSnapshotter:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter
     tag: v1.1.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   csiResizer:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-resizer
     tag: v0.3.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   livenessProbe:
     repository: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe
     tag: v1.1.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   nodeDriverRegistrar:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar
     tag: v1.1.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
 
 serviceAccount:
   create: true

--- a/charts/v0.6.0/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
+++ b/charts/v0.6.0/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
@@ -34,7 +34,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -56,7 +55,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
           - mountPath: /csi
             name: socket-dir

--- a/charts/v0.6.0/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
+++ b/charts/v0.6.0/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
@@ -19,7 +19,6 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: liveness-probe
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/charts/v0.6.0/azuredisk-csi-driver/values.yaml
+++ b/charts/v0.6.0/azuredisk-csi-driver/values.yaml
@@ -2,39 +2,39 @@ image:
   azuredisk:
     repository: mcr.microsoft.com/k8s/csi/azuredisk-csi
     tag: v0.6.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   csiProvisioner:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner
     tag: v1.5.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   csiAttacher:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-attacher
     tag: v1.2.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   clusterDriverRegistrar:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-cluster-driver-registrar
     tag: v1.0.1
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   csiSnapshotter:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter
     tag: v2.0.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   csiResizer:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-resizer
     tag: v0.3.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   livenessProbe:
     repository: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe
     tag: v1.1.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   nodeDriverRegistrar:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar
     tag: v1.1.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   csiSnapshotController:
     repository: mcr.microsoft.com/oss/kubernetes-csi/snapshot-controller
     tag: v2.0.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
 
 serviceAccount:
   create: true

--- a/deploy/csi-azuredisk-controller.yaml
+++ b/deploy/csi-azuredisk-controller.yaml
@@ -39,7 +39,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -61,7 +60,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -172,7 +170,6 @@ spec:
               value: "/etc/kubernetes/azure.json"
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/deploy/csi-azuredisk-node-windows.yaml
+++ b/deploy/csi-azuredisk-node-windows.yaml
@@ -18,7 +18,6 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: liveness-probe
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: C:\csi
               name: plugin-dir
@@ -58,7 +57,6 @@ spec:
               mountPath: C:\csi
             - name: registration-dir
               mountPath: C:\registration
-          imagePullPolicy: Always
           resources:
             limits:
               cpu: 200m
@@ -97,7 +95,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          imagePullPolicy: Always
           securityContext:
             privileged: true
           volumeMounts:

--- a/deploy/csi-azuredisk-node.yaml
+++ b/deploy/csi-azuredisk-node.yaml
@@ -17,9 +17,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
+      tolerations:
+        - operator: "Exists"
       containers:
         - name: liveness-probe
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -37,7 +38,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: node-driver-registrar
-          image: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v1.1.0
+          image: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v1.2.0
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -95,7 +96,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          imagePullPolicy: Always
           securityContext:
             privileged: true
           volumeMounts:

--- a/deploy/csi-snapshot-controller.yaml
+++ b/deploy/csi-snapshot-controller.yaml
@@ -29,7 +29,6 @@ spec:
           args:
             - "--v=5"
             - "-leader-election"
-          imagePullPolicy: Always
           resources:
             limits:
               cpu: 1000m

--- a/deploy/v0.2.0/csi-azuredisk-controller.yaml
+++ b/deploy/v0.2.0/csi-azuredisk-controller.yaml
@@ -28,7 +28,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -41,7 +40,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
@@ -89,7 +87,6 @@ spec:
               value: "/etc/kubernetes/azure.json"
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/deploy/v0.2.0/csi-azuredisk-node.yaml
+++ b/deploy/v0.2.0/csi-azuredisk-node.yaml
@@ -18,7 +18,6 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: liveness-probe
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -75,7 +74,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          imagePullPolicy: Always
           securityContext:
             privileged: true
           volumeMounts:

--- a/deploy/v0.3.0/csi-azuredisk-controller.yaml
+++ b/deploy/v0.3.0/csi-azuredisk-controller.yaml
@@ -28,7 +28,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -41,7 +40,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
@@ -89,7 +87,6 @@ spec:
               value: "/etc/kubernetes/azure.json"
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/deploy/v0.3.0/csi-azuredisk-node.yaml
+++ b/deploy/v0.3.0/csi-azuredisk-node.yaml
@@ -18,7 +18,6 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: liveness-probe
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -75,7 +74,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          imagePullPolicy: Always
           securityContext:
             privileged: true
           volumeMounts:

--- a/deploy/v0.4.0/csi-azuredisk-controller.yaml
+++ b/deploy/v0.4.0/csi-azuredisk-controller.yaml
@@ -28,7 +28,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -41,7 +40,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
@@ -89,7 +87,6 @@ spec:
               value: "/etc/kubernetes/azure.json"
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/deploy/v0.4.0/csi-azuredisk-node.yaml
+++ b/deploy/v0.4.0/csi-azuredisk-node.yaml
@@ -18,7 +18,6 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: liveness-probe
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -75,7 +74,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          imagePullPolicy: Always
           securityContext:
             privileged: true
           volumeMounts:

--- a/deploy/v0.5.0/csi-azuredisk-controller.yaml
+++ b/deploy/v0.5.0/csi-azuredisk-controller.yaml
@@ -33,7 +33,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -48,7 +47,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
@@ -122,7 +120,6 @@ spec:
               value: "/etc/kubernetes/azure.json"
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/deploy/v0.5.0/csi-azuredisk-node.yaml
+++ b/deploy/v0.5.0/csi-azuredisk-node.yaml
@@ -18,7 +18,6 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: liveness-probe
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -75,7 +74,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          imagePullPolicy: Always
           securityContext:
             privileged: true
           volumeMounts:

--- a/deploy/v0.6.0/csi-azuredisk-controller.yaml
+++ b/deploy/v0.6.0/csi-azuredisk-controller.yaml
@@ -34,7 +34,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -56,7 +55,6 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -167,7 +165,6 @@ spec:
               value: "/etc/kubernetes/azure.json"
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/deploy/v0.6.0/csi-azuredisk-node.yaml
+++ b/deploy/v0.6.0/csi-azuredisk-node.yaml
@@ -19,7 +19,6 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: liveness-probe
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -95,7 +94,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          imagePullPolicy: Always
           securityContext:
             privileged: true
           volumeMounts:

--- a/deploy/v0.6.0/csi-snapshot-controller.yaml
+++ b/deploy/v0.6.0/csi-snapshot-controller.yaml
@@ -24,7 +24,6 @@ spec:
           args:
             - "--v=5"
             - "-leader-election"
-          imagePullPolicy: Always
           resources:
             limits:
               cpu: 1000m


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
This PR
 - change `imagePullPolicy` from `Always` to `IfNotPresent`([default value](https://kubernetes.io/docs/concepts/containers/images/#updating-images)), this PR could save around 1min for start up CSI driver deamonset pod on new VMSS node on AKS (with autoscaler enabled)
 - make node daemonset ignore taint
 - change `csi-node-driver-registrar` version to `v1.2.0`

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
none
```
