### PR TITLE
Do not install golangci-lint with 'go get'

### DIFF
--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-GO111MODULE=off go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0
 
 golangci-lint run --deadline=10m
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind flake 

**What this PR does / why we need it**:
Currently the go get for golangci-lint is failing with:
```
$ go get github.com/golangci/golangci-lint/cmd/golangci-lint
# github.com/golangci/golangci-lint/pkg/golinters
go/src/github.com/golangci/golangci-lint/pkg/golinters/golint.go:21:14: l.LintPkg undefined (type *"github.com/golangci/lint-1".Linter has no field or method LintPkg)
go/src/github.com/golangci/golangci-lint/pkg/golinters/gomnd.go:13:6: cannot use magic_numbers.Analyzer (type *"github.com/tommy-muehle/go-mnd/vendor/golang.org/x/tools/go/analysis".Analyzer) as type *"golang.org/x/tools/go/analysis".Analyzer in array or slice literal
```

The README.md of golangci-lint recommends to do not use go get for installation - https://github.com/golangci/golangci-lint#go.

This PR also pins the golangci-lint version to a stable one - v1.24.0.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
NONE
```
