### PR TITLE
test: fix windows output encoding for statefulset and deployment e2e test cases

### DIFF
--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -262,7 +262,6 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool) {
 	})
 
 	ginkgo.It("should create a deployment object, write and read to it, delete the pod and write and read to it again [kubernetes.io/azure-disk] [disk.csi.azure.com] [Windows]", func() {
-		skipIfTestingInWindowsCluster()
 		if isWindowsCluster {
 			// waiting for fix(https://github.com/kubernetes/kubernetes/pull/95456) in CSI driver
 			if !isUsingInTreeVolumePlugin || isTestingMigration {
@@ -586,7 +585,6 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool) {
 	})
 
 	ginkgo.It("should create a statefulset object, write and read to it, delete the pod and write and read to it again [kubernetes.io/azure-disk] [disk.csi.azure.com] [Windows]", func() {
-		skipIfTestingInWindowsCluster()
 		pod := testsuites.PodDetails{
 			Cmd: convertToPowershellorCmdCommandIfNecessary("echo 'hello world' >> /mnt/test-1/data && while true; do sleep 3600; done"),
 			Volumes: t.normalizeVolumes([]testsuites.VolumeDetails{
@@ -600,7 +598,7 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool) {
 				},
 			}, isMultiZone),
 			IsWindows: isWindowsCluster,
-			UseCMD:    true,
+			UseCMD:    false,
 		}
 
 		podCheckCmd := []string{"cat", "/mnt/test-1/data"}

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -251,7 +251,7 @@ func convertToPowershellorCmdCommandIfNecessary(command string) string {
 	case "while true; do echo $(date -u) >> /mnt/test-1/data; sleep 3600; done":
 		return "while (1) { Add-Content -Encoding Ascii C:\\mnt\\test-1\\data.txt $(Get-Date -Format u); sleep 3600 }"
 	case "echo 'hello world' >> /mnt/test-1/data && while true; do sleep 3600; done":
-		return "echo hello world>> C:\\mnt\\test-1\\data.txt&sleep 3600"
+		return "echo 'hello world' | Out-File -Append -FilePath C:\\mnt\\test-1\\data.txt; Get-Content C:\\mnt\\test-1\\data.txt | findstr 'hello world'; Start-Sleep 3600"
 	case "echo 'hello world' > /mnt/test-1/data && echo 'hello world' > /mnt/test-2/data && echo 'hello world' > /mnt/test-3/data && grep 'hello world' /mnt/test-1/data && grep 'hello world' /mnt/test-2/data && grep 'hello world' /mnt/test-3/data":
 		return "echo 'hello world' | Out-File -FilePath C:\\mnt\\test-1\\data.txt; Get-Content C:\\mnt\\test-1\\data.txt | findstr 'hello world'; echo 'hello world' | Out-File -FilePath C:\\mnt\\test-2\\data.txt; Get-Content C:\\mnt\\test-2\\data.txt | findstr 'hello world'; echo 'hello world' | Out-File -FilePath C:\\mnt\\test-3\\data.txt; Get-Content C:\\mnt\\test-3\\data.txt | findstr 'hello world'"
 	}

--- a/test/utils/check_driver_pods_restart.sh
+++ b/test/utils/check_driver_pods_restart.sh
@@ -43,7 +43,7 @@ for ((i=0; i<${#processed_restarts[@]}; i++)); do
         if [[ "$1" == "log" ]]; then
             kubectl describe po ${processed_pods[$i]} -n kube-system
             echo "======================================================================================"
-            echo "print previous azuredisk cotnainer logs since there is a restart"
+            echo "print previous azuredisk container logs since there is a restart"
             kubectl logs ${processed_pods[$i]} -c azuredisk -p -n kube-system
             echo "======================================================================================"
         fi


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

Fixes the output text encoding for the Windows statefulset and deployment e2e test cases by using the Powershell Out-File cmdlet.
Fixes a minor spelling error in test result logging.

**Which issue(s) this PR fixes**:

Fixes #381, #615

Re-enables one of the two test cases (statefulset) for #615. The deployment e2e test is still waiting for fix https://github.com/kubernetes/kubernetes/pull/95456.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
