### PR TITLE
chore: Fix arm64 container build

### DIFF
--- a/docs/csi-dev.md
+++ b/docs/csi-dev.md
@@ -42,7 +42,7 @@ $ make build
 #### Start CSI driver locally
 ```console
 $ cd $GOPATH/src/sigs.k8s.io/azuredisk-csi-driver
-$ ./_output/azurediskplugin --endpoint tcp://127.0.0.1:10000 --nodeid CSINode -v=5 &
+$ ./_output/amd64/azurediskplugin --endpoint tcp://127.0.0.1:10000 --nodeid CSINode -v=5 &
 ```
 > Before running CSI driver, create "/etc/kubernetes/azure.json" file under testing server(it's better copy `azure.json` file from a k8s cluster with service principle configured correctly) and set `AZURE_CREDENTIAL_FILE` as following:
 ```console

--- a/pkg/azurediskplugin/Dockerfile
+++ b/pkg/azurediskplugin/Dockerfile
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 ARG ARCH
-
 FROM k8s.gcr.io/build-image/debian-base-${ARCH}:v2.1.3
 RUN clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs
 
 LABEL maintainers="andyzhangx"
 LABEL description="Azure Disk CSI Driver"
 
+ARG ARCH
 ARG PLUGIN_NAME=azurediskplugin
-COPY ./_output/${PLUGIN_NAME} /azurediskplugin
+COPY ./_output/${ARCH}/${PLUGIN_NAME} /azurediskplugin
 ENTRYPOINT ["/azurediskplugin"]

--- a/pkg/azurediskplugin/Windows.Dockerfile
+++ b/pkg/azurediskplugin/Windows.Dockerfile
@@ -1,5 +1,6 @@
+ARG ARCH=amd64
 ARG OSVERSION
-FROM --platform=linux/amd64 gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-${OSVERSION} as core
+FROM --platform=linux/${ARCH} gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-${ARCH}-${OSVERSION} as core
 
 FROM mcr.microsoft.com/windows/nanoserver:${OSVERSION}
 COPY --from=core /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll
@@ -7,6 +8,7 @@ COPY --from=core /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll
 USER ContainerAdministrator
 LABEL description="CSI Azure disk plugin"
 
+ARG ARCH
 ARG PLUGIN_NAME=azurediskplugin
-COPY ./_output/${PLUGIN_NAME}.exe /azurediskplugin.exe
+COPY ./_output/${ARCH}/${PLUGIN_NAME}.exe /azurediskplugin.exe
 ENTRYPOINT ["/azurediskplugin.exe"]

--- a/pkg/azurediskplugin/dev.Dockerfile
+++ b/pkg/azurediskplugin/dev.Dockerfile
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 FROM mcr.microsoft.com/aks/fundamental/base-ubuntu:v0.0.5
 RUN apt-get update && apt-get install -y util-linux e2fsprogs mount ca-certificates udev xfsprogs
 LABEL maintainers="andyzhangx"
 LABEL description="Azure Disk CSI Driver"
 
+ARG ARCH=amd64
 ARG PLUGIN_NAME=azurediskplugin
-COPY ./_output/${PLUGIN_NAME} /azurediskplugin
+COPY ./_output/${ARCH}/${PLUGIN_NAME} /azurediskplugin
 ENTRYPOINT ["/azurediskplugin"]

--- a/test/integration/run-test.sh
+++ b/test/integration/run-test.sh
@@ -41,11 +41,16 @@ fi
 
 echo "Begin to run integration test on $cloud..."
 
+ARCH=$(uname -p)
+if [[ "${ARCH}" == "x86_64" || ${ARCH} == "unknown" ]]; then
+  ARCH="amd64"
+fi
+
 # Run CSI driver as a background service
 if [[ $# -lt 4 || "$4" != "v2" ]]; then
-  _output/azurediskplugin --endpoint "$endpoint" --nodeid "$node" -v=5 &
+  _output/${ARCH}/azurediskplugin --endpoint "$endpoint" --nodeid "$node" -v=5 &
 else
-  _output/azurediskpluginv2 --endpoint "$endpoint" --nodeid "$node" -v=5 --temp-use-driver-v2 &
+  _output/${ARCH}/azurediskpluginv2 --endpoint "$endpoint" --nodeid "$node" -v=5 --temp-use-driver-v2 &
 fi
 trap cleanup EXIT
 

--- a/test/sanity/run-test.sh
+++ b/test/sanity/run-test.sh
@@ -31,10 +31,15 @@ if [[ "$#" -gt 0 ]] && [[ -n "$1" ]]; then
   nodeid="$1"
 fi
 
+ARCH=$(uname -p)
+if [[ "${ARCH}" == "x86_64" || ${ARCH} == "unknown" ]]; then
+  ARCH="amd64"
+fi
+
 if [[ "$#" -lt 2 || "$2" != "v2" ]]; then
-  _output/azurediskplugin --endpoint "$endpoint" --nodeid "$nodeid" -v=5 &
+  _output/${ARCH}/azurediskplugin --endpoint "$endpoint" --nodeid "$nodeid" -v=5 &
 else
-  _output/azurediskpluginv2 --endpoint "$endpoint" --nodeid "$nodeid" -v=5 --temp-use-driver-v2 &
+  _output/${ARCH}/azurediskpluginv2 --endpoint "$endpoint" --nodeid "$nodeid" -v=5 --temp-use-driver-v2 &
 fi
 
 echo 'Begin to run sanity test...'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

Fixes the Makefile `container-all` target to build the correct architecture binary and splits outputs into architecture-specific directories to ensure the correct binary is used when building the container image.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

The initial support for the arm64 build through `container-all` appeared to work but actually picked up the amd64 build because the incorrect `ARCH=$${arch} $(MAKE) azurefile` command would fail to re-build the binary for each architecture. The amd64 build was still in the dependency list for the `container-all` target, and subsequent container build commands would simply use the previously built amd64 binary.

**Release note**:
```
none
```
