### PR TITLE
Make GO111MODULE on by default in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ GINKGO_FLAGS += -ginkgo.focus="\[single-az\]"
 endif
 GOPATH ?= $(shell go env GOPATH)
 GOBIN ?= $(GOPATH)/bin
-GO111MODULE = off
+GO111MODULE = on
 DOCKER_CLI_EXPERIMENTAL = enabled
 export GOPATH GOBIN GO111MODULE DOCKER_CLI_EXPERIMENTAL
 

--- a/test/sanity/run-tests-all-clouds.sh
+++ b/test/sanity/run-tests-all-clouds.sh
@@ -27,6 +27,7 @@ function install_csi_sanity_bin {
   popd
 }
 
+export GO111MODULE=off
 apt update && apt install cifs-utils procps -y
 install_csi_sanity_bin
 test/sanity/run-test.sh "$nodeid"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This turns on GO111MODULE by default in the Makefile.

**Release note**:
```
none
```
