### PR TITLE
test: upgrade sanity-test to v4.0.2

### DIFF
--- a/test/sanity/run-test.sh
+++ b/test/sanity/run-test.sh
@@ -35,4 +35,4 @@ _output/azurediskplugin --endpoint "$endpoint" --nodeid "$nodeid" -v=5 &
 
 echo 'Begin to run sanity test...'
 readonly CSI_SANITY_BIN='csi-sanity'
-"$CSI_SANITY_BIN" --ginkgo.v --csi.endpoint="$endpoint" --ginkgo.skip='should work|should fail when volume does not exist on the specified path|should return appropriate capabilities|pagination should detect volumes added between pages and accept tokens when the last volume from a page is deleted'
+"$CSI_SANITY_BIN" --ginkgo.v --csi.endpoint="$endpoint" --ginkgo.skip='should work|should fail when volume does not exist on the specified path|should be idempotent|pagination should detect volumes added between pages and accept tokens when the last volume from a page is deleted'

--- a/test/sanity/run-tests-all-clouds.sh
+++ b/test/sanity/run-tests-all-clouds.sh
@@ -21,14 +21,13 @@ function install_csi_sanity_bin {
   mkdir -p $GOPATH/src/github.com/kubernetes-csi
   pushd $GOPATH/src/github.com/kubernetes-csi
   export GO111MODULE=off
-  git clone https://github.com/kubernetes-csi/csi-test.git -b v2.2.0
+  git clone https://github.com/kubernetes-csi/csi-test.git -b v4.0.2
   pushd csi-test/cmd/csi-sanity
   make install
   popd
   popd
 }
 
-apt update && apt install procps -y
 if [[ -z "$(command -v csi-sanity)" ]]; then
 	install_csi_sanity_bin
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
test: upgrade sanity-test to v4.0.2

the following two sanity tests actually could not pass since
 - node should be idempotent: CI is running inside container in google cloud
 - controller should be idempotent:  there is delete volume error in the test cleanup since at that time disk is still attached to the node
```
[91m[1mSummarizing 2 Failures:[0m

[91m[1m[Fail] [0m[90mNode Service [0m[91m[1m[It] should be idempotent [0m
[37m/home/prow/go/src/github.com/kubernetes-csi/csi-test/pkg/sanity/node.go:140[0m

[91m[1m[Fail] [0m[90mController Service [Controller Server] [0m[91m[1m[AfterEach] volume lifecycle [0m[90mshould be idempotent [0m
[37m/home/prow/go/src/github.com/kubernetes-csi/csi-test/vendor/github.com/onsi/ginkgo/internal/leafnodes/runner.go:113[0m

[91m[1m• Failure in Spec Teardown (AfterEach) [16.428 seconds][0m
Controller Service [Controller Server]
[90m/home/prow/go/src/github.com/kubernetes-csi/csi-test/pkg/sanity/tests.go:44[0m
  [91m[1mvolume lifecycle [AfterEach][0m
  [90m/home/prow/go/src/github.com/kubernetes-csi/csi-test/pkg/sanity/controller.go:1055[0m
    should be idempotent
    [90m/home/prow/go/src/github.com/kubernetes-csi/csi-test/pkg/sanity/controller.go:1066[0m

    [91mrecorded 1 failure(s)[0m

    /home/prow/go/src/github.com/kubernetes-csi/csi-test/vendor/github.com/onsi/ginkgo/internal/leafnodes/runner.go:113
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #633, #622

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
test: upgrade sanity-test to v4.0.2
```
