### PR TITLE
Revert "fix: create nonroot user in Dockerfile"

### DIFF
--- a/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
+++ b/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
@@ -156,8 +156,6 @@ spec:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          securityContext:
-            runAsUser: 0
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
+++ b/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
@@ -106,7 +106,6 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             privileged: true
-            runAsUser: 0
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/deploy/csi-azuredisk-controller.yaml
+++ b/deploy/csi-azuredisk-controller.yaml
@@ -153,8 +153,6 @@ spec:
                   optional: true
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-          securityContext:
-            runAsUser: 0
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/deploy/csi-azuredisk-node.yaml
+++ b/deploy/csi-azuredisk-node.yaml
@@ -104,7 +104,6 @@ spec:
                   fieldPath: spec.nodeName
           securityContext:
             privileged: true
-            runAsUser: 0
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/pkg/azurediskplugin/Dockerfile
+++ b/pkg/azurediskplugin/Dockerfile
@@ -19,8 +19,4 @@ RUN clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs
 LABEL maintainers="andyzhangx"
 LABEL description="Azure Disk CSI Driver"
 
-# Create a nonroot user
-RUN useradd -u 10001 nonroot
-USER nonroot
-
 ENTRYPOINT ["/azurediskplugin"]

--- a/pkg/azurediskplugin/dev.Dockerfile
+++ b/pkg/azurediskplugin/dev.Dockerfile
@@ -17,9 +17,5 @@ RUN apt-get update && apt-get install -y util-linux e2fsprogs mount ca-certifica
 LABEL maintainers="andyzhangx"
 LABEL description="Azure Disk CSI Driver"
 
-# Create a nonroot user
-RUN useradd -u 10001 nonroot
-USER nonroot
-
 COPY ./_output/azurediskplugin /azurediskplugin
 ENTRYPOINT ["/azurediskplugin"]


### PR DESCRIPTION
Reverts kubernetes-sigs/azuredisk-csi-driver#558

Original PR did not improve the security, that PR is just for bypass security scanning, while would introduce various permission setting issue.