### PR TITLE
test: deflake deployment test case

### DIFF
--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -272,10 +272,10 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool) {
 		}
 
 		podCheckCmd := []string{"cat", "/mnt/test-1/data"}
-		expectedString := "hello world\nhello world\n"
+		expectedString := "hello world\n"
 		if isWindowsCluster {
 			podCheckCmd = []string{"powershell.exe", "cat", "C:\\mnt\\test-1\\data.txt"}
-			expectedString = "hello world\r\nhello world\r\n"
+			expectedString = "hello world\r\n"
 		}
 		test := testsuites.DynamicallyProvisionedDeletePodTest{
 			CSIDriver: testDriver,

--- a/test/e2e/testsuites/dynamically_provisioned_delete_pod_tester.go
+++ b/test/e2e/testsuites/dynamically_provisioned_delete_pod_tester.go
@@ -51,6 +51,11 @@ func (t *DynamicallyProvisionedDeletePodTest) Run(client clientset.Interface, na
 	ginkgo.By("checking that the pod is running")
 	tDeployment.WaitForPodReady()
 
+	if t.PodCheck != nil {
+		ginkgo.By("checking pod exec")
+		tDeployment.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString)
+	}
+
 	ginkgo.By("deleting the pod for deployment")
 	tDeployment.DeletePodAndWait()
 
@@ -59,6 +64,7 @@ func (t *DynamicallyProvisionedDeletePodTest) Run(client clientset.Interface, na
 
 	if t.PodCheck != nil {
 		ginkgo.By("checking pod exec")
-		tDeployment.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString)
+		// pod will be restarted so expect to see 2 instances of string
+		tDeployment.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString+t.PodCheck.ExpectedString)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

For `should create a deployment object, write and read to it, delete the pod and write and read to it again` test case, we should ensure the text file created by the deployment exists before deleting the pod.

/assign @andyzhangx 
/test pull-in-tree-azure-disk-e2e-windows

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/pull/89768#issuecomment-607910662.

**Special notes for your reviewer**:


**Release note**:
```

```
