### PR TITLE
chore: MCR pipeline support for V2 driver build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ GIT_COMMIT ?= $(shell git rev-parse HEAD)
 REGISTRY ?= andyzhangx
 REGISTRY_NAME ?= $(shell echo $(REGISTRY) | sed "s/.azurecr.io//g")
 IMAGE_NAME ?= azuredisk-csi
-ifndef BUILD_V2
+ifneq ($(BUILD_V2), true)
 PLUGIN_NAME = azurediskplugin
 IMAGE_VERSION ?= v1.9.0
 CHART_VERSION ?= latest
@@ -141,7 +141,7 @@ azuredisk:
 
 .PHONY: azuredisk-v2
 azuredisk-v2:
-	BUILD_V2=1 $(MAKE) azuredisk
+	BUILD_V2=true $(MAKE) azuredisk
 
 .PHONY: azuredisk-windows
 azuredisk-windows:
@@ -149,7 +149,7 @@ azuredisk-windows:
 
 .PHONY: azuredisk-windows-v2
 azuredisk-windows-v2:
-	BUILD_V2=1 $(MAKE) azuredisk
+	BUILD_V2=true $(MAKE) azuredisk
 
 .PHONY: azuredisk-darwin
 azuredisk-darwin:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

The pipeline used to build and publish container images to the MCR supports the use of environment variables, but requires their value be used to customize the build and not just their presence. In order to support building both the V1 & V2 driver from the same pipeline, this PR changes the Makefile to rely on the value of the `BUILD_V2` environment variable to determine whether to build the V1 or V2 driver.

Although the V2 driver will be built from the `main_v2` branch, this change is necessary on master to correctly build the V1 driver and avoid inadvertently building and publish an incomplete V2 driver image from master when the pipeline definition is updated.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
