### PR TITLE
chore: upgrade snapshot controller to v2.1.1

### DIFF
--- a/charts/latest/azuredisk-csi-driver/templates/crd-csi-snapshot.yaml
+++ b/charts/latest/azuredisk-csi-driver/templates/crd-csi-snapshot.yaml
@@ -4,21 +4,57 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/139"
+    controller-gen.kubebuilder.io/version: v0.2.5
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/260"
   creationTimestamp: null
   name: volumesnapshots.snapshot.storage.k8s.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.readyToUse
+    description: Indicates if a snapshot is ready to be used to restore a volume.
+    name: ReadyToUse
+    type: boolean
+  - JSONPath: .spec.source.persistentVolumeClaimName
+    description: Name of the source PVC from where a dynamically taken snapshot will
+      be created.
+    name: SourcePVC
+    type: string
+  - JSONPath: .spec.source.volumeSnapshotContentName
+    description: Name of the VolumeSnapshotContent which represents a pre-provisioned
+      snapshot.
+    name: SourceSnapshotContent
+    type: string
+  - JSONPath: .status.restoreSize
+    description: Represents the complete size of the snapshot.
+    name: RestoreSize
+    type: string
+  - JSONPath: .spec.volumeSnapshotClassName
+    description: The name of the VolumeSnapshotClass requested by the VolumeSnapshot.
+    name: SnapshotClass
+    type: string
+  - JSONPath: .status.boundVolumeSnapshotContentName
+    description: The name of the VolumeSnapshotContent to which this VolumeSnapshot
+      is bound.
+    name: SnapshotContent
+    type: string
+  - JSONPath: .status.creationTime
+    description: Timestamp when the point-in-time snapshot is taken by the underlying
+      storage system.
+    name: CreationTime
+    type: date
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: snapshot.storage.k8s.io
   names:
     kind: VolumeSnapshot
     listKind: VolumeSnapshotList
     plural: volumesnapshots
     singular: volumesnapshot
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
-  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       description: VolumeSnapshot is a user's request for either creating a point-in-time
@@ -27,12 +63,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         spec:
           description: 'spec defines the desired characteristics of a snapshot requested
@@ -63,7 +99,7 @@ spec:
                 on empty string. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes'
               type: string
           required:
-            - source
+          - source
           type: object
         status:
           description: 'status represents the current information of a snapshot. NOTE:
@@ -121,6 +157,9 @@ spec:
                 of a snapshot is unknown.
               type: boolean
             restoreSize:
+              anyOf:
+              - type: integer
+              - type: string
               description: restoreSize represents the complete size of the snapshot
                 in bytes. In dynamic snapshot creation case, this field will be filled
                 in with the "size_bytes" value returned from CSI "CreateSnapshotRequest"
@@ -130,16 +169,17 @@ spec:
                 this snapshot, the size of the volume MUST NOT be smaller than the
                 restoreSize if it is specified, otherwise the restoration will fail.
                 If not specified, it indicates that the size is unknown.
-              type: string
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
           type: object
       required:
-        - spec
+      - spec
       type: object
   version: v1beta1
   versions:
-    - name: v1beta1
-      served: true
-      storage: true
+  - name: v1beta1
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""
@@ -152,19 +192,32 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/139"
+    controller-gen.kubebuilder.io/version: v0.2.5
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/260"
   creationTimestamp: null
   name: volumesnapshotclasses.snapshot.storage.k8s.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .driver
+    name: Driver
+    type: string
+  - JSONPath: .deletionPolicy
+    description: Determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass
+      should be deleted when its bound VolumeSnapshot is deleted.
+    name: DeletionPolicy
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: snapshot.storage.k8s.io
   names:
     kind: VolumeSnapshotClass
     listKind: VolumeSnapshotClassList
     plural: volumesnapshotclasses
     singular: volumesnapshotclass
-  scope: Cluster
   preserveUnknownFields: false
