### PR TITLE
feat: replace base image with gcr.io/distroless

### DIFF
--- a/pkg/azurediskplugin/Dockerfile
+++ b/pkg/azurediskplugin/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/aks/fundamental/base-ubuntu:v0.0.5
+FROM gcr.io/distroless/static@sha256:c6d5981545ce1406d33e61434c61e9452dad93ecd8397c41e89036ef977a88f4
 RUN apt-get update && apt-get install -y util-linux e2fsprogs mount ca-certificates udev xfsprogs
 LABEL maintainers="andyzhangx"
 LABEL description="Azure Disk CSI Driver"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: replace base image with gcr.io/distroless
This PR failed with following error, do you know how to fix this? @sozercan thanks

```
# make azuredisk-container
make azuredisk
make[1]: Entering directory '/root/go/src/sigs.k8s.io/azuredisk-csi-driver'
if [ ! -d ./vendor ]; then dep ensure -vendor-only; fi
CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-X sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk.driverVersion=v0.8.0 -X sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk.gitCommit=f4607681a69ab065dc795619de2086b5b504e331 -X sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk.buildDate=2020-05-13T03:35:34Z -X sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk.DriverName=disk.csi.azure.com -X sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk.topologyKey=topology.disk.csi.azure.com/zone -extldflags "-static"" -o _output/azurediskplugin ./pkg/azurediskplugin
make[1]: Leaving directory '/root/go/src/sigs.k8s.io/azuredisk-csi-driver'
docker build --no-cache -t andyzhangx/azuredisk-csi:v0.8.0 -f ./pkg/azurediskplugin/Dockerfile .
Sending build context to Docker daemon  284.6MB
Step 1/6 : FROM gcr.io/distroless/static@sha256:c6d5981545ce1406d33e61434c61e9452dad93ecd8397c41e89036ef977a88f4
 ---> e4d2a899b1bf
Step 2/6 : RUN apt-get update && apt-get install -y util-linux e2fsprogs mount ca-certificates udev xfsprogs
 ---> Running in bc8d6f09337e
OCI runtime create failed: container_linux.go:348: starting container process caused "exec: \"/bin/sh\": stat /bin/sh: no such file or directory": unknown
Makefile:122: recipe for target 'azuredisk-container' failed
make: *** [azuredisk-container] Error 1
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
feat: replace base image with gcr.io/distroless
```
