### PR TITLE
fix: reduce driver logs

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-versions: [1.13.x]
+        go-versions: [1.15.x]
         platform: [windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
+++ b/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
@@ -34,7 +34,7 @@ spec:
           args:
             - "--feature-gates=Topology=true"
             - "--csi-address=$(ADDRESS)"
-            - "--v=5"
+            - "--v=2"
             - "--timeout=15s"
             - "--enable-leader-election"
             - "--leader-election-type=leases"
@@ -54,7 +54,7 @@ spec:
         - name: csi-attacher
           image: "{{ .Values.image.csiAttacher.repository }}:{{ .Values.image.csiAttacher.tag }}"
           args:
-            - "-v=5"
+            - "-v=2"
             - "-csi-address=$(ADDRESS)"
             - "-timeout=120s"
             - "-leader-election"
@@ -77,7 +77,7 @@ spec:
           args:
             - "-csi-address=$(ADDRESS)"
             - "-leader-election"
-            - "-v=5"
+            - "-v=2"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -96,7 +96,7 @@ spec:
           image: "{{ .Values.image.csiResizer.repository }}:{{ .Values.image.csiResizer.tag }}"
           args:
             - "-csi-address=$(ADDRESS)"
-            - "-v=5"
+            - "-v=2"
             - "-leader-election"
             - '-handle-volume-inuse-error=true'
           env:
@@ -118,7 +118,7 @@ spec:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
             - --health-port=29602
-            - --v=5
+            - --v=2
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-node-windows.yaml
+++ b/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-node-windows.yaml
@@ -40,7 +40,7 @@ spec:
             - "--csi-address=$(CSI_ENDPOINT)"
             - "--probe-timeout=3s"
             - "--health-port=29603"
-            - "--v=5"
+            - "--v=2"
           env:
             - name: CSI_ENDPOINT
               value: unix://C:\\csi\\csi.sock
@@ -55,7 +55,7 @@ spec:
         - name: node-driver-registrar
           image: "{{ .Values.windows.image.nodeDriverRegistrar.repository }}:{{ .Values.windows.image.nodeDriverRegistrar.tag }}"
           args:
-            - "--v=5"
+            - "--v=2"
             - "--csi-address=$(CSI_ENDPOINT)"
             - "--kubelet-registration-path=C:\\var\\lib\\kubelet\\plugins\\disk.csi.azure.com\\csi.sock"
           env:

--- a/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
+++ b/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
@@ -42,7 +42,7 @@ spec:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
             - --health-port=29603
-            - --v=5
+            - --v=2
           resources:
             limits:
               cpu: 100m
@@ -55,7 +55,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --v=5
+            - --v=2
           lifecycle:
             preStop:
               exec:

--- a/charts/latest/azuredisk-csi-driver/templates/csi-snapshot-controller.yaml
+++ b/charts/latest/azuredisk-csi-driver/templates/csi-snapshot-controller.yaml
@@ -29,7 +29,7 @@ spec:
         - name: csi-snapshot-controller
           image: "{{ .Values.snapshot.image.csiSnapshotController.repository }}:{{ .Values.snapshot.image.csiSnapshotController.tag }}"
           args:
-            - "--v=5"
+            - "--v=2"
             - "--leader-election=false"
           resources:
             limits:

--- a/deploy/csi-azuredisk-controller.yaml
+++ b/deploy/csi-azuredisk-controller.yaml
@@ -30,7 +30,7 @@ spec:
           args:
             - "--feature-gates=Topology=true"
             - "--csi-address=$(ADDRESS)"
-            - "--v=5"
+            - "--v=2"
             - "--timeout=15s"
             - "--enable-leader-election"
             - "--leader-election-type=leases"
@@ -50,7 +50,7 @@ spec:
         - name: csi-attacher
           image: mcr.microsoft.com/oss/kubernetes-csi/csi-attacher:v2.2.0
           args:
-            - "-v=5"
+            - "-v=2"
             - "-csi-address=$(ADDRESS)"
             - "-timeout=120s"
             - "-leader-election"
@@ -72,7 +72,7 @@ spec:
           args:
             - "-csi-address=$(ADDRESS)"
             - "-leader-election"
-            - "--v=5"
+            - "--v=2"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -90,7 +90,7 @@ spec:
           image: mcr.microsoft.com/oss/kubernetes-csi/csi-resizer:v1.1.0
           args:
             - "-csi-address=$(ADDRESS)"
-            - "-v=5"
+            - "-v=2"
             - "-leader-election"
             - '-handle-volume-inuse-error=true'
           env:
@@ -112,7 +112,7 @@ spec:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
             - --health-port=29602
-            - --v=5
+            - --v=2
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/deploy/csi-azuredisk-node-windows.yaml
+++ b/deploy/csi-azuredisk-node-windows.yaml
@@ -36,7 +36,7 @@ spec:
             - "--csi-address=$(CSI_ENDPOINT)"
             - "--probe-timeout=3s"
             - "--health-port=29603"
-            - "--v=5"
+            - "--v=2"
           env:
             - name: CSI_ENDPOINT
               value: unix://C:\\csi\\csi.sock
@@ -50,7 +50,7 @@ spec:
         - name: node-driver-registrar
           image: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.0.1
           args:
-            - "--v=5"
+            - "--v=2"
             - "--csi-address=$(CSI_ENDPOINT)"
             - "--kubelet-registration-path=C:\\var\\lib\\kubelet\\plugins\\disk.csi.azure.com\\csi.sock"
           env:

--- a/deploy/csi-azuredisk-node.yaml
+++ b/deploy/csi-azuredisk-node.yaml
@@ -40,7 +40,7 @@ spec:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
             - --health-port=29603
-            - --v=5
+            - --v=2
           resources:
             limits:
               cpu: 100m
@@ -53,7 +53,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --v=5
+            - --v=2
           lifecycle:
             preStop:
               exec:

--- a/deploy/csi-snapshot-controller.yaml
+++ b/deploy/csi-snapshot-controller.yaml
@@ -27,7 +27,7 @@ spec:
         - name: csi-snapshot-controller
           image: mcr.microsoft.com/oss/kubernetes-csi/snapshot-controller:v3.0.3
           args:
-            - "--v=5"
+            - "--v=2"
             - "--leader-election=false"
           resources:
             limits:

--- a/hack/verify-examples.sh
+++ b/hack/verify-examples.sh
@@ -23,16 +23,18 @@ if [[ "$1" == "linux" ]]; then
     kubectl apply -f deploy/example/deployment.yaml
     kubectl apply -f deploy/example/statefulset.yaml
     kubectl apply -f deploy/example/statefulset-nonroot.yaml
-    echo "sleep 120s ..."
-    sleep 120
 fi
 
 if [[ "$1" == "windows" ]]; then
     kubectl apply -f deploy/example/windows/deployment.yaml
     kubectl apply -f deploy/example/windows/statefulset.yaml
-    echo "sleep 180s ..."
-    sleep 180
 fi
+
+echo "sleep 180s ..."
+sleep 180
+
+echo "begin to check pod status ..."
+kubectl get pods
 
 if [[ "$1" == "linux" ]]; then
     kubectl get pods --field-selector status.phase=Running | grep deployment-azuredisk
@@ -41,6 +43,8 @@ if [[ "$1" == "linux" ]]; then
 fi
 
 if [[ "$1" == "windows" ]]; then
+    echo "sleep 120s for Windows ..."
+    sleep 120
     kubectl get pods --field-selector status.phase=Running | grep deployment-azuredisk-win
     kubectl get pods --field-selector status.phase=Running | grep statefulset-azuredisk-win-0
 fi

--- a/pkg/csi-common/controllerserver-default.go
+++ b/pkg/csi-common/controllerserver-default.go
@@ -21,7 +21,6 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/klog/v2"
 )
 
 type DefaultControllerServer struct {
@@ -45,8 +44,6 @@ func (cs *DefaultControllerServer) ControllerUnpublishVolume(ctx context.Context
 }
 
 func (cs *DefaultControllerServer) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
-	klog.V(5).Infof("Using default ValidateVolumeCapabilities")
-
 	for _, c := range req.GetVolumeCapabilities() {
 		found := false
 		for _, c1 := range cs.Driver.VC {
@@ -76,8 +73,6 @@ func (cs *DefaultControllerServer) GetCapacity(ctx context.Context, req *csi.Get
 // ControllerGetCapabilities implements the default GRPC callout.
 // Default supports all capabilities
 func (cs *DefaultControllerServer) ControllerGetCapabilities(ctx context.Context, req *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
-	klog.V(5).Infof("Using default ControllerGetCapabilities")
-
 	return &csi.ControllerGetCapabilitiesResponse{
 		Capabilities: cs.Driver.Cap,
 	}, nil

--- a/pkg/csi-common/identityserver-default.go
+++ b/pkg/csi-common/identityserver-default.go
@@ -21,7 +21,6 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/klog/v2"
 )
 
 type DefaultIdentityServer struct {
@@ -29,8 +28,6 @@ type DefaultIdentityServer struct {
 }
 
 func (ids *DefaultIdentityServer) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
-	klog.V(5).Infof("Using default GetPluginInfo")
-
 	if ids.Driver.Name == "" {
 		return nil, status.Error(codes.Unavailable, "Driver name not configured")
 	}
@@ -50,7 +47,6 @@ func (ids *DefaultIdentityServer) Probe(ctx context.Context, req *csi.ProbeReque
 }
 
 func (ids *DefaultIdentityServer) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
-	klog.V(5).Infof("Using default capabilities")
 	return &csi.GetPluginCapabilitiesResponse{
 		Capabilities: []*csi.PluginCapability{
 			{

--- a/pkg/csi-common/nodeserver-default.go
+++ b/pkg/csi-common/nodeserver-default.go
@@ -19,7 +19,6 @@ package csicommon
 import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/net/context"
-	"k8s.io/klog/v2"
 )
 
 type DefaultNodeServer struct {
@@ -27,16 +26,12 @@ type DefaultNodeServer struct {
 }
 
 func (ns *DefaultNodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
-	klog.V(5).Infof("Using default NodeGetInfo")
-
 	return &csi.NodeGetInfoResponse{
 		NodeId: ns.Driver.NodeID,
 	}, nil
 }
 
 func (ns *DefaultNodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
-	klog.V(2).Infof("Using default NodeGetCapabilities")
-
 	return &csi.NodeGetCapabilitiesResponse{
 		Capabilities: ns.Driver.NSCap,
 	}, nil

--- a/pkg/csi-common/utils.go
+++ b/pkg/csi-common/utils.go
@@ -80,14 +80,25 @@ func NewNodeServiceCapability(cap csi.NodeServiceCapability_RPC_Type) *csi.NodeS
 	}
 }
 
+func getLogLevel(method string) int32 {
+	if method == "/csi.v1.Identity/Probe" ||
+		method == "/csi.v1.Node/NodeGetCapabilities" ||
+		method == "/csi.v1.Node/NodeGetVolumeStats" {
+		return 10
+	}
+	return 2
+}
+
 func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-	klog.V(3).Infof("GRPC call: %s", info.FullMethod)
-	klog.V(5).Infof("GRPC request: %s", protosanitizer.StripSecrets(req))
+	level := klog.Level(getLogLevel(info.FullMethod))
+	klog.V(level).Infof("GRPC call: %s", info.FullMethod)
+	klog.V(level).Infof("GRPC request: %s", protosanitizer.StripSecrets(req))
+
 	resp, err := handler(ctx, req)
 	if err != nil {
 		klog.Errorf("GRPC error: %v", err)
 	} else {
-		klog.V(5).Infof("GRPC response: %s", protosanitizer.StripSecrets(resp))
+		klog.V(level).Infof("GRPC response: %s", protosanitizer.StripSecrets(resp))
 	}
 	return resp, err
 }

--- a/pkg/csi-common/utils_test.go
+++ b/pkg/csi-common/utils_test.go
@@ -222,3 +222,38 @@ func TestNewNodeServiceCapability(t *testing.T) {
 		assert.Equal(t, resp.XXX_sizecache, int32(0))
 	}
 }
+
+func TestGetLogLevel(t *testing.T) {
+	tests := []struct {
+		method string
+		level  int32
+	}{
+		{
+			method: "/csi.v1.Identity/Probe",
+			level:  10,
+		},
+		{
+			method: "/csi.v1.Node/NodeGetCapabilities",
+			level:  10,
+		},
+		{
+			method: "/csi.v1.Node/NodeGetVolumeStats",
+			level:  10,
+		},
+		{
+			method: "",
+			level:  2,
+		},
+		{
+			method: "unknown",
+			level:  2,
+		},
+	}
+
+	for _, test := range tests {
+		level := getLogLevel(test.method)
+		if level != test.level {
+			t.Errorf("returned level: (%v), expected level: (%v)", level, test.level)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: reduce driver logs

 - don't print following method logs by default
following 3 method logs constitute 99.8% logs of all driver logs, this PR set the log level of following 3 methods as `10`, and it would not show in driver logs by default(<= `5` will show in driver logs)
```
/csi.v1.Identity/Probe
/csi.v1.Node/NodeGetCapabilities
/csi.v1.Node/NodeGetVolumeStats
```

 - set log level of csi side car contains as 2
This could reduce `17,280` logs every day of csi-provisioner, csi-resizer, etc which has lease election, following logs would show every 5s:
```
I0119 12:57:02.073355       1 leaderelection.go:282] successfully renewed lease kube-system/blob-csi-azure-com
I0119 12:57:07.081182       1 leaderelection.go:282] successfully renewed lease kube-system/blob-csi-azure-com
I0119 12:57:12.097738       1 leaderelection.go:282] successfully renewed lease kube-system/blob-csi-azure-com
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: reduce driver logs
```
