### PR TITLE
[V2] fix: Fix script to check for driver pod restarts🐞

### DIFF
--- a/test/utils/check_driver_pods_restart.sh
+++ b/test/utils/check_driver_pods_restart.sh
@@ -30,15 +30,16 @@ mapfile -t PODS_WITH_RESTARTS < <(kubectl get pods --namespace kube-system \
     --output=jsonpath='{range .items[*]}{.metadata.name} {range .status.containerStatuses[?(@.restartCount!=0)]}{.name};{end}{"\n"}{end}' \
     | awk '{if ($2 != "") print $1}')
 
-processed_pods=("$(get_array "${original_pods[@]}")")
-processed_restarts=("$(get_array "${original_restarts[@]}")")
+for POD_WITH_RESTART in "${PODS_WITH_RESTARTS[@]}"; do
+    echo "there is a driver pod which has restarted"
 
-if [[ "$1" == "log" ]]; then
-    kubectl describe pod "$POD_WITH_RESTART" --namespace kube-system
-    echo "======================================================================================"
-    echo "print previous azuredisk container logs since there is a restart"
-    kubectl logs "$POD_WITH_RESTART" --container azuredisk --previous --namespace kube-system
-    echo "======================================================================================"
-fi
+    if [[ "$1" == "log" ]]; then
+        kubectl describe pod "$POD_WITH_RESTART" --namespace kube-system
+        echo "======================================================================================"
+        echo "print previous azuredisk container logs since there is a restart"
+        kubectl logs "$POD_WITH_RESTART" --container azuredisk --previous --namespace kube-system
+        echo "======================================================================================"
+    fi
+done
 
 echo "======================================================================================"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
There is an issue in the test/utils/check_driver_pods_restart.sh where POD_WITH_RESTART is not defined. It is meant to be set in a for-loop from the PODS_WITH_RESTARTS array. This issue manifests when running e2e tests, but it does not cause a test failure. I cherrypicked Ed's fix from master and brought it to main_v2. 

/kind bug

**What this PR does / why we need it**:
This fixes an issues with a script that runs during e2e tests.


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1284 

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
- I cherrypicked Ed's change because I thought that this would be the best way to maintain git hygiene. Please let me know if there is a better method.

- I also expected that the bot would prompt me to sign the CLA, as I do not believe I have signed it (this is my first commit). It is not requiring that I sign as I think Ed is technically the author of this change. If there is a way to sign the CLA without making a pull request please let me know.

**Release note**:
```
none
```
