### PR TITLE
fix: disable disk capacity check in CreateVolume

### DIFF
--- a/pkg/azuredisk/azuredisk.go
+++ b/pkg/azuredisk/azuredisk.go
@@ -65,6 +65,7 @@ type DriverOptions struct {
 	EnableListSnapshots        bool
 	SupportZone                bool
 	GetNodeInfoFromLabels      bool
+	EnableDiskCapacityCheck    bool
 }
 
 // CSIDriver defines the interface for a CSI driver.
@@ -103,6 +104,7 @@ type DriverCore struct {
 	enableListSnapshots        bool
 	supportZone                bool
 	getNodeInfoFromLabels      bool
+	enableDiskCapacityCheck    bool
 }
 
 // Driver is the v1 implementation of the Azure Disk CSI Driver.
@@ -134,6 +136,7 @@ func newDriverV1(options *DriverOptions) *Driver {
 	driver.enableListSnapshots = options.EnableListVolumes
 	driver.supportZone = options.SupportZone
 	driver.getNodeInfoFromLabels = options.GetNodeInfoFromLabels
+	driver.enableDiskCapacityCheck = options.EnableDiskCapacityCheck
 	driver.volumeLocks = volumehelper.NewVolumeLocks()
 	driver.ioHandler = azureutils.NewOSIOHandler()
 	driver.hostUtil = hostutil.NewHostUtil()

--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -161,8 +161,10 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		}
 	}
 