+  scope: Cluster
+  subresources: {}
   validation:
     openAPIV3Schema:
       description: VolumeSnapshotClass specifies parameters that a underlying storage
@@ -175,7 +228,7 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         deletionPolicy:
           description: deletionPolicy determines whether a VolumeSnapshotContent created
@@ -185,8 +238,8 @@ spec:
             storage system are kept. "Delete" means that the VolumeSnapshotContent
             and its physical snapshot on underlying storage system are deleted. Required.
           enum:
-            - Delete
-            - Retain
+          - Delete
+          - Retain
           type: string
         driver:
           description: driver is the name of the storage driver that handles this
@@ -195,7 +248,7 @@ spec:
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         parameters:
           additionalProperties:
@@ -204,14 +257,14 @@ spec:
             parameters for creating snapshots. These values are opaque to Kubernetes.
           type: object
       required:
-        - deletionPolicy
-        - driver
+      - deletionPolicy
+      - driver
       type: object
   version: v1beta1
   versions:
-    - name: v1beta1
-      served: true
-      storage: true
+  - name: v1beta1
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""
@@ -224,21 +277,53 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/139"
+    controller-gen.kubebuilder.io/version: v0.2.5
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/260"
   creationTimestamp: null
   name: volumesnapshotcontents.snapshot.storage.k8s.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.readyToUse
+    description: Indicates if a snapshot is ready to be used to restore a volume.
+    name: ReadyToUse
+    type: boolean
+  - JSONPath: .status.restoreSize
+    description: Represents the complete size of the snapshot in bytes
+    name: RestoreSize
+    type: integer
+  - JSONPath: .spec.deletionPolicy
+    description: Determines whether this VolumeSnapshotContent and its physical snapshot
+      on the underlying storage system should be deleted when its bound VolumeSnapshot
+      is deleted.
+    name: DeletionPolicy
+    type: string
+  - JSONPath: .spec.driver
+    description: Name of the CSI driver used to create the physical snapshot on the
+      underlying storage system.
+    name: Driver
+    type: string
+  - JSONPath: .spec.volumeSnapshotClassName
+    description: Name of the VolumeSnapshotClass to which this snapshot belongs.
+    name: VolumeSnapshotClass
+    type: string
+  - JSONPath: .spec.volumeSnapshotRef.name
+    description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent
+      object is bound.
+    name: VolumeSnapshot
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: snapshot.storage.k8s.io
   names:
     kind: VolumeSnapshotContent
     listKind: VolumeSnapshotContentList
     plural: volumesnapshotcontents
     singular: volumesnapshotcontent
+  preserveUnknownFields: false
   scope: Cluster
   subresources:
     status: {}
-  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       description: VolumeSnapshotContent represents the actual "on-disk" snapshot
@@ -247,12 +332,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         spec:
           description: spec defines properties of a VolumeSnapshotContent created
@@ -271,8 +356,8 @@ spec:
                 pre-existing snapshots, users MUST specify this field when creating
                 the VolumeSnapshotContent object. Required.
               enum:
-                - Delete
-                - Retain
+              - Delete
+              - Retain
               type: string
             driver:
               description: driver is the name of the CSI driver used to create the
@@ -324,7 +409,7 @@ spec:
                     in the future.'
                   type: string
                 kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                   type: string
                 name:
                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
@@ -334,17 +419,17 @@ spec:
                   type: string
                 resourceVersion:
                   description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                   type: string
                 uid:
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                   type: string
               type: object
           required:
-            - deletionPolicy
-            - driver
-            - source
-            - volumeSnapshotRef
+          - deletionPolicy
+          - driver
+          - source
+          - volumeSnapshotRef
           type: object
         status:
           description: status represents the current information of a snapshot.
@@ -406,13 +491,13 @@ spec:
               type: string
           type: object
       required:
-        - spec
+      - spec
       type: object
   version: v1beta1
   versions:
-    - name: v1beta1
-      served: true
-      storage: true
+  - name: v1beta1
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""

