### PR TITLE
feat: support ZRS disk

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           # start the CSI Proxy before running tests on windows
           Start-Job -Name CSIProxy -ScriptBlock {
-            Invoke-WebRequest https://kubernetesartifacts.azureedge.net/csi-proxy/v0.2.2/binaries/csi-proxy.tar.gz -OutFile csi-proxy.tar.gz;
+            Invoke-WebRequest https://acs-mirror.azureedge.net/csi-proxy/v0.2.2/binaries/csi-proxy-v0.2.2.tar.gz -OutFile csi-proxy.tar.gz;
             tar -xvf csi-proxy.tar.gz
             .\bin\csi-proxy.exe --kubelet-csi-plugins-path $pwd --kubelet-pod-path $pwd
           };

--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -216,7 +216,25 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		return nil, err
 	}
 
-	selectedAvailabilityZone := pickAvailabilityZone(req.GetAccessibilityRequirements(), d.cloud.Location)
+	diskZone := pickAvailabilityZone(req.GetAccessibilityRequirements(), d.cloud.Location)
+	accessibleTopology := []*csi.Topology{}
+	if skuName == compute.StandardSSDZRS || skuName == compute.PremiumZRS {
+		klog.V(2).Infof("diskZone(%s) is reset as empty since disk(%s) is ZRS(%s)", diskZone, diskName, skuName)
+		diskZone = ""
+		// make volume scheduled on all 3 availability zones
+		for i := 1; i <= 3; i++ {
+			topology := &csi.Topology{
+				Segments: map[string]string{topologyKey: fmt.Sprintf("%s-%d", d.cloud.Location, i)},
+			}
+			accessibleTopology = append(accessibleTopology, topology)
+		}
+	} else {
+		accessibleTopology = []*csi.Topology{
+			{
+				Segments: map[string]string{topologyKey: diskZone},
+			},
+		}
+	}
 
 	if ok, err := d.checkDiskCapacity(ctx, resourceGroup, diskName, requestGiB); !ok {
 		return nil, err
@@ -233,8 +251,8 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		mc.ObserveOperationWithResult(isOperationSucceeded)
 	}()
 
-	klog.V(2).Infof("begin to create azure disk(%s) account type(%s) rg(%s) location(%s) size(%d) selectedAvailabilityZone(%v) maxShares(%d)",
-		diskName, skuName, resourceGroup, location, requestGiB, selectedAvailabilityZone, maxShares)
+	klog.V(2).Infof("begin to create azure disk(%s) account type(%s) rg(%s) location(%s) size(%d) diskZone(%v) maxShares(%d)",
+		diskName, skuName, resourceGroup, location, requestGiB, diskZone, maxShares)
 
 	tags := make(map[string]string)
 	contentSource := &csi.VolumeContentSource{}
@@ -286,7 +304,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		PVCName:             "",
 		SizeGB:              requestGiB,
 		Tags:                tags,
-		AvailabilityZone:    selectedAvailabilityZone,
+		AvailabilityZone:    diskZone,
 		DiskIOPSReadWrite:   diskIopsReadWrite,
 		DiskMBpsReadWrite:   diskMbpsReadWrite,
 		SourceResourceID:    sourceID,
@@ -308,15 +326,11 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 
 	return &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
-			VolumeId:      diskURI,
-			CapacityBytes: capacityBytes,
-			VolumeContext: parameters,
-			ContentSource: contentSource,
-			AccessibleTopology: []*csi.Topology{
-				{
-					Segments: map[string]string{topologyKey: selectedAvailabilityZone},
-				},
-			},
+			VolumeId:           diskURI,
+			CapacityBytes:      capacityBytes,
+			VolumeContext:      parameters,
+			ContentSource:      contentSource,
+			AccessibleTopology: accessibleTopology,
 		},
 	}, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: support ZRS disk

To support ZRS disk on one subscription, run:
```console
az feature register --name SsdZrsManagedDisks --namespace Microsoft.Compute
az feature list -o table --query "[?contains(name, 'Microsoft.Compute/SsdZrsManagedDisks')].{Name:name,State:properties.state}"
az provider register --namespace Microsoft.Compute
```

 - `nodeAffinity` of ZRS disk
```
  spec:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 10Gi
    claimRef:
      apiVersion: v1
      kind: PersistentVolumeClaim
      name: persistent-storage-statefulset-azuredisk-0
      namespace: default
      resourceVersion: "48991"
      uid: 47534b37-c817-464a-8b8e-c37427f77c00
    csi:
      driver: disk.csi.azure.com
      volumeAttributes:
        skuname: StandardSSD_ZRS
        storage.kubernetes.io/csiProvisionerIdentity: 1618402610023-8081-disk.csi.azure.com
      volumeHandle: /subscriptions/xxx/resourceGroups/mc_andy-aks1199_andy-aks1199_eastus2euap/providers/Microsoft.Compute/disks/pvc-47534b37-c817-464a-8b8e-c37427f77c00
    nodeAffinity:
      required:
        nodeSelectorTerms:
        - matchExpressions:
          - key: topology.disk.csi.azure.com/zone
            operator: In
            values:
            - eastus2euap-1
        - matchExpressions:
          - key: topology.disk.csi.azure.com/zone
            operator: In
            values:
            - eastus2euap-2
        - matchExpressions:
          - key: topology.disk.csi.azure.com/zone
            operator: In
            values:
            - eastus2euap-3
    persistentVolumeReclaimPolicy: Delete
    storageClassName: managed-csi
    volumeMode: Filesystem
  status:
    phase: Bound
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #573

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
feat: support ZRS disk
```
