### PR TITLE
feat: expose metadata for static PV attachment

### DIFF
--- a/pkg/azureutils/azure_disk_utils.go
+++ b/pkg/azureutils/azure_disk_utils.go
@@ -453,3 +453,34 @@ func getKubeClient(kubeconfig string) (*kubernetes.Clientset, error) {
 
 	return kubernetes.NewForConfig(config)
 }
+
+// InsertDiskProperties: insert disk properties to map
+func InsertDiskProperties(disk *compute.Disk, publishConext map[string]string) {
+	if disk == nil || publishConext == nil {
+		return
+	}
+
+	if disk.Sku != nil {
+		publishConext[consts.SkuNameField] = string(disk.Sku.Name)
+	}
+	prop := disk.DiskProperties
+	if prop != nil {
+		publishConext[consts.NetworkAccessPolicyField] = string(prop.NetworkAccessPolicy)
+		if prop.DiskIOPSReadWrite != nil {
+			publishConext[consts.DiskIOPSReadWriteField] = strconv.Itoa(int(*prop.DiskIOPSReadWrite))
+		}
+		if prop.DiskMBpsReadWrite != nil {
+			publishConext[consts.DiskMBPSReadWriteField] = strconv.Itoa(int(*prop.DiskMBpsReadWrite))
+		}
+		if prop.CreationData != nil && prop.CreationData.LogicalSectorSize != nil {
+			publishConext[consts.LogicalSectorSizeField] = strconv.Itoa(int(*prop.CreationData.LogicalSectorSize))
+		}
+		if prop.Encryption != nil &&
+			prop.Encryption.DiskEncryptionSetID != nil {
+			publishConext[consts.DesIDField] = *prop.Encryption.DiskEncryptionSetID
+		}
+		if prop.MaxShares != nil {
+			publishConext[consts.MaxSharesField] = strconv.Itoa(int(*prop.MaxShares))
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: expose metadata for static PV attachment

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
```console
# k get volumeattachments
NAME                                                                   ATTACHER             PV                                         NODE                           ATTACHED   AGE
csi-b848a2790e08e279bd52b47c1db0177d5d804cfbccc64e28b3392028f972527d   disk.csi.azure.com   pv-azuredisk                               aks-disk-18870927-vmss000000   true       10m

# k get volumeattachments csi-b848a2790e08e279bd52b47c1db0177d5d804cfbccc64e28b3392028f972527d -o yaml
apiVersion: storage.k8s.io/v1
kind: VolumeAttachment
metadata:
  annotations:
    csi.alpha.kubernetes.io/node-id: aks-disk-18870927-vmss000000
  creationTimestamp: "2021-09-03T10:46:59Z"
  finalizers:
  - external-attacher/disk-csi-azure-com
  name: csi-b848a2790e08e279bd52b47c1db0177d5d804cfbccc64e28b3392028f972527d
  resourceVersion: "17068153"
  uid: c4412fa9-0abc-4cf5-86d5-3f3505f2c506
spec:
  attacher: disk.csi.azure.com
  nodeName: aks-disk-18870927-vmss000000
  source:
    persistentVolumeName: pv-azuredisk
status:
  attached: true
  attachmentMetadata:
    LUN: "5"
    diskiopsreadwrite: "500"
    diskmbpsreadwrite: "60"
    networkaccesspolicy: AllowAll
    skuname: StandardSSD_LRS
```

**Release note**:
```
feat: expose metadata for static PV attachment
```