--- a/charts/latest/azuredisk-csi-driver/templates/csi-snapshot-controller.yaml
+++ b/charts/latest/azuredisk-csi-driver/templates/csi-snapshot-controller.yaml
@@ -29,7 +29,7 @@ spec:
           image: "{{ .Values.snapshot.image.csiSnapshotController.repository }}:{{ .Values.snapshot.image.csiSnapshotController.tag }}"
           args:
             - "--v=5"
-            - "-leader-election"
+            - "--leader-election=false"
           resources:
             limits:
               cpu: 1000m

--- a/charts/latest/azuredisk-csi-driver/values.yaml
+++ b/charts/latest/azuredisk-csi-driver/values.yaml
@@ -41,11 +41,11 @@ snapshot:
   image:
     csiSnapshotter:
       repository: mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter
-      tag: v2.0.0
+      tag: v2.0.1
       pullPolicy: IfNotPresent
     csiSnapshotController:
       repository: mcr.microsoft.com/oss/kubernetes-csi/snapshot-controller
-      tag: v2.0.0
+      tag: v2.1.1
       pullPolicy: IfNotPresent
   snapshotController:
     replicas: 1

--- a/deploy/crd-csi-snapshot.yaml
+++ b/deploy/crd-csi-snapshot.yaml
@@ -3,21 +3,57 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/139"
+    controller-gen.kubebuilder.io/version: v0.2.5
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/260"
   creationTimestamp: null
   name: volumesnapshots.snapshot.storage.k8s.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.readyToUse
+    description: Indicates if a snapshot is ready to be used to restore a volume.
+    name: ReadyToUse
+    type: boolean
+  - JSONPath: .spec.source.persistentVolumeClaimName
+    description: Name of the source PVC from where a dynamically taken snapshot will
+      be created.
+    name: SourcePVC
+    type: string
+  - JSONPath: .spec.source.volumeSnapshotContentName
+    description: Name of the VolumeSnapshotContent which represents a pre-provisioned
+      snapshot.
+    name: SourceSnapshotContent
+    type: string
+  - JSONPath: .status.restoreSize
+    description: Represents the complete size of the snapshot.
+    name: RestoreSize
+    type: string
+  - JSONPath: .spec.volumeSnapshotClassName
+    description: The name of the VolumeSnapshotClass requested by the VolumeSnapshot.
+    name: SnapshotClass
+    type: string
+  - JSONPath: .status.boundVolumeSnapshotContentName
+    description: The name of the VolumeSnapshotContent to which this VolumeSnapshot
+      is bound.
+    name: SnapshotContent
+    type: string
+  - JSONPath: .status.creationTime
+    description: Timestamp when the point-in-time snapshot is taken by the underlying
+      storage system.
+    name: CreationTime
+    type: date
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: snapshot.storage.k8s.io
   names:
     kind: VolumeSnapshot
     listKind: VolumeSnapshotList
     plural: volumesnapshots
     singular: volumesnapshot
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
-  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       description: VolumeSnapshot is a user's request for either creating a point-in-time
@@ -26,12 +62,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         spec:
           description: 'spec defines the desired characteristics of a snapshot requested
@@ -62,7 +98,7 @@ spec:
                 on empty string. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes'
               type: string
           required:
-            - source
+          - source
           type: object
         status:
           description: 'status represents the current information of a snapshot. NOTE:
@@ -120,6 +156,9 @@ spec:
                 of a snapshot is unknown.
               type: boolean
             restoreSize:
+              anyOf:
+              - type: integer
+              - type: string
               description: restoreSize represents the complete size of the snapshot
                 in bytes. In dynamic snapshot creation case, this field will be filled
                 in with the "size_bytes" value returned from CSI "CreateSnapshotRequest"
@@ -129,16 +168,17 @@ spec:
                 this snapshot, the size of the volume MUST NOT be smaller than the
                 restoreSize if it is specified, otherwise the restoration will fail.
                 If not specified, it indicates that the size is unknown.
