### PR TITLE
[WIP]fix: DNS latency in controller

### DIFF
--- a/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
+++ b/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
@@ -24,6 +24,12 @@ spec:
           operator: "Equal"
           value: "true"
           effect: "NoSchedule"
+      dnsConfig:
+        options:
+          - name: single-request-reopen
+          - name: ndots
+            value: "5"
+          - name: use-vc
       containers:
         - name: csi-provisioner
           image: "{{ .Values.image.csiProvisioner.repository }}:{{ .Values.image.csiProvisioner.tag }}"

--- a/deploy/csi-azuredisk-controller.yaml
+++ b/deploy/csi-azuredisk-controller.yaml
@@ -24,6 +24,12 @@ spec:
           operator: "Equal"
           value: "true"
           effect: "NoSchedule"
+      dnsConfig:
+        options:
+          - name: single-request-reopen
+          - name: ndots
+            value: "5"
+          - name: use-vc
       containers:
         - name: csi-provisioner
           image: mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v1.5.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: DNS latency in controller

Create Disk/snapshot/Resize Disk costs 10s now, with this PR, it could complete within ~5s(sometimes 2s)

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #441

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
##dnsConfig options

We can update the dnsConfig in pod’s spec to avoid the race condition. For example, we can enable the option single-request-reopen:
```
dnsConfig:  
  options:  
    - name: single-request-reopen
```
The description about the option is:
```
single-request-reopen (since glibc 2.9)
    Sets RES_SNGLKUPREOP in _res.options.  The resolver
    uses the same socket for the A and AAAA requests.  Some
    hardware mistakenly sends back only one reply.  When
    that happens the client system will sit and wait for
    the second reply.  Turning this option on changes this
    behavior so that if two requests from the same port are
    not handled correctly it will close the socket and open
    a new one before sending the second request.
```
Similarly, we can enable the option use-vc to enforce TCP when resolving DNS:
```
use-vc (since glibc 2.14)
    Sets RES_USEVC in _res.options.  This option forces the
    use of TCP for DNS resolutions.
```
Notice that these two options have dependencies on glibc, but glibc is unavailable in some images, such as alpine. We have to use other images if we’d like to go with dnsConfig options.

If we put everything together, the pod spec may look like:
```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: app
spec:
  template:
    spec:
      dnsConfig:
        options:
         - name: single-request-reopen
         - name: ndots
           value: "5"
         - name: use-vc 
      containers:
```


**Release note**:
```
fix: DNS latency in controller
```
