### PR TITLE
fix: CVE issues in image build

### DIFF
--- a/pkg/azurediskplugin/Dockerfile
+++ b/pkg/azurediskplugin/Dockerfile
@@ -17,12 +17,13 @@ FROM k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
 RUN apt update && apt-mark unhold libcap2
 RUN clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs btrfs-progs
 # install updated packages to fix CVE issues
-RUN clean-install libgmp10 bsdutils libssl1.1 openssl
+RUN clean-install libgmp10 bsdutils libssl1.1 openssl libc6 libc-bin libsystemd0
 
 LABEL maintainers="andyzhangx"
 LABEL description="Azure Disk CSI Driver"
 
 ARG ARCH=amd64
 ARG PLUGIN_NAME=azurediskplugin
-COPY ./_output/${ARCH}/${PLUGIN_NAME} /azurediskplugin
+ARG binary=./_output/${ARCH}/${PLUGIN_NAME}
+COPY ${binary} /azurediskplugin
 ENTRYPOINT ["/azurediskplugin"]

--- a/pkg/azurediskplugin/Windows.Dockerfile
+++ b/pkg/azurediskplugin/Windows.Dockerfile
@@ -10,5 +10,6 @@ LABEL description="CSI Azure disk plugin"
 
 ARG ARCH
 ARG PLUGIN_NAME=azurediskplugin
-COPY ./_output/${ARCH}/${PLUGIN_NAME}.exe /azurediskplugin.exe
+ARG binary=./_output/${ARCH}/${PLUGIN_NAME}.exe
+COPY ${binary} /azurediskplugin.exe
 ENTRYPOINT ["/azurediskplugin.exe"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: CVE issues in image build

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
```console
+-------------+------------------+----------+-------------------+-----------------+---------------------------------------+
|   LIBRARY   | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |  FIXED VERSION  |                 TITLE                 |
+-------------+------------------+----------+-------------------+-----------------+---------------------------------------+
| libc-bin    | CVE-2021-33574   | CRITICAL | 2.[31](https://github.com/kubernetes-sigs/azuredisk-csi-driver/runs/5707112390?check_suite_focus=true#step:6:31)-13+deb11u2   | 2.31-13+deb11u3 | glibc: mq_notify does                 |
|             |                  |          |                   |                 | not handle separately                 |
|             |                  |          |                   |                 | allocated thread attributes           |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2021-33574 |
+             +------------------+          +                   +                 +---------------------------------------+
|             | CVE-2022-2[32](https://github.com/kubernetes-sigs/azuredisk-csi-driver/runs/5707112390?check_suite_focus=true#step:6:32)18   |          |                   |                 | glibc: Stack-based buffer overflow    |
|             |                  |          |                   |                 | in svcunix_create via long pathnames  |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2022-23218 |
+             +------------------+          +                   +                 +---------------------------------------+
|             | CVE-2022-23219   |          |                   |                 | glibc: Stack-based buffer             |
|             |                  |          |                   |                 | overflow in sunrpc clnt_create        |
|             |                  |          |                   |                 | via a long pathname                   |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2022-23219 |
+             +------------------+----------+                   +                 +---------------------------------------+
|             | CVE-2021-4[33](https://github.com/kubernetes-sigs/azuredisk-csi-driver/runs/5707112390?check_suite_focus=true#step:6:33)96   | LOW      |                   |                 | glibc: conversion from                |
|             |                  |          |                   |                 | ISO-2022-JP-3 with iconv may          |
|             |                  |          |                   |                 | emit spurious NUL character on...     |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2021-43396 |
+-------------+------------------+----------+                   +                 +---------------------------------------+
| libc6       | CVE-2021-3[35](https://github.com/kubernetes-sigs/azuredisk-csi-driver/runs/5707112390?check_suite_focus=true#step:6:35)74   | CRITICAL |                   |                 | glibc: mq_notify does                 |
|             |                  |          |                   |                 | not handle separately                 |
|             |                  |          |                   |                 | allocated thread attributes           |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2021-33574 |
+             +------------------+          +                   +                 +---------------------------------------+
|             | CVE-2022-23218   |          |                   |                 | glibc: Stack-based buffer overflow    |
|             |                  |          |                   |                 | in svcunix_create via long pathnames  |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2022-23218 |
+             +------------------+          +                   +                 +---------------------------------------+
|             | CVE-2022-23219   |          |                   |                 | glibc: Stack-based buffer             |
|             |                  |          |                   |                 | overflow in sunrpc clnt_create        |
|             |                  |          |                   |                 | via a long pathname                   |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2022-23219 |
+             +------------------+----------+                   +                 +---------------------------------------+
|             | CVE-2021-43[39](https://github.com/kubernetes-sigs/azuredisk-csi-driver/runs/5707112390?check_suite_focus=true#step:6:39)6   | LOW      |                   |                 | glibc: conversion from                |
|             |                  |          |                   |                 | ISO-2022-JP-3 with iconv may          |
|             |                  |          |                   |                 | emit spurious NUL character on...     |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2021-[43](https://github.com/kubernetes-sigs/azuredisk-csi-driver/runs/5707112390?check_suite_focus=true#step:6:43)396 |
+-------------+------------------+----------+-------------------+-----------------+---------------------------------------+
| libsystemd0 | CVE-2021-3997    | MEDIUM   | 2[47](https://github.com/kubernetes-sigs/azuredisk-csi-driver/runs/5707112390?check_suite_focus=true#step:6:47).3-6           | 247.3-7         | systemd: Uncontrolled recursion in    |
|             |                  |          |                   |                 | systemd-tmpfiles when removing files  |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2021-3997  |
+-------------+------------------+----------+-------------------+-----------------+---------------------------------------+
```

**Release note**:
```
fix: CVE issues in image build
```