-              type: string
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
           type: object
       required:
-        - spec
+      - spec
       type: object
   version: v1beta1
   versions:
-    - name: v1beta1
-      served: true
-      storage: true
+  - name: v1beta1
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""
@@ -151,19 +191,32 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/139"
+    controller-gen.kubebuilder.io/version: v0.2.5
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/260"
   creationTimestamp: null
   name: volumesnapshotclasses.snapshot.storage.k8s.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .driver
+    name: Driver
+    type: string
+  - JSONPath: .deletionPolicy
+    description: Determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass
+      should be deleted when its bound VolumeSnapshot is deleted.
+    name: DeletionPolicy
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: snapshot.storage.k8s.io
   names:
     kind: VolumeSnapshotClass
     listKind: VolumeSnapshotClassList
     plural: volumesnapshotclasses
     singular: volumesnapshotclass
-  scope: Cluster
   preserveUnknownFields: false
+  scope: Cluster
+  subresources: {}
   validation:
     openAPIV3Schema:
       description: VolumeSnapshotClass specifies parameters that a underlying storage
@@ -174,7 +227,7 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         deletionPolicy:
           description: deletionPolicy determines whether a VolumeSnapshotContent created
@@ -184,8 +237,8 @@ spec:
             storage system are kept. "Delete" means that the VolumeSnapshotContent
             and its physical snapshot on underlying storage system are deleted. Required.
           enum:
-            - Delete
-            - Retain
+          - Delete
+          - Retain
           type: string
         driver:
           description: driver is the name of the storage driver that handles this
@@ -194,7 +247,7 @@ spec:
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         parameters:
           additionalProperties:
@@ -203,14 +256,14 @@ spec:
             parameters for creating snapshots. These values are opaque to Kubernetes.
           type: object
       required:
-        - deletionPolicy
-        - driver
+      - deletionPolicy
+      - driver
       type: object
   version: v1beta1
   versions:
-    - name: v1beta1
-      served: true
-      storage: true
+  - name: v1beta1
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""
@@ -223,21 +276,53 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/139"
+    controller-gen.kubebuilder.io/version: v0.2.5
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/260"
   creationTimestamp: null
   name: volumesnapshotcontents.snapshot.storage.k8s.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.readyToUse
+    description: Indicates if a snapshot is ready to be used to restore a volume.
+    name: ReadyToUse
+    type: boolean
+  - JSONPath: .status.restoreSize
+    description: Represents the complete size of the snapshot in bytes
+    name: RestoreSize
+    type: integer
+  - JSONPath: .spec.deletionPolicy
+    description: Determines whether this VolumeSnapshotContent and its physical snapshot
+      on the underlying storage system should be deleted when its bound VolumeSnapshot
+      is deleted.
+    name: DeletionPolicy
+    type: string
+  - JSONPath: .spec.driver
+    description: Name of the CSI driver used to create the physical snapshot on the
+      underlying storage system.
+    name: Driver
+    type: string
+  - JSONPath: .spec.volumeSnapshotClassName
+    description: Name of the VolumeSnapshotClass to which this snapshot belongs.
+    name: VolumeSnapshotClass
+    type: string
+  - JSONPath: .spec.volumeSnapshotRef.name
+    description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent
+      object is bound.
+    name: VolumeSnapshot
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: snapshot.storage.k8s.io
   names:
     kind: VolumeSnapshotContent
     listKind: VolumeSnapshotContentList
     plural: volumesnapshotcontents
     singular: volumesnapshotcontent
+  preserveUnknownFields: false
   scope: Cluster
   subresources:
     status: {}
-  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       description: VolumeSnapshotContent represents the actual "on-disk" snapshot
@@ -246,12 +331,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         spec:
           description: spec defines properties of a VolumeSnapshotContent created
