### PR TITLE
feat: support disable-avset-nodes in install-driver.sh script

### DIFF
--- a/deploy/csi-azuredisk-controller.yaml
+++ b/deploy/csi-azuredisk-controller.yaml
@@ -136,6 +136,7 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--metrics-address=0.0.0.0:29604"
             - "--user-agent-suffix=OSS-kubectl"
+            - "--disable-avset-nodes=true"
           ports:
             - containerPort: 29602
               name: healthz

--- a/deploy/install-driver.sh
+++ b/deploy/install-driver.sh
@@ -34,6 +34,14 @@ if [ $ver != "master" ]; then
 fi
 
 echo "Installing Azure Disk CSI driver, version: $ver ..."
+
+if [[ "$#" -gt 1 ]]; then
+  if [[ "$2" == *"enable-avset"* ]]; then
+    echo "set disable-avset-nodes as false ..."
+    sed -i 's/disable-avset-nodes=true/disable-avset-nodes=false/g' $repo/csi-azuredisk-controller.yaml
+  fi
+fi
+
 kubectl apply -f $repo/csi-azuredisk-driver.yaml
 kubectl apply -f $repo/rbac-csi-azuredisk-controller.yaml
 kubectl apply -f $repo/rbac-csi-azuredisk-node.yaml

--- a/pkg/azurediskplugin/main.go
+++ b/pkg/azurediskplugin/main.go
@@ -44,7 +44,7 @@ var (
 	kubeconfig                 = flag.String("kubeconfig", "", "Absolute path to the kubeconfig file. Required only when running out of cluster.")
 	driverName                 = flag.String("drivername", consts.DefaultDriverName, "name of the driver")
 	volumeAttachLimit          = flag.Int64("volume-attach-limit", -1, "maximum number of attachable volumes per node")
-	disableAVSetNodes          = flag.Bool("disable-avset-nodes", false, "disable DisableAvailabilitySetNodes in cloud config for controller")
+	disableAVSetNodes          = flag.Bool("disable-avset-nodes", true, "disable DisableAvailabilitySetNodes in cloud config for controller")
 	enablePerfOptimization     = flag.Bool("enable-perf-optimization", false, "boolean flag to enable disk perf optimization")
 	cloudConfigSecretName      = flag.String("cloud-config-secret-name", "azure-cloud-provider", "cloud config secret name")
 	cloudConfigSecretNamespace = flag.String("cloud-config-secret-namespace", "kube-system", "cloud config secret namespace")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: support disable-avset-nodes in install-driver.sh script
This PR is mainly for fixing e2e tests on capz with vmss & vmas mixed node pools. 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
```console
./deploy/install-driver.sh master local,snapshot,enable-avset
```

Should set `disable-avset-nodes` as `true` for non mixed node pools, otherwise this driver would introduce uncessary vm list operations.

https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_azuredisk-csi-driver/1007/pull-azuredisk-csi-driver-e2e-single-az/1435169955581530112/build-log.txt

```
       <*errors.errorString | 0xc000765220>: {
            s: "Attach volume \"/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/kubetest-dtgupzus/providers/Microsoft.Compute/disks/reattach-disk-multiple-nodes\" to instance \"k8s-agentpool1-25623319-0\" failed with newAvailabilitySetNodesCache: failed to list vms in the resource group kubetest-dtgupzus: Retriable: false, RetryAfter: 9s, HTTPStatusCode: 429, RawError: {\r\n  \"error\": {\r\n    \"details\": [\r\n      {\r\n        \"code\": \"TooManyRequests\",\r\n        \"message\": \"{\\\"operationGroup\\\":\\\"HighCostGet3Min\\\",\\\"startTime\\\":\\\"2021-09-07T09:33:20.7824151+00:00\\\",\\\"endTime\\\":\\\"2021-09-07T09:33:30+00:00\\\",\\\"allowedRequestCount\\\":140,\\\"measuredRequestCount\\\":153}\",\r\n        \"target\": \"HighCostGet3Min\"\r\n      }\r\n    ],\r\n    \"innererror\": {\r\n      \"internalErrorCode\": \"TooManyRequestsReceived\"\r\n    },\r\n    \"code\": \"OperationNotAllowed\",\r\n    \"message\": \"The server rejected the request because too many requests have been received for this subscription.\"\r\n  }\r\n}",
        }
        Attach volume "/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/kubetest-dtgupzus/providers/Microsoft.Compute/disks/reattach-disk-multiple-nodes" to instance "k8s-agentpool1-25623319-0" failed with newAvailabilitySetNodesCache: failed to list vms in the resource group kubetest-dtgupzus: Retriable: false, RetryAfter: 9s, HTTPStatusCode: 429, RawError: {
          "error": {
            "details": [
              {
                "code": "TooManyRequests",
                "message": "{\"operationGroup\":\"HighCostGet3Min\",\"startTime\":\"2021-09-07T09:33:20.7824151+00:00\",\"endTime\":\"2021-09-07T09:33:30+00:00\",\"allowedRequestCount\":140,\"measuredRequestCount\":153}",
                "target": "HighCostGet3Min"
              }
            ],
            "innererror": {
              "internalErrorCode": "TooManyRequestsReceived"
            },
            "code": "OperationNotAllowed",
            "message": "The server rejected the request because too many requests have been received for this subscription."
          }
        }
```

**Release note**:
```
feat: support disable-avset-nodes in install-driver.sh script
```
