### PR TITLE
[WIP]fix: topology.kubernetes.io/zone should be empty for non-zone

### DIFF
--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -304,7 +304,7 @@ func (d *Driver) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabi
 func (d *Driver) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
 	var instanceType string
 	topology := &csi.Topology{
-		Segments: map[string]string{topologyKey: ""},
+		Segments: map[string]string{topologyKey: "", consts.WellKnownTopologyKey: ""},
 	}
 
 	if runtime.GOOS == "windows" && d.cloud.UseInstanceMetadata && d.cloud.Metadata != nil {

--- a/pkg/azuredisk/nodeserver_v2.go
+++ b/pkg/azuredisk/nodeserver_v2.go
@@ -309,7 +309,7 @@ func (d *DriverV2) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest)
 	}
 
 	topology := &csi.Topology{
-		Segments: map[string]string{topologyKey: ""},
+		Segments: map[string]string{topologyKey: "", consts.WellKnownTopologyKey: ""},
 	}
 	zone, err := d.cloud.GetZone(ctx)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: topology.kubernetes.io/zone should be empty for non-zone
current value:
```
topology.disk.csi.azure.com/zone=,topology.kubernetes.io/region=eastus2,topology.kubernetes.io/zone=0
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
/hold

```
I1222 02:21:47.301065       1 main.go:164] Version: v2.3.0-0-gde03348b
I1222 02:21:47.301103       1 main.go:165] Running node-driver-registrar in mode=registration
I1222 02:21:47.301583       1 main.go:189] Attempting to open a gRPC connection with: "/csi/csi.sock"
I1222 02:21:47.303225       1 main.go:196] Calling CSI driver to discover driver name
I1222 02:21:47.384757       1 main.go:206] CSI driver name: "disk2.csi.azure.com"
I1222 02:21:47.384955       1 node_register.go:52] Starting Registration Server at: /registration/disk2.csi.azure.com-reg.sock
I1222 02:21:47.385336       1 node_register.go:61] Registration Server started at: /registration/disk2.csi.azure.com-reg.sock
I1222 02:21:47.385489       1 node_register.go:91] Skipping healthz server because HTTP endpoint is set to: ""
I1222 02:21:49.204046       1 main.go:100] Received GetInfo call: &InfoRequest{}
I1222 02:21:49.204482       1 main.go:107] "Kubelet registration probe created" path="/var/lib/kubelet/plugins/disk2.csi.azure.com/registration"
I1222 02:21:49.602517       1 main.go:118] Received NotifyRegistrationStatus call: &RegistrationStatus{PluginRegistered:false,Error:RegisterPlugin error -- plugin registration failed with err: error updating Node object with CSI driver node info: error updating node: timed out waiting for the condition; caused by: detected topology value collision: driver reported "topology.kubernetes.io/zone":"" but existing label is "topology.kubernetes.io/zone":"0",}
E1222 02:21:49.602575       1 main.go:120] Registration process failed with error: RegisterPlugin error -- plugin registration failed with err: error updating Node object with CSI driver node info: error updating node: timed out waiting for the condition; caused by: detected topology value collision: driver reported "topology.kubernetes.io/zone":"" but existing label is "topology.kubernetes.io/zone":"0", restarting registration container.
```

**Release note**:
```
fix: topology.kubernetes.io/zone should be empty for non-zone
```
