### PR TITLE
test: fix resize e2e test failure

### DIFF
--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -538,7 +538,7 @@ func (d *Driver) ControllerExpandVolume(ctx context.Context, req *csi.Controller
 	}
 	oldSize := *resource.NewQuantity(int64(*result.DiskProperties.DiskSizeGB), resource.BinarySI)
 
-	klog.V(2).Infof("begin to expand azure disk(%s) with new size(%v)", diskURI, requestSize)
+	klog.V(2).Infof("begin to expand azure disk(%s) with new size(%d)", diskURI, requestSize.Value())
 	newSize, err := d.cloud.ResizeDisk(diskURI, oldSize, requestSize)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to resize disk(%s) with error(%v)", diskURI, err)
@@ -549,7 +549,7 @@ func (d *Driver) ControllerExpandVolume(ctx context.Context, req *csi.Controller
 		return nil, status.Errorf(codes.Internal, "failed to transform disk size with error(%v)", err)
 	}
 
-	klog.V(2).Infof("expand azure disk(%s) successfully, currentSize(%v)", diskURI, currentSize)
+	klog.V(2).Infof("expand azure disk(%s) successfully, currentSize(%d)", diskURI, currentSize)
 
 	return &csi.ControllerExpandVolumeResponse{
 		CapacityBytes:         currentSize,

--- a/test/e2e/testsuites/dynamically_provisioned_resize_volume_tester.go
+++ b/test/e2e/testsuites/dynamically_provisioned_resize_volume_tester.go
@@ -19,6 +19,7 @@ package testsuites
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/onsi/ginkgo"
 
@@ -66,6 +67,9 @@ func (t *DynamicallyProvisionedResizeVolumeTest) Run(client clientset.Interface,
 		framework.ExpectNoError(err, fmt.Sprintf("fail to resize pvc(%s): %v", pvcName, err))
 	}
 	updatedSize := updatedPvc.Spec.Resources.Requests["storage"]
+
+	ginkgo.By("sleep 30s waiting for resize complete")
+	time.Sleep(30 * time.Second)
 
 	ginkgo.By("checking the resizing result")
 	newPvc, err := client.CoreV1().PersistentVolumeClaims(namespace.Name).Get(context.TODO(), pvcName, metav1.GetOptions{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
test: fix resize e2e test failure

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
fixed the resize e2e test failure:
```
[pod/csi-azuredisk-controller-5fbc7fdc6b-fk8q2/azuredisk] I0721 01:13:53.468923       1 utils.go:112] GRPC call: /csi.v1.Controller/ControllerExpandVolume
[pod/csi-azuredisk-controller-5fbc7fdc6b-fk8q2/azuredisk] I0721 01:13:53.469033       1 utils.go:113] GRPC request: volume_id:"/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/kubetest-f50c87d9-cae6-11ea-83ab-52a5d34da032/providers/Microsoft.Compute/disks/pvc-f742d627-4878-47f1-86c8-37512347dbb1" capacity_range:<required_bytes:11811160064 > 
[pod/csi-azuredisk-controller-5fbc7fdc6b-fk8q2/azuredisk] I0721 01:13:53.486797       1 controllerserver.go:541] begin to expand azure disk(/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/kubetest-f50c87d9-cae6-11ea-83ab-52a5d34da032/providers/Microsoft.Compute/disks/pvc-f742d627-4878-47f1-86c8-37512347dbb1) with new size({{11811160064 0} {<nil>}  BinarySI})
[pod/csi-azuredisk-controller-5fbc7fdc6b-fk8q2/azuredisk] I0721 01:13:53.504032       1 azure_managedDiskController.go:294] azureDisk - begin to resize disk(pvc-f742d627-4878-47f1-86c8-37512347dbb1) with new size(11), old size({{10 0} {<nil>}  BinarySI})
[pod/csi-azuredisk-controller-5fbc7fdc6b-fk8q2/azuredisk] I0721 01:13:53.548064       1 utils.go:112] GRPC call: /csi.v1.Controller/DeleteVolume
[pod/csi-azuredisk-controller-5fbc7fdc6b-fk8q2/azuredisk] I0721 01:13:53.548201       1 utils.go:113] GRPC request: volume_id:"/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/kubetest-f50c87d9-cae6-11ea-83ab-52a5d34da032/providers/Microsoft.Compute/disks/pvc-f742d627-4878-47f1-86c8-37512347dbb1" 
[pod/csi-azuredisk-controller-5fbc7fdc6b-fk8q2/azuredisk] I0721 01:13:53.548219       1 controllerserver.go:338] deleting azure disk(/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/kubetest-f50c87d9-cae6-11ea-83ab-52a5d34da032/providers/Microsoft.Compute/disks/pvc-f742d627-4878-47f1-86c8-37512347dbb1)
[pod/csi-azuredisk-controller-5fbc7fdc6b-fk8q2/azuredisk] I0721 01:13:56.036935       1 utils.go:112] GRPC call: /csi.v1.Identity/Probe
[pod/csi-azuredisk-controller-5fbc7fdc6b-fk8q2/azuredisk] I0721 01:13:56.036975       1 utils.go:113] GRPC request: 
[pod/csi-azuredisk-controller-5fbc7fdc6b-fk8q2/azuredisk] I0721 01:13:56.036983       1 utils.go:119] GRPC response: ready:<value:true > 
[pod/csi-azuredisk-controller-5fbc7fdc6b-fk8q2/azuredisk] I0721 01:13:58.711873       1 azure_managedDiskController.go:244] azureDisk - deleted a managed disk: /subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/kubetest-f50c87d9-cae6-11ea-83ab-52a5d34da032/providers/Microsoft.Compute/disks/pvc-f742d627-4878-47f1-86c8-37512347dbb1
[pod/csi-azuredisk-controller-5fbc7fdc6b-fk8q2/azuredisk] I0721 01:13:58.711901       1 controllerserver.go:348] delete azure disk(/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/kubetest-f50c87d9-cae6-11ea-83ab-52a5d34da032/providers/Microsoft.Compute/disks/pvc-f742d627-4878-47f1-86c8-37512347dbb1) successfully
[pod/csi-azuredisk-controller-5fbc7fdc6b-fk8q2/azuredisk] I0721 01:13:58.711913       1 utils.go:119] GRPC response: 
[pod/csi-azuredisk-controller-5fbc7fdc6b-fk8q2/azuredisk] I0721 01:14:03.629308       1 azure_armclient.go:245] Received error in WaitForCompletionRef: 'Code="OperationPreempted" Message="The operation could not be completed as it has been preempted by a recent operation. Please check your Activity Log for more details on that operation. Read about activity log at https://aka.ms/ActivityLogView."'
[pod/csi-azuredisk-controller-5fbc7fdc6b-fk8q2/azuredisk] I0721 01:14:03.629347       1 azure_armclient.go:266] Received error in WaitForAsyncOperationCompletion: 'Code="OperationPreempted" Message="The operation could not be completed as it has been preempted by a recent operation. Please check your Activity Log for more details on that operation. Read about activity log at https://aka.ms/ActivityLogView."'
[pod/csi-azuredisk-controller-5fbc7fdc6b-fk8q2/azuredisk] I0721 01:14:03.629383       1 azure_armclient.go:439] Received error in WaitForAsyncOperationResult: 'Code="OperationPreempted" Message="The operation could not be completed as it has been preempted by a recent operation. Please check your Activity Log for more details on that operation. Read about activity log at https://aka.ms/ActivityLogView."', no response
[pod/csi-azuredisk-controller-5fbc7fdc6b-fk8q2/azuredisk] I0721 01:14:03.629399       1 azure_diskclient.go:182] Received error in disk.put.request: resourceID: /subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/kubetest-f50c87d9-cae6-11ea-83ab-52a5d34da032/providers/Microsoft.Compute/disks/pvc-f742d627-4878-47f1-86c8-37512347dbb1, error: Retriable: true, RetryAfter: 0s, HTTPStatusCode: -1, RawError: Code="OperationPreempted" Message="The operation could not be completed as it has been preempted by a recent operation. Please check your Activity Log for more details on that operation. Read about activity log at https://aka.ms/ActivityLogView."
[pod/csi-azuredisk-controller-5fbc7fdc6b-fk8q2/azuredisk] E0721 01:14:03.629435       1 utils.go:117] GRPC error: rpc error: code = Internal desc = failed to resize disk(/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/kubetest-f50c87d9-cae6-11ea-83ab-52a5d34da032/providers/Microsoft.Compute/disks/pvc-f742d627-4878-47f1-86c8-37512347dbb1) with error(Retriable: true, RetryAfter: 0s, HTTPStatusCode: -1, RawError: Code="OperationPreempted" Message="The operation could not be completed as it has been preempted by a recent operation. Please check your Activity Log for more details on that operation. Read about activity log at https://aka.ms/ActivityLogView.")
```

**Release note**:
```
none
```
