### PR TITLE
[WIP][test]feat: install kernel 5.3.0-1020-azure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,9 @@ azuredisk-windows:
 	CGO_ENABLED=0 GOOS=windows go build -a -ldflags ${LDFLAGS} -o _output/azurediskplugin.exe ./pkg/azurediskplugin
 
 .PHONY: container
-container: azuredisk
-        docker build --no-cache -t $(IMAGE_TAG) -f ./pkg/azurediskplugin/Dockerfile .
+container: 
+	make azuredisk
+	docker build --no-cache -t $(IMAGE_TAG) -f ./pkg/azurediskplugin/Dockerfile .
 
 .PHONY: azuredisk-container
 azuredisk-container:

--- a/pkg/azurediskplugin/Dockerfile
+++ b/pkg/azurediskplugin/Dockerfile
@@ -14,6 +14,8 @@
 
 FROM mcr.microsoft.com/aks/fundamental/base-ubuntu:v0.0.5
 RUN apt-get update && apt-get install -y util-linux e2fsprogs mount ca-certificates udev xfsprogs
+# install kernel 5.3.0-1020-azure
+RUN apt install linux-image-5.3.0-1020-azure -y
 LABEL maintainers="andyzhangx"
 LABEL description="Azure Disk CSI Driver"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: install kernel 5.3.0-1020-azure 


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
```
Creating config file /etc/default/grub with new version
Setting up grub-gfxpayload-lists (0.7) ...
Processing triggers for libc-bin (2.27-3ubuntu1) ...
Processing triggers for systemd (237-3ubuntu10.31) ...
Processing triggers for initramfs-tools (0.130ubuntu3.9) ...
Processing triggers for linux-image-5.3.0-51-generic (5.3.0-51.44~18.04.2) ...
/etc/kernel/postinst.d/initramfs-tools:
update-initramfs: Generating /boot/initrd.img-5.3.0-51-generic
Processing triggers for dbus (1.12.2-1ubuntu1.1) ...
Removing intermediate container 0ab768518cd2
 ---> 95a19f52bee4
Step 4/7 : LABEL maintainers="andyzhangx"
 ---> Running in 927b6963392d
Removing intermediate container 927b6963392d
 ---> 23410ab196f6
Step 5/7 : LABEL description="Azure Disk CSI Driver"
 ---> Running in 26b03f4cdca7
Removing intermediate container 26b03f4cdca7
 ---> 20f5f3ad7b59
Step 6/7 : COPY ./_output/azurediskplugin /azurediskplugin
 ---> 91a86b747821
Step 7/7 : ENTRYPOINT ["/azurediskplugin"]
 ---> Running in d91469741b71
Removing intermediate container d91469741b71
 ---> c67589cd7262
Successfully built c67589cd7262
```

**Release note**:
```
feat: install kernel 5.3.0-1020-azure
```
