### PR TITLE
test: set timeout as 10min for windows pod

### DIFF
--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -209,7 +209,7 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool) {
 	ginkgo.It("should create multiple PV objects, bind to PVCs and attach all to different pods on the same node [kubernetes.io/azure-disk] [disk.csi.azure.com] [Windows]", func() {
 		pods := []testsuites.PodDetails{
 			{
-				Cmd: convertToPowershellCommandIfNecessary("while true; do echo $(date -u) >> /mnt/test-1/data; sleep 100; done"),
+				Cmd: convertToPowershellCommandIfNecessary("while true; do echo $(date -u) >> /mnt/test-1/data; sleep 3600; done"),
 				Volumes: t.normalizeVolumes([]testsuites.VolumeDetails{
 					{
 						FSType:    "ext3",
@@ -223,7 +223,7 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool) {
 				IsWindows: isWindowsCluster,
 			},
 			{
-				Cmd: convertToPowershellCommandIfNecessary("while true; do echo $(date -u) >> /mnt/test-1/data; sleep 100; done"),
+				Cmd: convertToPowershellCommandIfNecessary("while true; do echo $(date -u) >> /mnt/test-1/data; sleep 3600; done"),
 				Volumes: t.normalizeVolumes([]testsuites.VolumeDetails{
 					{
 						FSType:    "ext4",
@@ -237,7 +237,7 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool) {
 				IsWindows: isWindowsCluster,
 			},
 			{
-				Cmd: convertToPowershellCommandIfNecessary("while true; do echo $(date -u) >> /mnt/test-1/data; sleep 100; done"),
+				Cmd: convertToPowershellCommandIfNecessary("while true; do echo $(date -u) >> /mnt/test-1/data; sleep 3600; done"),
 				Volumes: t.normalizeVolumes([]testsuites.VolumeDetails{
 					{
 						FSType:    "xfs",
@@ -262,7 +262,7 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool) {
 
 	ginkgo.It("should create a deployment object, write and read to it, delete the pod and write and read to it again [kubernetes.io/azure-disk] [disk.csi.azure.com] [Windows]", func() {
 		pod := testsuites.PodDetails{
-			Cmd: convertToPowershellCommandIfNecessary("echo 'hello world' >> /mnt/test-1/data && while true; do sleep 100; done"),
+			Cmd: convertToPowershellCommandIfNecessary("echo 'hello world' >> /mnt/test-1/data && while true; do sleep 3600; done"),
 			Volumes: t.normalizeVolumes([]testsuites.VolumeDetails{
 				{
 					FSType:    "ext3",

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -197,10 +197,10 @@ func convertToPowershellCommandIfNecessary(command string) string {
 		return "echo 'hello world' | Out-File -FilePath C:\\mnt\\test-1\\data.txt; Get-Content C:\\mnt\\test-1\\data.txt | findstr 'hello world'"
 	case "touch /mnt/test-1/data":
 		return "echo $null >> C:\\mnt\\test-1\\data"
-	case "while true; do echo $(date -u) >> /mnt/test-1/data; sleep 100; done":
-		return "while (1) { Add-Content -Encoding Unicode C:\\mnt\\test-1\\data.txt $(Get-Date -Format u); sleep 100 }"
-	case "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 100; done":
-		return "Add-Content -Encoding Unicode C:\\mnt\\test-1\\data.txt 'hello world'; while (1) { sleep 100 }"
+	case "while true; do echo $(date -u) >> /mnt/test-1/data; sleep 3600; done":
+		return "while (1) { Add-Content -Encoding Unicode C:\\mnt\\test-1\\data.txt $(Get-Date -Format u); sleep 3600 }"
+	case "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 3600; done":
+		return "Add-Content -Encoding Unicode C:\\mnt\\test-1\\data.txt 'hello world'; while (1) { sleep 3600 }"
 	case "echo 'hello world' > /mnt/test-1/data && echo 'hello world' > /mnt/test-2/data && echo 'hello world' > /mnt/test-3/data && grep 'hello world' /mnt/test-1/data && grep 'hello world' /mnt/test-2/data && grep 'hello world' /mnt/test-3/data":
 		return "echo 'hello world' | Out-File -FilePath C:\\mnt\\test-1\\data.txt; Get-Content C:\\mnt\\test-1\\data.txt | findstr 'hello world'; echo 'hello world' | Out-File -FilePath C:\\mnt\\test-2\\data.txt; Get-Content C:\\mnt\\test-2\\data.txt | findstr 'hello world'; echo 'hello world' | Out-File -FilePath C:\\mnt\\test-3\\data.txt; Get-Content C:\\mnt\\test-3\\data.txt | findstr 'hello world'"
 	}

--- a/test/e2e/testsuites/testsuites.go
+++ b/test/e2e/testsuites/testsuites.go
@@ -458,7 +458,8 @@ func (t *TestDeployment) WaitForPodReady() {
 	// always get first pod as there should only be one
 	pod := pods.Items[0]
 	t.podName = pod.Name
-	err = framework.WaitForPodRunningInNamespace(t.client, &pod)
+	// set timeout as 10min for windows pod
+	err = framework.WaitTimeoutForPodRunningInNamespace(t.client, pod.Name, pod.Namespace, slowPodStartTimeout)
 	framework.ExpectNoError(err)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
test: set timeout as 10min for windows pod


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
as I could find out, the successful pod start time could be around 2.5min, while in some cases, it would exceed 5min(not sure why), increase the timeout to 10min in this windows e2e case first.

below are some logs for case `ginkgo.It("should create a deployment object, write and read to it, delete the pod and write and read to it again [kubernetes.io/azure-disk] [disk.csi.azure.com] [Windows]"`:

```
May  6 14:28:51.908: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/root/tmp531642905/kubeconfig/kubeconfig.eastus2.json exec azuredisk-volume-tester-jtx6n-574b7769b4-h9dsv --namespace=azuredisk-4590 -- powershell.exe -Command Get-Content C:\mnt\test-1\data.txt'
May  6 14:28:53.692: INFO: stderr: ""
May  6 14:28:53.692: INFO: stdout: "hello world\r\n"
STEP: deleting the pod for deployment
May  6 14:28:53.692: INFO: Deleting pod "azuredisk-volume-tester-jtx6n-574b7769b4-h9dsv" in namespace "azuredisk-4590"
May  6 14:28:53.736: INFO: Waiting for pod "azuredisk-volume-tester-jtx6n-574b7769b4-h9dsv" in namespace "azuredisk-4590" to be fully deleted
STEP: checking again that the pod is running
STEP: checking pod exec
May  6 14:31:20.009: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/root/tmp531642905/kubeconfig/kubeconfig.eastus2.json exec azuredisk-volume-tester-jtx6n-574b7769b4-2dn5r --namespace=azuredisk-4590 -- powershell.exe -Command Get-Content C:\mnt\test-1\data.txt'
```

**Release note**:
```
none
```
