### PR TITLE
fix: panic when vm size not in SkuMap table

### DIFF
--- a/pkg/azuredisk/azuredisk.go
+++ b/pkg/azuredisk/azuredisk.go
@@ -161,7 +161,7 @@ func (d *Driver) Run(endpoint, kubeconfig string, disableAVSetNodes, testingMock
 	if d.getPerfOptimizationEnabled() {
 		d.nodeInfo, err = optimization.NewNodeInfo(d.getCloud(), d.NodeID)
 		if err != nil {
-			klog.Fatalf("Failed to get node info. Error: %v", err)
+			klog.Errorf("Failed to get node info. Error: %v", err)
 		}
 	}
 

--- a/pkg/azuredisk/azuredisk_v2.go
+++ b/pkg/azuredisk/azuredisk_v2.go
@@ -115,7 +115,7 @@ func (d *DriverV2) Run(endpoint, kubeconfig string, disableAVSetNodes, testingMo
 	if d.getPerfOptimizationEnabled() {
 		d.nodeInfo, err = optimization.NewNodeInfo(d.getCloud(), d.NodeID)
 		if err != nil {
-			klog.Fatalf("Failed to get node info. Error: %v", err)
+			klog.Errorf("Failed to get node info. Error: %v", err)
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: panic when vm size not in SkuMap table
If vm size is not in skuMap now, (e.g. standard_nd12s), `csi-azuredisk-node` DeamonSet would crash now.
This PR print a warning if vm size is not in supported list.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
 - driver node panic is like following:
```
I0901 15:25:01.078827       1 skus.go:120] PopulateNodeAndSkuInfo: Starting to populate node and disk sku information.
I0901 15:25:01.093092       1 skus.go:139] PopulateNodeAndSkuInfo: Populated node and disk sku information. NodeInfo=&{Standard_ND12s 0 eastus 0 0 0 0 0 0}
F0901 15:25:01.093111       1 azuredisk.go:195] Failed to get node info. Error: PopulateNodeAndSkuInfo: Could populate sku information. Error: populateSkuMap: Could not find SKU standard_nd12s in the sku map
goroutine 1 [running]:
k8s.io/klog/v2.stacks(0xc00000e001, 0xc000192200, 0xd0, 0x1ed)
	/agent/_work/1/s/go/src/sigs.k8s.io/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:1021 +0xb9
k8s.io/klog/v2.(*loggingT).output(0x2ad9ce0, 0xc000000003, 0x0, 0x0, 0xc0000f0e70, 0x22e3e44, 0xc, 0xc3, 0x0)
	/agent/_work/1/s/go/src/sigs.k8s.io/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:970 +0x191
k8s.io/klog/v2.(*loggingT).printf(0x2ad9ce0, 0xc000000003, 0x0, 0x0, 0x0, 0x0, 0x1cb83a2, 0x22, 0xc00002e1d0, 0x1, ...)
	/agent/_work/1/s/go/src/sigs.k8s.io/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:751 +0x191
k8s.io/klog/v2.Fatalf(...)
	/agent/_work/1/s/go/src/sigs.k8s.io/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:1509
sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk.(*Driver).Run(0xc00011e000, 0x7fff4737b9fd, 0x14, 0x0, 0x0, 0x1)
	/agent/_work/1/s/go/src/sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk/azuredisk.go:195 +0x786
main.handle()
	/agent/_work/1/s/go/src/sigs.k8s.io/azuredisk-csi-driver/pkg/azurediskplugin/main.go:75 +0x9c
main.main()
	/agent/_work/1/s/go/src/sigs.k8s.io/azuredisk-csi-driver/pkg/azurediskplugin/main.go:65 +0xae

goroutine 6 [chan receive]:
k8s.io/klog/v2.(*loggingT).flushDaemon(0x2ad9ce0)
	/agent/_work/1/s/go/src/sigs.k8s.io/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:1164 +0x8b
created by k8s.io/klog/v2.init.0
	/agent/_work/1/s/go/src/sigs.k8s.io/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:418 +0xdf
```

**Release note**:
```
none
```