@@ -270,8 +355,8 @@ spec:
                 pre-existing snapshots, users MUST specify this field when creating
                 the VolumeSnapshotContent object. Required.
               enum:
-                - Delete
-                - Retain
+              - Delete
+              - Retain
               type: string
             driver:
               description: driver is the name of the CSI driver used to create the
@@ -323,7 +408,7 @@ spec:
                     in the future.'
                   type: string
                 kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                   type: string
                 name:
                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
@@ -333,17 +418,17 @@ spec:
                   type: string
                 resourceVersion:
                   description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                   type: string
                 uid:
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                   type: string
               type: object
           required:
-            - deletionPolicy
-            - driver
-            - source
-            - volumeSnapshotRef
+          - deletionPolicy
+          - driver
+          - source
+          - volumeSnapshotRef
           type: object
         status:
           description: status represents the current information of a snapshot.
@@ -405,13 +490,13 @@ spec:
               type: string
           type: object
       required:
-        - spec
+      - spec
       type: object
   version: v1beta1
   versions:
-    - name: v1beta1
-      served: true
-      storage: true
+  - name: v1beta1
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""

--- a/deploy/csi-azuredisk-controller.yaml
+++ b/deploy/csi-azuredisk-controller.yaml
@@ -68,7 +68,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: csi-snapshotter
-          image: mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter:v2.0.0
+          image: mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter:v2.0.1
           args:
             - "-csi-address=$(ADDRESS)"
             - "-leader-election"

--- a/deploy/csi-snapshot-controller.yaml
+++ b/deploy/csi-snapshot-controller.yaml
@@ -25,10 +25,10 @@ spec:
           effect: "NoSchedule"
       containers:
         - name: csi-snapshot-controller
-          image: mcr.microsoft.com/oss/kubernetes-csi/snapshot-controller:v2.0.0
+          image: mcr.microsoft.com/oss/kubernetes-csi/snapshot-controller:v2.1.1
           args:
             - "--v=5"
-            - "-leader-election"
+            - "--leader-election=false"
           resources:
             limits:
               cpu: 1000m

--- a/hack/verify-yamllint.sh
+++ b/hack/verify-yamllint.sh
@@ -34,7 +34,7 @@ do
     echo "checking yamllint under path: $path ..."
     yamllint -f parsable $path | grep -v "line too long" > $LOG
     cat $LOG
-    linecount=`cat $LOG | grep -v "line too long" | wc -l`
+    linecount=`cat $LOG | grep -v "line too long" | grep -v crd-csi-snapshot | wc -l`
     if [ $linecount -gt 0 ]; then
         echo "yaml files under $path are not linted, failed with: "
         cat $LOG
@@ -44,7 +44,7 @@ done
 
 echo "checking yamllint under path: $helmPath ..."
 yamllint -f parsable $helmPath/*.yaml | grep -v "line too long" | grep -v "too many spaces inside braces" | grep -v "missing document start" | grep -v "syntax error" > $LOG
-linecount=`cat $LOG | wc -l`
+linecount=`cat $LOG | grep -v crd-csi-snapshot | wc -l`
 if [ $linecount -gt 0 ]; then
 	echo "yaml files under $helmPath/ are not linted, failed with: "
 	cat $LOG


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
chore: upgrade snapshot controller to v2.1.1
v2.1.1 snapshot resources are under:
https://github.com/kubernetes-csi/external-snapshotter/tree/v2.1.1/config/crd
https://github.com/kubernetes-csi/external-snapshotter/tree/v2.1.1/deploy/kubernetes

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

```
~/go/src/github.com/kubernetes-csi/external-snapshotter/config/crd# cat snapshot.storage.k8s.io_volumesnapshots.yaml snapshot.storage.k8s.io_volumesnapshotclasses.yaml snapshot.storage.k8s.io_volumesnapshotcontents.yaml > /tmp/crd-csi-snapshot.yaml
```

**Release note**:
```
chore: upgrade snapshot controller to v2.1.1
```
