### PR TITLE
chore: remove volumeLifecycleModes in CSIDriver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,8 @@ ifdef TEST_WINDOWS
 	helm install azuredisk-csi-driver charts/latest/azuredisk-csi-driver --namespace kube-system --wait --timeout=15m -v=5 --debug \
 		--set image.azuredisk.repository=$(REGISTRY)/$(IMAGE_NAME) \
 		--set image.azuredisk.tag=$(IMAGE_VERSION) \
-		--set windows.enabled=true
+		--set windows.enabled=true \
+		--set controller.replicas=1
 else
 	helm install azuredisk-csi-driver charts/latest/azuredisk-csi-driver --namespace kube-system --wait --timeout=15m -v=5 --debug \
 		--set image.azuredisk.repository=$(REGISTRY)/$(IMAGE_NAME) \

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This driver allows Kubernetes to use [azure disk](https://azure.microsoft.com/en
 |v0.4.0                         |mcr.microsoft.com/k8s/csi/azuredisk-csi:v0.4.0      | yes    |
 
 ### Kubernetes Compatibility
-| Azure Disk CSI Driver\Kubernetes Version | 1.16+ |
+| Azure Disk CSI Driver\Kubernetes Version | 1.14+ |
 |------------------------------------------|-------|
 | master branch                            | yes   |
 | v0.6.0                                   | yes   |

--- a/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-driver.yaml
+++ b/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-driver.yaml
@@ -5,5 +5,3 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: true
-  volumeLifecycleModes:  # added in Kubernetes 1.16
-    - Persistent

--- a/charts/v0.6.0/azuredisk-csi-driver/templates/csi-azuredisk-driver.yaml
+++ b/charts/v0.6.0/azuredisk-csi-driver/templates/csi-azuredisk-driver.yaml
@@ -5,5 +5,3 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: true
-  volumeLifecycleModes:  # added in Kubernetes 1.16
-    - Persistent

--- a/deploy/csi-azuredisk-driver.yaml
+++ b/deploy/csi-azuredisk-driver.yaml
@@ -6,5 +6,3 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: true
-  volumeLifecycleModes:  # added in Kubernetes 1.16
-    - Persistent

--- a/deploy/v0.6.0/csi-azuredisk-driver.yaml
+++ b/deploy/v0.6.0/csi-azuredisk-driver.yaml
@@ -6,5 +6,3 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: true
-  volumeLifecycleModes:  # added in Kubernetes 1.16
-    - Persistent


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
Since we won't support inline feature in the near future, the `volumeLifecycleModes` field is unnecessary. So that azuredisk-csi-driver can be still compatible with v1.14+.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```

```
