### PR TITLE
test: use a different path for csi-sanity test

### DIFF
--- a/test/sanity/run-test.sh
+++ b/test/sanity/run-test.sh
@@ -34,5 +34,5 @@ fi
 _output/azurediskplugin --endpoint "$endpoint" --nodeid "$nodeid" -v=5 &
 
 echo 'Begin to run sanity test...'
-readonly CSI_SANITY_BIN='csi-test/cmd/csi-sanity/csi-sanity'
+readonly CSI_SANITY_BIN='test/sanity/csi-sanity'
 "$CSI_SANITY_BIN" --ginkgo.v --csi.endpoint="$endpoint" --ginkgo.skip='should work|should fail when volume does not exist on the specified path'

--- a/test/sanity/run-tests-all-clouds.sh
+++ b/test/sanity/run-tests-all-clouds.sh
@@ -16,14 +16,5 @@
 
 set -euo pipefail
 
-function install_csi_sanity_bin {
-  echo 'Installing CSI sanity test binary...'
-  git clone https://github.com/kubernetes-csi/csi-test.git -b v2.2.0
-  pushd csi-test/cmd/csi-sanity
-  make
-  popd
-}
-
-apt update && apt install cifs-utils procps -y
-install_csi_sanity_bin
+apt update && apt install procps -y
 test/sanity/run-test.sh "$nodeid"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
test: use a different path for csi-sanity test

original path would cause following error with go 1.14+:
```
/home/prow/go/src/sigs.k8s.io/azuredisk-csi-driver/csi-test/cmd/csi-sanity /home/prow/go/src/sigs.k8s.io/azuredisk-csi-driver
make[1]: Entering directory '/home/prow/go/src/sigs.k8s.io/azuredisk-csi-driver/csi-test/cmd/csi-sanity'
go test -ldflags "-w -X github.com/kubernetes-csi/csi-test/cmd/csi-sanity.VERSION=v1.1.0-172-g82b0519-HEAD -extldflags '-z relro -z now'" -c -o csi-sanity
# sigs.k8s.io/azuredisk-csi-driver/csi-test/cmd/csi-sanity
sanity_test.go:24:2: cannot find package "." in:
	/home/prow/go/src/sigs.k8s.io/azuredisk-csi-driver/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity
FAIL	sigs.k8s.io/azuredisk-csi-driver/csi-test/cmd/csi-sanity [setup failed]
make[1]: *** [Makefile:26: csi-sanity] Error 1
make[1]: Leaving directory '/home/prow/go/src/sigs.k8s.io/azuredisk-csi-driver/csi-test/cmd/csi-sanity'
    sanity_test.go:89: Sanity test failed exit status 2
```

 - how to get csi-sanity v2.2.0 test binary
```
git clone https://github.com/kubernetes-csi/csi-test.git -b v2.2.0 ~/csi-test
cd ~/csi-test/cmd/csi-sanity/
make
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
