### PR TITLE
chore: upgrade csi-attacher to v2.2.0

### DIFF
--- a/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
+++ b/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
@@ -54,7 +54,6 @@ spec:
             - "-csi-address=$(ADDRESS)"
             - "-timeout=120s"
             - "-leader-election"
-            - "-leader-election-type=leases"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/charts/latest/azuredisk-csi-driver/templates/rbac-csi-azuredisk-controller.yaml
+++ b/charts/latest/azuredisk-csi-driver/templates/rbac-csi-azuredisk-controller.yaml
@@ -69,7 +69,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]

--- a/charts/latest/azuredisk-csi-driver/values.yaml
+++ b/charts/latest/azuredisk-csi-driver/values.yaml
@@ -9,7 +9,7 @@ image:
     pullPolicy: IfNotPresent
   csiAttacher:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-attacher
-    tag: v2.0.0
+    tag: v2.2.0
     pullPolicy: IfNotPresent
   csiResizer:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-resizer

--- a/charts/latest/azuredisk-csi-driver/values.yaml
+++ b/charts/latest/azuredisk-csi-driver/values.yaml
@@ -9,7 +9,7 @@ image:
     pullPolicy: IfNotPresent
   csiAttacher:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-attacher
-    tag: v1.2.0
+    tag: v2.0.0
     pullPolicy: IfNotPresent
   csiResizer:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-resizer

--- a/deploy/csi-azuredisk-controller.yaml
+++ b/deploy/csi-azuredisk-controller.yaml
@@ -48,13 +48,12 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: csi-attacher
-          image: mcr.microsoft.com/oss/kubernetes-csi/csi-attacher:v1.2.0
+          image: mcr.microsoft.com/oss/kubernetes-csi/csi-attacher:v2.0.0
           args:
             - "-v=5"
             - "-csi-address=$(ADDRESS)"
             - "-timeout=120s"
             - "-leader-election"
-            - "-leader-election-type=leases"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/deploy/csi-azuredisk-controller.yaml
+++ b/deploy/csi-azuredisk-controller.yaml
@@ -48,7 +48,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: csi-attacher
-          image: mcr.microsoft.com/oss/kubernetes-csi/csi-attacher:v2.0.0
+          image: mcr.microsoft.com/oss/kubernetes-csi/csi-attacher:v2.2.0
           args:
             - "-v=5"
             - "-csi-address=$(ADDRESS)"

--- a/deploy/rbac-csi-azuredisk-controller.yaml
+++ b/deploy/rbac-csi-azuredisk-controller.yaml
@@ -71,7 +71,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
chore: upgrade csi-attacher to v2.2.0
To support `LIST_VOLUMES_PUBLISHED_NODES` capability

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #339

**Special notes for your reviewer**:
/hold
hold on, need to check whether csi-attacher `v2.2.0` supports v1.14 or not

**Release note**:
```
none
```
