### PR TITLE
Cleanup usage of /devhost volume for v0.6.0

### DIFF
--- a/charts/v0.6.0/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
+++ b/charts/v0.6.0/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
@@ -108,7 +108,7 @@ spec:
             - mountPath: /var/lib/waagent/ManagedIdentity-Settings
               readOnly: true
               name: msi
-            - mountPath: /devhost #use /devhost to avoid conflict
+            - mountPath: /dev
               name: device-dir
             - mountPath: /sys/bus/scsi/devices
               name: sys-devices-dir

--- a/deploy/v0.6.0/csi-azuredisk-node.yaml
+++ b/deploy/v0.6.0/csi-azuredisk-node.yaml
@@ -107,7 +107,7 @@ spec:
             - mountPath: /var/lib/waagent/ManagedIdentity-Settings
               readOnly: true
               name: msi
-            - mountPath: /devhost  # use /devhost to avoid conflict
+            - mountPath: /dev
               name: device-dir
             - mountPath: /sys/bus/scsi/devices
               name: sys-devices-dir


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Cleanup `/devhost` usage in example resources for `v0.6.0` after #313

**Which issue(s) this PR fixes**:
Ref #360

**Release note**:
```

```
