### PR TITLE
feat: Disable DiagTrack service on Windows image

### DIFF
--- a/pkg/azurediskplugin/Windows.Dockerfile
+++ b/pkg/azurediskplugin/Windows.Dockerfile
@@ -2,12 +2,10 @@ ARG ARCH=amd64
 ARG OSVERSION
 FROM --platform=linux/${ARCH} gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-${ARCH}-${OSVERSION} as core
 
-FROM mcr.microsoft.com/windows/nanoserver:${OSVERSION}
+FROM mcr.microsoft.com/oss/kubernetes/windows-pause-image-base:v0.2
 COPY --from=core /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll
 
 USER ContainerAdministrator
-# Delete DiagTrack service as it causes CPU spikes and delays pod/container startup times.
-RUN sc.exe delete diagtrack -f
 
 LABEL description="CSI Azure disk plugin"
 

--- a/pkg/azurediskplugin/Windows.Dockerfile
+++ b/pkg/azurediskplugin/Windows.Dockerfile
@@ -6,6 +6,9 @@ FROM mcr.microsoft.com/windows/nanoserver:${OSVERSION}
 COPY --from=core /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll
 
 USER ContainerAdministrator
+# Delete DiagTrack service as it causes CPU spikes and delays pod/container startup times.
+RUN sc.exe delete diagtrack -f
+
 LABEL description="CSI Azure disk plugin"
 
 ARG ARCH


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: Disable DiagTrack service on Windows image

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1101

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
```console
C:\>sc.exe query diagtrack

SERVICE_NAME: diagtrack
        TYPE               : 10  WIN32_OWN_PROCESS
        STATE              : 4  RUNNING
                                (STOPPABLE, NOT_PAUSABLE, ACCEPTS_PRESHUTDOWN)
        WIN32_EXIT_CODE    : 0  (0x0)
        SERVICE_EXIT_CODE  : 0  (0x0)
        CHECKPOINT         : 0x0
        WAIT_HINT          : 0x0
```

```console
 => ERROR [stage-1 3/4] RUN sc.exe stop diagtrack                                                                                                       0.1s
------
 > [stage-1 3/4] RUN sc.exe stop diagtrack:
------
Windows.Dockerfile:11
--------------------
   9 |     # service in the driver and there's no reason for it to have any CPU usage.
  10 |     #COPY --from=core /Windows/System32/netapi32.dll /Windows/System32/diagtrack.dll
  11 | >>> RUN sc.exe stop diagtrack
  12 |
  13 |     USER ContainerAdministrator
--------------------
error: failed to solve: process "cmd /S /C sc.exe stop diagtrack" did not complete successfully: unable to find user ContainerUser: invalid argument
Makefile:175: recipe for target 'container-windows' failed

------
 > [stage-1 4/4] RUN sc.exe stop diagtrack:
------
Windows.Dockerfile:18
--------------------
  16 |     ARG PLUGIN_NAME=azurediskplugin
  17 |     COPY ./_output/${ARCH}/${PLUGIN_NAME}.exe /azurediskplugin.exe
  18 | >>> RUN sc.exe stop diagtrack
  19 |     ENTRYPOINT ["/azurediskplugin.exe"]
  20 |
--------------------
error: failed to solve: process "cmd /S /C sc.exe stop diagtrack" did not complete successfully: unable to find user ContainerAdministrator: invalid argument
Makefile:175: recipe for target 'container-windows' failed
make[1]: *** [container-windows] Error 1
```

**Release note**:
```
feat: Disable DiagTrack service on Windows image
```
