### PR TITLE
[V2] chore: DeleteVolume should wait for replicas to be fully deleted

### DIFF
--- a/pkg/azureconstants/azure_constants.go
+++ b/pkg/azureconstants/azure_constants.go
@@ -131,6 +131,7 @@ const (
 	CRIUpdateRetryDuration  = time.Duration(1) * time.Second
 	CRIUpdateRetryFactor    = 3.0
 	CRIUpdateRetryStep      = 5
+	DefaultInformerResync   = time.Duration(30) * time.Second
 	ZonedField              = "zoned"
 	NormalUpdateMaxNetRetry = 0
 	ForcedUpdateMaxNetRetry = 10

--- a/pkg/controller/common.go
+++ b/pkg/controller/common.go
@@ -43,8 +43,11 @@ import (
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
 	diskv1beta1 "sigs.k8s.io/azuredisk-csi-driver/pkg/apis/azuredisk/v1beta1"
 	azClientSet "sigs.k8s.io/azuredisk-csi-driver/pkg/apis/client/clientset/versioned"
+	azurediskInformers "sigs.k8s.io/azuredisk-csi-driver/pkg/apis/client/informers/externalversions"
 	consts "sigs.k8s.io/azuredisk-csi-driver/pkg/azureconstants"
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/azureutils"
+	"sigs.k8s.io/azuredisk-csi-driver/pkg/util"
+	"sigs.k8s.io/azuredisk-csi-driver/pkg/watcher"
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/workflow"
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -269,10 +272,11 @@ type SharedState struct {
 	cachedClient                  client.Client
 	azClient                      azClientSet.Interface
 	kubeClient                    kubernetes.Interface
+	conditionWatcher              *watcher.ConditionWatcher
 }
 
 func NewSharedState(driverName, objectNamespace, topologyKey string, eventRecorder record.EventRecorder, cachedClient client.Client, azClient azClientSet.Interface, kubeClient kubernetes.Interface) *SharedState {
-	newSharedState := &SharedState{driverName: driverName, objectNamespace: objectNamespace, topologyKey: topologyKey, eventRecorder: eventRecorder, cachedClient: cachedClient, azClient: azClient, kubeClient: kubeClient}
+	newSharedState := &SharedState{driverName: driverName, objectNamespace: objectNamespace, topologyKey: topologyKey, eventRecorder: eventRecorder, cachedClient: cachedClient, azClient: azClient, kubeClient: kubeClient, conditionWatcher: watcher.New(context.Background(), azClient, azurediskInformers.NewSharedInformerFactory(azClient, consts.DefaultInformerResync), objectNamespace)}
 	newSharedState.createReplicaRequestsQueue()
 	return newSharedState
 }
@@ -2177,4 +2181,17 @@ func (c *SharedState) getNodesForReplica(ctx context.Context, volumeName string,
 	}
 
 	return filtered, nil
+}
+
+func verifyObjectDeleted(obj interface{}, objectDeleted bool) (bool, error) {
+	if obj == nil || objectDeleted {
+		return true, nil
+	}
+
+	// otherwise, the volume detachment has either failed with error or pending
+	azVolumeAttachmentInstance := obj.(*diskv1beta1.AzVolumeAttachment)
+	if azVolumeAttachmentInstance.Status.Error != nil {
+		return false, util.ErrorFromAzError(azVolumeAttachmentInstance.Status.Error)
+	}
+	return false, nil
 }

--- a/pkg/controller/replica_test.go
+++ b/pkg/controller/replica_test.go
@@ -70,6 +70,7 @@ func TestReplicaReconcile(t *testing.T) {
 				replicaAttachment := testReplicaAzVolumeAttachment
 				now := metav1.Time{Time: metav1.Now().Add(-1000)}
 				replicaAttachment.DeletionTimestamp = &now
+				replicaAttachment.Status.State = diskv1beta1.Detaching
 
 				newVolume := testAzVolume0.DeepCopy()
 				newVolume.Status.Detail = &diskv1beta1.AzVolumeStatusDetail{

--- a/pkg/provisioner/crdprovisioner_test.go
+++ b/pkg/provisioner/crdprovisioner_test.go
@@ -37,6 +37,7 @@ import (
 	azurediskInformers "sigs.k8s.io/azuredisk-csi-driver/pkg/apis/client/informers/externalversions"
 	consts "sigs.k8s.io/azuredisk-csi-driver/pkg/azureconstants"
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/azureutils"
+	"sigs.k8s.io/azuredisk-csi-driver/pkg/watcher"
 )
 
 const (
@@ -147,14 +148,14 @@ func NewTestCrdProvisioner(controller *gomock.Controller) *CrdProvisioner {
 	return &CrdProvisioner{
 		azDiskClient:     fakeDiskClient,
 		namespace:        testNameSpace,
-		conditionWatcher: newConditionWatcher(context.Background(), fakeDiskClient, informerFactory, testNameSpace),
+		conditionWatcher: watcher.New(context.Background(), fakeDiskClient, informerFactory, testNameSpace),
 	}
 }
 
 func UpdateTestCrdProvisionerWithNewClient(provisioner *CrdProvisioner, azDiskClient azDiskClientSet.Interface) {
 	informerFactory := azurediskInformers.NewSharedInformerFactory(azDiskClient, testResync)
 	provisioner.azDiskClient = azDiskClient
-	provisioner.conditionWatcher = newConditionWatcher(context.Background(), azDiskClient, informerFactory, testNameSpace)
+	provisioner.conditionWatcher = watcher.New(context.Background(), azDiskClient, informerFactory, testNameSpace)
 }
 
 func TestCrdProvisionerCreateVolume(t *testing.T) {

--- a/pkg/watcher/conditionwaiter.go
+++ b/pkg/watcher/conditionwaiter.go
@@ -14,47 +14,48 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package provisioner
+package watcher
 
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/workflow"
 )
 
-type conditionWaiter struct {
-	objType objectType
+type ConditionWaiter struct {
+	objType ObjectType
 	objName string
 	entry   *waitEntry
-	watcher *conditionWatcher
+	watcher *ConditionWatcher
 }
 
-func (w *conditionWaiter) Wait(ctx context.Context) (runtime.Object, error) {
+func (w *ConditionWaiter) Wait(ctx context.Context) (runtime.Object, error) {
 	var obj runtime.Object
 	var err error
 	namespace := w.watcher.namespace
 
 	switch w.objType {
-	case azVolumeType:
+	case AzVolumeType:
 		obj, err = w.watcher.informerFactory.Disk().V1beta1().AzVolumes().Lister().AzVolumes(namespace).Get(w.objName)
-	case azVolumeAttachmentType:
+	case AzVolumeAttachmentType:
 		obj, err = w.watcher.informerFactory.Disk().V1beta1().AzVolumeAttachments().Lister().AzVolumeAttachments(namespace).Get(w.objName)
-	case azDriverNodeType:
+	case AzDriverNodeType:
 		obj, err = w.watcher.informerFactory.Disk().V1beta1().AzDriverNodes().Lister().AzDriverNodes(namespace).Get(w.objName)
-	}
-
-	// if there exists an object in cache, evaluate condition function on it
-	// if condition function returns error, the error could be coming from stale cache, so wait for another condition assessment from event handler.
-	if err == nil {
-		success, _ := w.entry.conditionFunc(obj, false)
-		if success {
-			return obj, nil
-		}
 	}
 
 	_, wf := workflow.New(ctx, workflow.WithDetails(workflow.GetObjectDetails(obj)...))
 	defer func() { wf.Finish(err) }()
+
+	// if there exists an object in cache, evaluate condition function on it
+	// if condition function returns error, the error could be coming from stale cache, so wait for another condition assessment from event handler.
+	if notFound := errors.IsNotFound(err); err == nil || notFound {
+		success, _ := w.entry.conditionFunc(obj, notFound)
+		if success {
+			return obj, nil
+		}
+	}
 
 	// if not wait for the event handler signal
 	select {
@@ -67,6 +68,6 @@ func (w *conditionWaiter) Wait(ctx context.Context) (runtime.Object, error) {
 	}
 }
 
-func (w *conditionWaiter) Close() {
+func (w *ConditionWaiter) Close() {
 	w.watcher.waitMap.Delete(getTypedName(w.objType, w.objName))
 }


### PR DESCRIPTION
instead of requeuing

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind chore
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
* `AzVolume` controller originally relied on reconciler requeue to wait for replica `AzVolumeAttachment` to be fully deleted but this can lead to huge backoffs causing a significant delay in volume deletion.
* This PR leverages condition watcher / waiter component to have `AzVolume` controller wait for the replica AzVolumeAttachments to be deleted to avoid over issuance of requeue
* And replaces existing polling in replica controller with event triggered waiter package.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
