### PR TITLE
Revert "test: enable topology for azure disk in-tree e2e tests"

### DIFF
--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -120,10 +120,6 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool) {
 			Pods:                   pods,
 			StorageClassParameters: map[string]string{"skuName": "Standard_LRS"},
 		}
-
-		if isMultiZone && isUsingInTreeVolumePlugin {
-			test.StorageClassParameters["zoned"] = "true"
-		}
 		test.Run(cs, ns)
 	})
 
@@ -154,9 +150,6 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool) {
 			Pods:                   pods,
 			StorageClassParameters: map[string]string{"skuName": "StandardSSD_LRS"},
 		}
-		if isMultiZone && isUsingInTreeVolumePlugin {
-			test.StorageClassParameters["zoned"] = "true"
-		}
 		test.Run(cs, ns)
 	})
 
@@ -182,9 +175,6 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool) {
 			CSIDriver:              testDriver,
 			Pods:                   pods,
 			StorageClassParameters: map[string]string{"skuName": "Premium_LRS"},
-		}
-		if isMultiZone && isUsingInTreeVolumePlugin {
-			test.StorageClassParameters["zoned"] = "true"
 		}
 		test.Run(cs, ns)
 	})
@@ -212,9 +202,6 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool) {
 			CSIDriver:              testDriver,
 			Pods:                   pods,
 			StorageClassParameters: map[string]string{"skuName": "StandardSSD_LRS"},
-		}
-		if isMultiZone && isUsingInTreeVolumePlugin {
-			test.StorageClassParameters["zoned"] = "true"
 		}
 		test.Run(cs, ns)
 	})
@@ -270,9 +257,6 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool) {
 			ColocatePods:           true,
 			StorageClassParameters: map[string]string{"skuName": "Premium_LRS"},
 		}
-		if isMultiZone && isUsingInTreeVolumePlugin {
-			test.StorageClassParameters["zoned"] = "true"
-		}
 		test.Run(cs, ns)
 	})
 
@@ -321,9 +305,6 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool) {
 		test := testsuites.DynamicallyProvisionedReclaimPolicyTest{
 			CSIDriver: testDriver,
 			Volumes:   volumes,
-		}
-		if isMultiZone && isUsingInTreeVolumePlugin {
-			test.StorageClassParameters["zoned"] = "true"
 		}
 		test.Run(cs, ns)
 	})
@@ -417,9 +398,6 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool) {
 			Pods:                   pods,
 			StorageClassParameters: map[string]string{"skuName": "StandardSSD_LRS"},
 		}
-		if isMultiZone && isUsingInTreeVolumePlugin {
-			test.StorageClassParameters["zoned"] = "true"
-		}
 		test.Run(cs, ns)
 	})
 
@@ -455,9 +433,6 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool) {
 			CSIDriver:              testDriver,
 			Pods:                   pods,
 			StorageClassParameters: map[string]string{"skuName": "Premium_LRS"},
-		}
-		if isMultiZone && isUsingInTreeVolumePlugin {
-			test.StorageClassParameters["zoned"] = "true"
 		}
 		test.Run(cs, ns)
 	})


### PR DESCRIPTION
Reverts kubernetes-sigs/azuredisk-csi-driver#383
actually it's not a necessary test change, `zoned` is always true for managed disk