-	if ok, err := d.checkDiskCapacity(ctx, diskParams.SubscriptionID, diskParams.ResourceGroup, diskParams.DiskName, requestGiB); !ok {
-		return nil, err
+	if d.enableDiskCapacityCheck {
+		if ok, err := d.checkDiskCapacity(ctx, diskParams.SubscriptionID, diskParams.ResourceGroup, diskParams.DiskName, requestGiB); !ok {
+			return nil, err
+		}
 	}
 
 	mc := metrics.NewMetricContext(consts.AzureDiskCSIDriverName, "controller_create_volume", d.cloud.ResourceGroup, d.cloud.SubscriptionID, d.Name)

--- a/pkg/azuredisk/controllerserver_v2.go
+++ b/pkg/azuredisk/controllerserver_v2.go
@@ -122,8 +122,10 @@ func (d *DriverV2) CreateVolume(ctx context.Context, req *csi.CreateVolumeReques
 
 	selectedAvailabilityZone := azureutils.PickAvailabilityZone(req.GetAccessibilityRequirements(), d.cloud.Location, topologyKey)
 
-	if ok, err := d.checkDiskCapacity(ctx, diskParams.SubscriptionID, diskParams.ResourceGroup, diskParams.DiskName, requestGiB); !ok {
-		return nil, err
+	if d.enableDiskCapacityCheck {
+		if ok, err := d.checkDiskCapacity(ctx, diskParams.SubscriptionID, diskParams.ResourceGroup, diskParams.DiskName, requestGiB); !ok {
+			return nil, err
+		}
 	}
 
 	mc := metrics.NewMetricContext(consts.AzureDiskCSIDriverName, "controller_create_volume", d.cloud.ResourceGroup, d.cloud.SubscriptionID, d.Name)

--- a/pkg/azurediskplugin/main.go
+++ b/pkg/azurediskplugin/main.go
@@ -58,6 +58,7 @@ var (
 	enableAsyncAttach          = flag.Bool("enable-async-attach", false, "boolean flag to enable async attach")
 	enableListVolumes          = flag.Bool("enable-list-volumes", false, "boolean flag to enable ListVolumes on controller")
 	enableListSnapshots        = flag.Bool("enable-list-snapshots", false, "boolean flag to enable ListSnapshots on controller")
+	enableDiskCapacityCheck    = flag.Bool("enable-disk-capacity-check", false, "boolean flag to enable volume capacity check in CreateVolume")
 )
 
 func main() {
@@ -99,6 +100,7 @@ func handle() {
 		EnableListSnapshots:        *enableListSnapshots,
 		SupportZone:                *supportZone,
 		GetNodeInfoFromLabels:      *getNodeInfoFromLabels,
+		EnableDiskCapacityCheck:    *enableDiskCapacityCheck,
 	}
 	driver := azuredisk.NewDriver(&driverOptions)
 	if driver == nil {

--- a/test/sanity/run-test.sh
+++ b/test/sanity/run-test.sh
@@ -37,9 +37,9 @@ if [[ "${ARCH}" == "x86_64" || ${ARCH} == "unknown" ]]; then
 fi
 
 if [[ "$#" -lt 2 || "$2" != "v2" ]]; then
-  _output/${ARCH}/azurediskplugin --endpoint "$endpoint" --nodeid "$nodeid" -v=5 -support-zone=false &
+  _output/${ARCH}/azurediskplugin --endpoint "$endpoint" --nodeid "$nodeid" -v=5 -support-zone=false -enable-disk-capacity-check=true &
 else
-  _output/${ARCH}/azurediskpluginv2 --endpoint "$endpoint" --nodeid "$nodeid" -v=5 -support-zone=false &
+  _output/${ARCH}/azurediskpluginv2 --endpoint "$endpoint" --nodeid "$nodeid" -v=5 -support-zone=false -enable-disk-capacity-check=true &
 fi
 
 echo 'Begin to run sanity test...'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
fix: disable disk capacity check in CreateVolume
This could reduce on disk get operation in CreateVolume

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
<details>

```
I0310 12:04:21.351288       1 utils.go:77] GRPC call: /csi.v1.Controller/CreateVolume
I0310 12:04:21.351315       1 utils.go:78] GRPC request: {"accessibility_requirements":{"preferred":[{"segments":{"topology.disk.csi.azure.com/zone":"westus2-1","topology.kubernetes.io/zone":"westus2-1"}},{"segments":{"topology.disk.csi.azure.com/zone":"","topology.kubernetes.io/zone":"0"}}],"requisite":[{"segments":{"topology.disk.csi.azure.com/zone":"westus2-1","topology.kubernetes.io/zone":"westus2-1"}},{"segments":{"topology.disk.csi.azure.com/zone":"","topology.kubernetes.io/zone":"0"}}]},"capacity_range":{"required_bytes":5368709120},"name":"pvc-4553381c-beb5-4842-baa2-87fa802db021","parameters":{"csi.storage.k8s.io/pv/name":"pvc-4553381c-beb5-4842-baa2-87fa802db021","csi.storage.k8s.io/pvc/name":"pvc-azuredisk","csi.storage.k8s.io/pvc/namespace":"default","skuname":"StandardSSD_LRS"},"volume_capabilities":[{"AccessType":{"Mount":{}},"access_mode":{"mode":7}}]}
I0310 12:04:21.591056       1 azure_diskclient.go:138] Received error in disk.get.request: resourceID: /subscriptions/xxx/resourceGroups/capz-4d21w4/providers/Microsoft.Compute/disks/pvc-4553381c-beb5-4842-baa2-87fa802db021, error: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 404, RawError: {"error":{"code":"ResourceNotFound","message":"The Resource 'Microsoft.Compute/disks/pvc-4553381c-beb5-4842-baa2-87fa802db021' under resource group 'capz-4d21w4' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix"}}
I0310 12:04:21.591431       1 controllerserver.go:174] begin to create azure disk(pvc-4553381c-beb5-4842-baa2-87fa802db021) account type(StandardSSD_LRS) rg(capz-4d21w4) location(westus2) size(5) diskZone(westus2-1) maxShares(0)
I0310 12:04:21.591479       1 azure_managedDiskController.go:90] azureDisk - creating new managed Name:pvc-4553381c-beb5-4842-baa2-87fa802db021 StorageAccountType:StandardSSD_LRS Size:5
I0310 12:04:24.058431       1 azure_managedDiskController.go:255] azureDisk - created new MD Name:pvc-4553381c-beb5-4842-baa2-87fa802db021 StorageAccountType:StandardSSD_LRS Size:5
I0310 12:04:24.058487       1 controllerserver.go:250] create azure disk(pvc-4553381c-beb5-4842-baa2-87fa802db021) account type(StandardSSD_LRS) rg(capz-4d21w4) location(westus2) size(5) tags(map[kubernetes.io-created-for-pv-name:pvc-4553381c-beb5-4842-baa2-87fa802db021 kubernetes.io-created-for-pvc-name:pvc-azuredisk kubernetes.io-created-for-pvc-namespace:default]) successfully
I0310 12:04:24.058536       1 utils.go:84] GRPC response: {"volume":{"accessible_topology":[{"segments":{"topology.disk.csi.azure.com/zone":"westus2-1"}}],"capacity_bytes":5368709120,"content_source":{"Type":null},"volume_context":{"csi.storage.k8s.io/pv/name":"pvc-4553381c-beb5-4842-baa2-87fa802db021","csi.storage.k8s.io/pvc/name":"pvc-azuredisk","csi.storage.k8s.io/pvc/namespace":"default","requestedsizegib":"5","skuname":"StandardSSD_LRS"},"volume_id":"/subscriptions/xxx/resourceGroups/capz-4d21w4/providers/Microsoft.Compute/disks/pvc-4553381c-beb5-4842-baa2-87fa802db021"}}
```

</details>

**Release note**:
```
fix: disable disk capacity check in CreateVolume
```
