### PR TITLE
chore: remove cluster driver registrar

### DIFF
--- a/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
+++ b/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
@@ -70,25 +70,6 @@ spec:
             requests:
               cpu: 10m
               memory: 20Mi
-        - name: cluster-driver-registrar
-          image: "{{ .Values.image.clusterDriverRegistrar.repository }}:{{ .Values.image.clusterDriverRegistrar.tag }}"
-          args:
-            - --csi-address=$(ADDRESS)
-            - --driver-requires-attachment=true
-            - --v=5
-          env:
-            - name: ADDRESS
-              value: /csi/csi.sock
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /csi
-          resources:
-            limits:
-              cpu: 200m
-              memory: 200Mi
-            requests:
-              cpu: 10m
-              memory: 20Mi
         {{- if .Values.snapshot.enabled}}
         - name: csi-snapshotter
           image: "{{ .Values.snapshot.image.csiSnapshotter.repository }}:{{ .Values.snapshot.image.csiSnapshotter.tag }}"

--- a/charts/latest/azuredisk-csi-driver/values.yaml
+++ b/charts/latest/azuredisk-csi-driver/values.yaml
@@ -11,10 +11,6 @@ image:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-attacher
     tag: v1.2.0
     pullPolicy: IfNotPresent
-  clusterDriverRegistrar:
-    repository: mcr.microsoft.com/oss/kubernetes-csi/csi-cluster-driver-registrar
-    tag: v1.0.1
-    pullPolicy: IfNotPresent
   csiResizer:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-resizer
     tag: v0.3.0

--- a/deploy/csi-azuredisk-controller.yaml
+++ b/deploy/csi-azuredisk-controller.yaml
@@ -70,25 +70,6 @@ spec:
             requests:
               cpu: 10m
               memory: 20Mi
-        - name: cluster-driver-registrar
-          image: mcr.microsoft.com/oss/kubernetes-csi/csi-cluster-driver-registrar:v1.0.1
-          args:
-            - --csi-address=$(ADDRESS)
-            - --driver-requires-attachment=true
-            - --v=5
-          env:
-            - name: ADDRESS
-              value: /csi/csi.sock
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /csi
-          resources:
-            limits:
-              cpu: 200m
-              memory: 200Mi
-            requests:
-              cpu: 10m
-              memory: 20Mi
         - name: csi-snapshotter
           image: mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter:v2.0.0
           args:

--- a/hack/verify-helm-chart.sh
+++ b/hack/verify-helm-chart.sh
@@ -43,20 +43,16 @@ pip install yq
 # Extract images from csi-azuredisk-controller.yaml
 expected_csi_provisioner_image="$(cat ${PKG_ROOT}/deploy/csi-azuredisk-controller.yaml | yq -r .spec.template.spec.containers[0].image | head -n 1)"
 expected_csi_attacher_image="$(cat ${PKG_ROOT}/deploy/csi-azuredisk-controller.yaml | yq -r .spec.template.spec.containers[1].image | head -n 1)"
-expected_cluster_driver_registrar_image="$(cat ${PKG_ROOT}/deploy/csi-azuredisk-controller.yaml | yq -r .spec.template.spec.containers[2].image | head -n 1)"
-expected_csi_snapshotter_image="$(cat ${PKG_ROOT}/deploy/csi-azuredisk-controller.yaml | yq -r .spec.template.spec.containers[3].image | head -n 1)"
-expected_csi_resizer_image="$(cat ${PKG_ROOT}/deploy/csi-azuredisk-controller.yaml | yq -r .spec.template.spec.containers[4].image | head -n 1)"
-expected_liveness_probe_image="$(cat ${PKG_ROOT}/deploy/csi-azuredisk-controller.yaml | yq -r .spec.template.spec.containers[5].image | head -n 1)"
-expected_azuredisk_image="$(cat ${PKG_ROOT}/deploy/csi-azuredisk-controller.yaml | yq -r .spec.template.spec.containers[6].image | head -n 1)"
+expected_csi_snapshotter_image="$(cat ${PKG_ROOT}/deploy/csi-azuredisk-controller.yaml | yq -r .spec.template.spec.containers[2].image | head -n 1)"
+expected_csi_resizer_image="$(cat ${PKG_ROOT}/deploy/csi-azuredisk-controller.yaml | yq -r .spec.template.spec.containers[3].image | head -n 1)"
+expected_liveness_probe_image="$(cat ${PKG_ROOT}/deploy/csi-azuredisk-controller.yaml | yq -r .spec.template.spec.containers[4].image | head -n 1)"
+expected_azuredisk_image="$(cat ${PKG_ROOT}/deploy/csi-azuredisk-controller.yaml | yq -r .spec.template.spec.containers[5].image | head -n 1)"
 
 csi_provisioner_image="$(get_image_from_helm_chart ".image.csiProvisioner")"
 validate_image "${expected_csi_provisioner_image}" "${csi_provisioner_image}"
 
 csi_attacher_image="$(get_image_from_helm_chart ".image.csiAttacher")"
 validate_image "${expected_csi_attacher_image}" "${csi_attacher_image}"
-
-cluster_driver_registrar_image="$(get_image_from_helm_chart ".image.clusterDriverRegistrar")"
-validate_image "${expected_cluster_driver_registrar_image}" "${cluster_driver_registrar_image}"
 
 csi_snapshotter_image="$(get_image_from_helm_chart ".snapshot.image.csiSnapshotter")"
 validate_image "${expected_csi_snapshotter_image}" "${csi_snapshotter_image}"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
According to Kubernetes CSI Developer Documentation, the cluster-driver-registrar side-car which was used to create CSIDriver objects in Kubernetes 1.13 has been deprecated for Kubernetes 1.16. No cluster-driver-registrar has been released for Kubernetes 1.14 and later.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #335 

**Special notes for your reviewer**:


**Release note**:
```
remove cluster driver registrar
```
