### PR TITLE
Allow disabling controller/node service via command line flags

### DIFF
--- a/docs/driver-services.md
+++ b/docs/driver-services.md
@@ -1,0 +1,12 @@
+### `disk.csi.azure.com` driver services
+ 
+Traditionally, you run the CSI controllers with the Azure Disk driver in the same Kubernetes cluster.
+Though, there may be cases where you will only want to run a subset of the available driver services (for example, one scenario is running the controllers outside of the cluster they are serving (while the Azure Disk driver still runs inside the served cluster), but there might be others scenarios).
+The CSI driver consists out of these services:
+
+* The **controller** service starts the GRPC server that serves `CreateVolume`, `DeleteVolume`, etc. It is depending on the Azure cloud config + credentials and talks with the Azure API.
+* The **identity** service is responsible to provide identity services like capability information of the CSI plugin.
+* The **node** service implements the various operations for volumes that are run locally from the node, for example `NodePublishVolume`, `NodeStageVolume`, etc. It does not do operations like `CreateVolume` or `ControllerPublish`. Also, it runs directly on the Azure VM instances. It is depending on the Azure cloud config but does not necessarily need to have the credentials.
+
+The CSI driver has two command line flags, `--run-controller-service` and `--run-node-service` which both default to `true`.
+You can disable the individual services by setting the respective flags to `false`.

--- a/pkg/azurediskplugin/main.go
+++ b/pkg/azurediskplugin/main.go
@@ -36,11 +36,13 @@ func init() {
 }
 
 var (
-	endpoint       = flag.String("endpoint", "unix://tmp/csi.sock", "CSI endpoint")
-	nodeID         = flag.String("nodeid", "", "node id")
-	version        = flag.Bool("version", false, "Print the version and exit.")
-	metricsAddress = flag.String("metrics-address", "0.0.0.0:29604", "export the metrics")
-	kubeconfig     = flag.String("kubeconfig", "", "Absolute path to the kubeconfig file. Required only when running out of cluster.")
+	endpoint             = flag.String("endpoint", "unix://tmp/csi.sock", "CSI endpoint")
+	kubeconfig           = flag.String("kubeconfig", "", "Absolute path to the kubeconfig file. Required only when running out of cluster.")
+	metricsAddress       = flag.String("metrics-address", "0.0.0.0:29604", "export the metrics")
+	nodeID               = flag.String("nodeid", "", "node id")
+	runControllerService = flag.Bool("run-controller-service", true, "If set to false then the CSI driver does not activate its controller service (default: true)")
+	runNodeService       = flag.Bool("run-node-service", true, "If set to false then the CSI driver does not activate its node service (default: true)")
+	version              = flag.Bool("version", false, "Print the version and exit.")
 )
 
 func main() {
@@ -54,7 +56,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	if *nodeID == "" {
+	if *nodeID == "" && *runNodeService {
 		// nodeid is not needed in controller component
 		klog.Warning("nodeid is empty")
 	}
@@ -69,7 +71,7 @@ func handle() {
 	if driver == nil {
 		klog.Fatalln("Failed to initialize azuredisk CSI Driver")
 	}
-	driver.Run(*endpoint, *kubeconfig)
+	driver.Run(*endpoint, *kubeconfig, *runControllerService, *runNodeService)
 }
 
 func exportMetrics() {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -96,7 +96,7 @@ var _ = ginkgo.BeforeSuite(func() {
 		kubeconfig := os.Getenv(kubeconfigEnvVar)
 		go func() {
 			os.Setenv("AZURE_CREDENTIAL_FILE", credentials.TempAzureCredentialFilePath)
-			azurediskDriver.Run(fmt.Sprintf("unix:///tmp/csi-%s.sock", uuid.NewUUID().String()), kubeconfig)
+			azurediskDriver.Run(fmt.Sprintf("unix:///tmp/csi-%s.sock", uuid.NewUUID().String()), kubeconfig, true, true)
 		}()
 	}
 })


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds two new command line flags `--run-controller-service` and `--run-node-service` (both default to `true`) which allow to particularly disable individual services if not required.

This enables the use-case of running the CSI controllers (csi-provisioner, csi-attacher, etc., + the driver controller) separately outside of the cluster they are serving. The disk plugin (node service part of CSI driver) still runs inside the cluster.

**Release note**:
```
It is now possible to disable the controller service by setting `--run-controller-service=false`. Similarly, it is possible to disable the node service by setting `--run-node-service=false`. The latter enables running the controller server of the Azure Disk driver separately/outside of the cluster it is serving.
```

