### PR TITLE
fix: Use new windows server image to avoid driver daemonset failure

### DIFF
--- a/test/e2e/manifest/migration-windows.json
+++ b/test/e2e/manifest/migration-windows.json
@@ -44,8 +44,8 @@
             "sshEnabled": true,
             "windowsPublisher": "microsoft-aks",
             "windowsOffer": "aks-windows",
-            "windowsSku": "2019-datacenter-core-smalldisk-2007",
-            "imageVersion": "17763.1339.200718"
+            "windowsSku": "2019-datacenter-core-smalldisk-2008",
+            "imageVersion": "17763.1397.200820"
         },        
         "linuxProfile": {
             "adminUsername": "azureuser",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

Optionally add one or more of the following kinds if applicable:

**What this PR does / why we need it**:
Updates windows image version to use in the e2e test manifest. New windows version has mitigation for driver DaemonSet crashes.

**Which issue(s) this PR fixes**:
Fixes #553 
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
@andyzhangx Please review.

**Release note**:
```
none
```
