### PR TITLE
[V2] chore: e2e test util fixes

### DIFF
--- a/test/e2e/azdiskschedulerextender_test.go
+++ b/test/e2e/azdiskschedulerextender_test.go
@@ -101,7 +101,7 @@ func schedulerExtenderTests(isMultiZone bool) {
 		test := testsuites.AzDiskSchedulerExtenderPodSchedulingWithPVTest{
 			CSIDriver:              testDriver,
 			Pod:                    pod,
-			StorageClassParameters: map[string]string{"skuName": "StandardSSD_LRS"},
+			StorageClassParameters: map[string]string{consts.SkuNameField: "StandardSSD_LRS"},
 		}
 		test.Run(cs, ns, schedulerName)
 	})
@@ -137,7 +137,7 @@ func schedulerExtenderTests(isMultiZone bool) {
 		test := testsuites.AzDiskSchedulerExtenderPodSchedulingOnFailover{
 			CSIDriver:              testDriver,
 			Pod:                    pod,
-			StorageClassParameters: map[string]string{"skuName": "StandardSSD_LRS"},
+			StorageClassParameters: map[string]string{consts.SkuNameField: "StandardSSD_LRS"},
 		}
 		test.Run(cs, ns, schedulerName)
 	})
@@ -205,7 +205,7 @@ func schedulerExtenderTests(isMultiZone bool) {
 			CSIDriver:              testDriver,
 			Pod:                    pod,
 			Replicas:               1,
-			StorageClassParameters: map[string]string{"skuName": skuName},
+			StorageClassParameters: map[string]string{consts.SkuNameField: skuName},
 			AzDiskClient:           azDiskClient,
 		}
 		test.Run(cs, ns, schedulerName)
@@ -245,7 +245,7 @@ func schedulerExtenderTests(isMultiZone bool) {
 			CSIDriver:              testDriver,
 			Pod:                    pod,
 			Replicas:               1,
-			StorageClassParameters: map[string]string{"skuName": skuName, "maxShares": "2", "cachingmode": "None"},
+			StorageClassParameters: map[string]string{consts.SkuNameField: skuName, "maxShares": "2", "cachingmode": "None"},
 			AzDiskClient:           azDiskClient,
 		}
 		test.Run(cs, ns, schedulerName)

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -128,7 +128,7 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 			CSIDriver: testDriver,
 			Pods:      pods,
 			StorageClassParameters: map[string]string{
-				"skuName": "Standard_LRS",
+				consts.SkuNameField: "Standard_LRS",
 			},
 		}
 
@@ -137,10 +137,10 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 			test.StorageClassParameters = map[string]string{"Kind": "managed"}
 		} else if isMultiZone {
 			if testutil.IsZRSSupported(location) {
-				test.StorageClassParameters["skuName"] = "StandardSSD_ZRS"
+				test.StorageClassParameters[consts.SkuNameField] = "StandardSSD_ZRS"
 				test.StorageClassParameters["networkAccessPolicy"] = "AllowAll"
 			} else {
-				test.StorageClassParameters["skuName"] = "UltraSSD_LRS"
+				test.StorageClassParameters[consts.SkuNameField] = "UltraSSD_LRS"
 				test.StorageClassParameters["diskIopsReadWrite"] = "2000"
 				test.StorageClassParameters["diskMbpsReadWrite"] = "320"
 				test.StorageClassParameters["logicalSectorSize"] = "512"
@@ -176,6 +176,7 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 		}
 
 		scParameters := map[string]string{
+			/*hard code skuName key to verify e2e test utils handle storage class params case insensitive*/
 			"skuName":             "Standard_LRS",
 			"networkAccessPolicy": "DenyAll",
 			"userAgent":           "azuredisk-e2e-test",
@@ -213,8 +214,8 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 			CSIDriver: testDriver,
 			Pods:      pods,
 			StorageClassParameters: map[string]string{
-				"skuName":     "Premium_LRS",
-				"perfProfile": "Basic",
+				consts.SkuNameField: "Premium_LRS",
+				"perfProfile":       "Basic",
 				// enableBursting can only be applied to Premium disk, disk size > 512GB, Ultra & shared disk is not supported.
 				"enableBursting":    "true",
 				"userAgent":         "azuredisk-e2e-test",
@@ -248,7 +249,7 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 			CSIDriver: testDriver,
 			Pods:      pods,
 			StorageClassParameters: map[string]string{
-				"skuName":                            "Premium_LRS",
+				consts.SkuNameField:                  "Premium_LRS",
 				"perfProfile":                        "Advanced",
 				"device-setting/queue/read_ahead_kb": "8",
 				"device-setting/queue/nomerges":      "0",
@@ -287,13 +288,13 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 		test := testsuites.DynamicallyProvisionedInvalidMountOptions{
 			CSIDriver:              testDriver,
 			Pods:                   pods,
-			StorageClassParameters: map[string]string{"skuName": "StandardSSD_LRS"},
+			StorageClassParameters: map[string]string{consts.SkuNameField: "StandardSSD_LRS"},
 		}
 		if !testconsts.IsUsingInTreeVolumePlugin && (location == "westus2" || location == "westeurope") {
-			test.StorageClassParameters = map[string]string{"skuName": "StandardSSD_ZRS"}
+			test.StorageClassParameters = map[string]string{consts.SkuNameField: "StandardSSD_ZRS"}
 		}
 		if testconsts.IsAzureStackCloud {
-			test.StorageClassParameters = map[string]string{"skuName": "Standard_LRS"}
+			test.StorageClassParameters = map[string]string{consts.SkuNameField: "Standard_LRS"}
 		}
 		test.Run(cs, ns, schedulerName)
 	})
@@ -320,10 +321,10 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
 			CSIDriver:              testDriver,
 			Pods:                   pods,
-			StorageClassParameters: map[string]string{"skuName": "Premium_LRS"},
+			StorageClassParameters: map[string]string{consts.SkuNameField: "Premium_LRS"},
 		}
 		if !testconsts.IsUsingInTreeVolumePlugin && testutil.IsZRSSupported(location) {
-			test.StorageClassParameters = map[string]string{"skuName": "StandardSSD_ZRS"}
+			test.StorageClassParameters = map[string]string{consts.SkuNameField: "StandardSSD_ZRS"}
 		}
 
 		test.Run(cs, ns, schedulerName)
@@ -352,10 +353,10 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 		test := testsuites.DynamicallyProvisionedReadOnlyVolumeTest{
 			CSIDriver:              testDriver,
 			Pods:                   pods,
-			StorageClassParameters: map[string]string{"skuName": "StandardSSD_LRS"},
+			StorageClassParameters: map[string]string{consts.SkuNameField: "StandardSSD_LRS"},
 		}
 		if !testconsts.IsUsingInTreeVolumePlugin && testutil.IsZRSSupported(location) {
-			test.StorageClassParameters = map[string]string{"skuName": "Premium_ZRS"}
+			test.StorageClassParameters = map[string]string{consts.SkuNameField: "Premium_ZRS"}
 			for _, pod := range pods {
 				for _, volume := range pod.Volumes {
 					volume.AllowedTopologyValues = make([]string, 0)
@@ -366,7 +367,7 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 			}
 		}
 		if testconsts.IsAzureStackCloud {
-			test.StorageClassParameters = map[string]string{"skuName": "Standard_LRS"}
+			test.StorageClassParameters = map[string]string{consts.SkuNameField: "Standard_LRS"}
 		}
 		test.Run(cs, ns, schedulerName)
 	})
@@ -423,10 +424,10 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 			CSIDriver:              testDriver,
 			Pods:                   pods,
 			ColocatePods:           true,
-			StorageClassParameters: map[string]string{"skuName": "Premium_LRS"},
+			StorageClassParameters: map[string]string{consts.SkuNameField: "Premium_LRS"},
 		}
 		if !testconsts.IsUsingInTreeVolumePlugin && testutil.IsZRSSupported(location) {
-			test.StorageClassParameters = map[string]string{"skuName": "StandardSSD_ZRS"}
+			test.StorageClassParameters = map[string]string{consts.SkuNameField: "StandardSSD_ZRS"}
 		}
 
 		test.Run(cs, ns, schedulerName)
@@ -533,8 +534,8 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 			Pod:                 pod,
 			PodWithClonedVolume: podWithClonedVolume,
 			StorageClassParameters: map[string]string{
-				"skuName": "Standard_LRS",
-				"fsType":  "xfs",
+				consts.SkuNameField: "Standard_LRS",
+				"fsType":            "xfs",
 			},
 		}
 
@@ -570,13 +571,13 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 			PodWithClonedVolume: podWithClonedVolume,
 			ClonedVolumeSize:    clonedVolumeSize,
 			StorageClassParameters: map[string]string{
-				"skuName": "Standard_LRS",
-				"fsType":  "xfs",
+				consts.SkuNameField: "Standard_LRS",
+				"fsType":            "xfs",
 			},
 		}
 		if !testconsts.IsUsingInTreeVolumePlugin && testutil.IsZRSSupported(location) {
 			test.StorageClassParameters = map[string]string{
-				"skuName":             "StandardSSD_ZRS",
+				consts.SkuNameField:   "StandardSSD_ZRS",
 				"fsType":              "xfs",
 				"networkAccessPolicy": "DenyAll",
 			}
@@ -623,13 +624,13 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
 			CSIDriver:              testDriver,
 			Pods:                   pods,
-			StorageClassParameters: map[string]string{"skuName": "StandardSSD_LRS"},
+			StorageClassParameters: map[string]string{consts.SkuNameField: "StandardSSD_LRS"},
 		}
 		if testconsts.IsAzureStackCloud {
-			test.StorageClassParameters = map[string]string{"skuName": "Standard_LRS"}
+			test.StorageClassParameters = map[string]string{consts.SkuNameField: "Standard_LRS"}
 		}
 		if !testconsts.IsUsingInTreeVolumePlugin && testutil.IsZRSSupported(location) {
-			test.StorageClassParameters = map[string]string{"skuName": "StandardSSD_ZRS"}
+			test.StorageClassParameters = map[string]string{consts.SkuNameField: "StandardSSD_ZRS"}
 		}
 		test.Run(cs, ns, schedulerName)
 	})
@@ -667,10 +668,10 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
 			CSIDriver:              testDriver,
 			Pods:                   pods,
-			StorageClassParameters: map[string]string{"skuName": "Premium_LRS"},
+			StorageClassParameters: map[string]string{consts.SkuNameField: "Premium_LRS"},
 		}
 		if !testconsts.IsUsingInTreeVolumePlugin && testutil.IsZRSSupported(location) {
-			test.StorageClassParameters = map[string]string{"skuName": "StandardSSD_ZRS"}
+			test.StorageClassParameters = map[string]string{consts.SkuNameField: "StandardSSD_ZRS"}
 		}
 		test.Run(cs, ns, schedulerName)
 	})
@@ -701,13 +702,13 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 			Pod:                    pod,
 			ShouldOverwrite:        false,
 			PodWithSnapshot:        podWithSnapshot,
-			StorageClassParameters: map[string]string{"skuName": "StandardSSD_LRS"},
+			StorageClassParameters: map[string]string{consts.SkuNameField: "StandardSSD_LRS"},
 		}
 		if testconsts.IsAzureStackCloud {
-			test.StorageClassParameters = map[string]string{"skuName": "Standard_LRS"}
+			test.StorageClassParameters = map[string]string{consts.SkuNameField: "Standard_LRS"}
 		}
 		if !testconsts.IsUsingInTreeVolumePlugin && testutil.IsZRSSupported(location) {
-			test.StorageClassParameters = map[string]string{"skuName": "StandardSSD_ZRS"}
+			test.StorageClassParameters = map[string]string{consts.SkuNameField: "StandardSSD_ZRS"}
 		}
 		test.Run(cs, snapshotrcs, ns, schedulerName)
 	})
@@ -745,13 +746,13 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 			ShouldOverwrite:        true,
 			PodOverwrite:           podOverwrite,
 			PodWithSnapshot:        podWithSnapshot,
-			StorageClassParameters: map[string]string{"skuName": "StandardSSD_LRS"},
+			StorageClassParameters: map[string]string{consts.SkuNameField: "StandardSSD_LRS"},
 		}
 		if testconsts.IsAzureStackCloud {
-			test.StorageClassParameters = map[string]string{"skuName": "Standard_LRS"}
+			test.StorageClassParameters = map[string]string{consts.SkuNameField: "Standard_LRS"}
 		}
 		if !testconsts.IsUsingInTreeVolumePlugin && testutil.IsZRSSupported(location) {
-			test.StorageClassParameters = map[string]string{"skuName": "StandardSSD_ZRS"}
+			test.StorageClassParameters = map[string]string{consts.SkuNameField: "StandardSSD_ZRS"}
 		}
 		test.Run(cs, snapshotrcs, ns, schedulerName)
 	})
@@ -816,10 +817,10 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 			Volume:                 volume,
 			Pod:                    pod,
 			ResizeOffline:          true,
-			StorageClassParameters: map[string]string{"skuName": "Standard_LRS"},
+			StorageClassParameters: map[string]string{consts.SkuNameField: "Standard_LRS"},
 		}
 		if !testconsts.IsUsingInTreeVolumePlugin && testutil.IsZRSSupported(location) {
-			test.StorageClassParameters = map[string]string{"skuName": "StandardSSD_ZRS", "fsType": "btrfs"}
+			test.StorageClassParameters = map[string]string{consts.SkuNameField: "StandardSSD_ZRS", "fsType": "btrfs"}
 		}
 		test.Run(cs, ns, schedulerName)
 	})
@@ -858,7 +859,7 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 			Volume:                 volume,
 			Pod:                    pod,
 			ResizeOffline:          false,
-			StorageClassParameters: map[string]string{"skuName": "Standard_LRS"},
+			StorageClassParameters: map[string]string{consts.SkuNameField: "Standard_LRS"},
 		}
 		test.Run(cs, ns, schedulerName)
 	})
@@ -898,7 +899,7 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 			Volume:                 volume,
 			Pod:                    pod,
 			ResizeOffline:          false,
-			StorageClassParameters: map[string]string{"skuName": "Standard_LRS"},
+			StorageClassParameters: map[string]string{consts.SkuNameField: "Standard_LRS"},
 		}
 		test.Run(cs, ns, schedulerName)
 	})
@@ -929,11 +930,11 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 		test := testsuites.DynamicallyProvisionedAzureDiskWithTag{
 			CSIDriver:              testDriver,
 			Pods:                   pods,
-			StorageClassParameters: map[string]string{"skuName": "Standard_LRS", "tags": tags},
+			StorageClassParameters: map[string]string{consts.SkuNameField: "Standard_LRS", "tags": tags},
 			Tags:                   tags,
 		}
 		if !testconsts.IsUsingInTreeVolumePlugin && testutil.IsZRSSupported(location) {
-			test.StorageClassParameters = map[string]string{"skuName": "StandardSSD_ZRS", "tags": tags}
+			test.StorageClassParameters = map[string]string{consts.SkuNameField: "StandardSSD_ZRS", "tags": tags}
 		}
 		test.Run(cs, ns, schedulerName)
 	})
@@ -962,10 +963,10 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 		test := testsuites.DynamicallyProvisionedAzureDiskDetach{
 			CSIDriver:              testDriver,
 			Pods:                   pods,
-			StorageClassParameters: map[string]string{"skuName": "Standard_LRS"},
+			StorageClassParameters: map[string]string{consts.SkuNameField: "Standard_LRS"},
 		}
 		if !testconsts.IsUsingInTreeVolumePlugin && testutil.IsZRSSupported(location) {
-			test.StorageClassParameters = map[string]string{"skuName": "StandardSSD_ZRS"}
+			test.StorageClassParameters = map[string]string{consts.SkuNameField: "StandardSSD_ZRS"}
 		}
 		test.Run(cs, ns, schedulerName)
 	})
@@ -1486,7 +1487,7 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 			expectedString = "hello world\r\n"
 		}
 
-		storageClassParameters := map[string]string{"skuName": "StandardSSD_LRS"}
+		storageClassParameters := map[string]string{consts.SkuNameField: "StandardSSD_LRS"}
 
 		test := testsuites.PodFailover{
 			CSIDriver: testDriver,
@@ -1537,7 +1538,7 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 			expectedString = "hello world\r\n"
 		}
 
-		storageClassParameters := map[string]string{"skuName": "StandardSSD_ZRS"}
+		storageClassParameters := map[string]string{consts.SkuNameField: "StandardSSD_ZRS"}
 
 		test := testsuites.PodFailover{
 			CSIDriver: testDriver,
@@ -1593,7 +1594,7 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 			expectedString = "hello world\r\n"
 		}
 
-		storageClassParameters := map[string]string{"skuName": skuName, "maxShares": "2"}
+		storageClassParameters := map[string]string{consts.SkuNameField: skuName, "maxShares": "2"}
 
 		test := testsuites.PodFailoverWithReplicas{
 			CSIDriver: testDriver,
@@ -1649,7 +1650,7 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 			expectedString = "hello world\r\n"
 		}
 
-		storageClassParameters := map[string]string{"skuName": skuName, "maxShares": "3", "cachingMode": "None"}
+		storageClassParameters := map[string]string{consts.SkuNameField: skuName, "maxShares": "3", "cachingMode": "None"}
 
 		test := testsuites.PodNodeScaleUp{
 			CSIDriver: testDriver,
@@ -1693,12 +1694,12 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 		}
 
 		storageClassParameters := map[string]string{
-			"skuName":     "StandardSSD_LRS",
-			"maxshares":   "2",
-			"cachingmode": "None",
+			consts.SkuNameField: "StandardSSD_LRS",
+			"maxshares":         "2",
+			"cachingmode":       "None",
 		}
 		if testutil.IsZRSSupported(location) {
-			storageClassParameters["skuName"] = "StandardSSD_ZRS"
+			storageClassParameters[consts.SkuNameField] = "StandardSSD_ZRS"
 		}
 
 		podCheck := &testsuites.PodExecCheck{

--- a/test/e2e/pre_provisioning_test.go
+++ b/test/e2e/pre_provisioning_test.go
@@ -248,9 +248,9 @@ var _ = ginkgo.Describe("Pre-Provisioned", func() {
 
 			sharedDiskSize := 10
 			volumeContext := map[string]string{
-				"skuName":     "Premium_LRS",
-				"maxshares":   "2",
-				"cachingMode": "None",
+				consts.SkuNameField: "Premium_LRS",
+				"maxshares":         "2",
+				"cachingMode":       "None",
 			}
 			volumeID, err = CreateVolume("shared-disk-multiple-pods", sharedDiskSize, volumeContext)
 			if err != nil {

--- a/test/e2e/testsuites/azdiskschedulerextender_pod_scheduling_on_failover_multiple_pv_perf_tester.go
+++ b/test/e2e/testsuites/azdiskschedulerextender_pod_scheduling_on_failover_multiple_pv_perf_tester.go
@@ -97,31 +97,33 @@ func (t *AzDiskSchedulerExtenderPodSchedulingOnFailoverMultiplePV) Run(client cl
 	}
 
 	//Check that AzVolumeAttachment resources were created correctly
-	allReplicasAttached := true
-	failedReplicaAttachments := &diskv1beta1.AzVolumeAttachmentList{}
+	allAttached := true
+	failedAttachments := []diskv1beta1.AzVolumeAttachment{}
 	err := wait.Poll(15*time.Second, 10*time.Minute, func() (bool, error) {
-		allReplicasAttached = true
-		var err error
-		var attached bool
-		var podFailedReplicaAttachments *diskv1beta1.AzVolumeAttachmentList
+		allAttached = true
+
+		failedAttachments = []diskv1beta1.AzVolumeAttachment{}
 		for _, ss := range tStatefulSets {
 			for _, pod := range ss.AllPods {
-				attached, podFailedReplicaAttachments, err = resources.VerifySuccessfulReplicaAzVolumeAttachments(pod, t.AzDiskClient, t.StorageClassParameters, client, namespace)
-				allReplicasAttached = allReplicasAttached && attached
-				if podFailedReplicaAttachments != nil {
-					failedReplicaAttachments.Items = append(failedReplicaAttachments.Items, podFailedReplicaAttachments.Items...)
+				attached, _, podFailedAttachments, err := resources.VerifySuccessfulAzVolumeAttachments(pod, t.AzDiskClient, t.StorageClassParameters, client, namespace)
+				allAttached = allAttached && attached
+				if podFailedAttachments != nil {
+					failedAttachments = append(failedAttachments, podFailedAttachments...)
+				}
+				if err != nil {
+					return allAttached, err
 				}
 			}
 		}
-		return allReplicasAttached, err
+		return allAttached, nil
 	})
-	if len(failedReplicaAttachments.Items) > 0 {
-		e2elog.Logf("found %d azvolumeattachments failed:", len(failedReplicaAttachments.Items))
-		for _, podAttachments := range failedReplicaAttachments.Items {
+	if len(failedAttachments) > 0 {
+		e2elog.Logf("found %d azvolumeattachments failed:", len(failedAttachments))
+		for _, podAttachments := range failedAttachments {
 			e2elog.Logf("azvolumeattachment: %s, err: %s", podAttachments.Name, podAttachments.Status.Error.Message)
 		}
 		ginkgo.Fail("failed due to replicas failing to attach")
-	} else if !allReplicasAttached {
+	} else if !allAttached {
 		ginkgo.Fail("could not find correct number of replicas")
 	} else if err != nil {
 		ginkgo.Fail(fmt.Sprintf("failed to verify replica attachments, err: %s", err))

--- a/test/e2e/testsuites/dynamically_provisioned_pod_failover_with_replicas_tester.go
+++ b/test/e2e/testsuites/dynamically_provisioned_pod_failover_with_replicas_tester.go
@@ -24,12 +24,14 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	diskv1beta1 "sigs.k8s.io/azuredisk-csi-driver/pkg/apis/azuredisk/v1beta1"
 	azDiskClientSet "sigs.k8s.io/azuredisk-csi-driver/pkg/apis/client/clientset/versioned"
 	"sigs.k8s.io/azuredisk-csi-driver/test/e2e/driver"
 	"sigs.k8s.io/azuredisk-csi-driver/test/resources"
 	nodeutil "sigs.k8s.io/azuredisk-csi-driver/test/utils/node"
+	podutil "sigs.k8s.io/azuredisk-csi-driver/test/utils/pod"
 )
 
 //  will provision required PV(s), PVC(s) and Pod(s)
@@ -52,7 +54,7 @@ func (t *PodFailoverWithReplicas) Run(client clientset.Interface, namespace *v1.
 		defer cleanup[i]()
 	}
 
-	// Get the list of available nodes for scheduling the pod
+	//Cordon nodes except for one worker node
 	nodes := nodeutil.ListNodeNames(client)
 	numRequiredNodes := 2
 	if t.IsMultiZone {
@@ -75,48 +77,64 @@ func (t *PodFailoverWithReplicas) Run(client clientset.Interface, namespace *v1.
 	}
 
 	//Check that AzVolumeAttachment resources were created correctly
-	allReplicasAttached := true
-	var failedReplicaAttachments *diskv1beta1.AzVolumeAttachmentList
+	allAttached := true
+	var failedAttachments []diskv1beta1.AzVolumeAttachment
+	var allAttachments []diskv1beta1.AzVolumeAttachment
+
 	err := wait.Poll(15*time.Second, 10*time.Minute, func() (bool, error) {
-		failedReplicaAttachments = nil
-		allReplicasAttached = true
+		failedAttachments = []diskv1beta1.AzVolumeAttachment{}
+		allAttachments = []diskv1beta1.AzVolumeAttachment{}
+		allAttached = true
 		var err error
-		var attached bool
-		var podFailedReplicaAttachments *diskv1beta1.AzVolumeAttachmentList
+
 		for _, pod := range tDeployment.Pods {
-			attached, podFailedReplicaAttachments, err = resources.VerifySuccessfulReplicaAzVolumeAttachments(pod, t.AzDiskClient, t.StorageClassParameters, client, namespace)
-			allReplicasAttached = allReplicasAttached && attached
-			if podFailedReplicaAttachments != nil {
-				failedReplicaAttachments.Items = append(failedReplicaAttachments.Items, podFailedReplicaAttachments.Items...)
+			attached, podAllAttachments, podFailedAttachments, derr := resources.VerifySuccessfulAzVolumeAttachments(pod, t.AzDiskClient, t.StorageClassParameters, client, namespace)
+			allAttached = allAttached && attached
+			if podFailedAttachments != nil {
+				failedAttachments = append(failedAttachments, podFailedAttachments...)
 			}
+			if podAllAttachments != nil {
+				allAttachments = append(allAttachments, podAllAttachments...)
+			}
+			err = derr
 		}
 
-		return allReplicasAttached, err
+		return allAttached, err
 	})
 
-	if failedReplicaAttachments != nil {
-		e2elog.Logf("found %d azvolumeattachments failed:", len(failedReplicaAttachments.Items))
-		for _, attachments := range failedReplicaAttachments.Items {
+	if len(failedAttachments) > 0 {
+		e2elog.Logf("found %d azvolumeattachments failed:", len(failedAttachments))
+		for _, attachments := range failedAttachments {
 			e2elog.Logf("azvolumeattachment: %s, err: %s", attachments.Name, attachments.Status.Error.Message)
 		}
 		ginkgo.Fail("failed due to replicas failing to attach")
-	} else if !allReplicasAttached {
+	} else if !allAttached {
 		ginkgo.Fail("could not find correct number of replicas")
 	} else if err != nil {
 		ginkgo.Fail(fmt.Sprintf("failed to verify replica attachments, err: %s", err))
 
 	}
-	ginkgo.By("replica attachments verified successfully")
+	ginkgo.By("attachments verified successfully")
 
-	ginkgo.By("cordoning node 0")
+	var primaryNode string
+	replicaNodeSet := map[string]struct{}{}
+	for _, attachment := range allAttachments {
+		if attachment.Spec.RequestedRole == diskv1beta1.PrimaryRole {
+			primaryNode = attachment.Spec.NodeName
+		} else {
+			replicaNodeSet[attachment.Spec.NodeName] = struct{}{}
+		}
+	}
+
+	ginkgo.By(fmt.Sprintf("cordoning node (%s) with primary attachment", primaryNode))
 
 	testPod := resources.TestPod{
 		Client: client,
 	}
 
-	// Make node#0 unschedulable to ensure that pods are scheduled on a different node
-	testPod.SetNodeUnschedulable(nodes[0], true)        // kubeclt cordon node
-	defer testPod.SetNodeUnschedulable(nodes[0], false) // defer kubeclt uncordon node
+	// Make primary node unschedulable to ensure that pods are scheduled on a different node
+	testPod.SetNodeUnschedulable(primaryNode, true)        // kubeclt cordon node
+	defer testPod.SetNodeUnschedulable(primaryNode, false) // defer kubeclt uncordon node
 
 	ginkgo.By("deleting the pod for deployment")
 	time.Sleep(10 * time.Second)
@@ -130,5 +148,14 @@ func (t *PodFailoverWithReplicas) Run(client clientset.Interface, namespace *v1.
 		time.Sleep(3 * time.Second)
 		// pod will be restarted so expect to see 2 instances of string
 		tDeployment.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString+t.PodCheck.ExpectedString)
+	}
+
+	ginkgo.By("Verifying that pod got created on the correct node.")
+	// verfiy that the pod failed over the replica node
+	podObjs, err := podutil.GetPodsForDeployment(tDeployment.Client, tDeployment.Deployment)
+	framework.ExpectNoError(err)
+	for _, podObj := range podObjs.Items {
+		_, isOnCorrectNode := replicaNodeSet[podObj.Spec.NodeName]
+		framework.ExpectEqual(isOnCorrectNode, true)
 	}
 }

--- a/test/integration/controller/controller_test.go
+++ b/test/integration/controller/controller_test.go
@@ -173,9 +173,9 @@ func TestAzVolume(t *testing.T) {
 			},
 			volumeCapabilities: []diskv1beta1.VolumeCapability{},
 			parameters: map[string]string{
-				"kind":      "managed",
-				"maxShares": "1",
-				"skuName":   "StandardSSD_LRS",
+				"kind":              "managed",
+				"maxShares":         "1",
+				consts.SkuNameField: "StandardSSD_LRS",
 			},
 			secrets:             map[string]string{},
 			volumeContentSource: nil,
@@ -218,9 +218,9 @@ func TestAzVolume(t *testing.T) {
 			},
 			volumeCapabilities: []diskv1beta1.VolumeCapability{},
 			parameters: map[string]string{
-				"kind":      "managed",
-				"maxShares": "2",
-				"skuName":   "Premium_LRS",
+				"kind":              "managed",
+				"maxShares":         "2",
+				consts.SkuNameField: "Premium_LRS",
 			},
 			secrets:             map[string]string{},
 			volumeContentSource: nil,
@@ -417,7 +417,7 @@ func TestAzVolumeAttachment(t *testing.T) {
 			volumeContext:    nil,
 			setUpFunc: func(t *testing.T, volumeName string) {
 				// create volume
-				_, err := crdProvisioner.CreateVolume(context.Background(), volumeName, &diskv1beta1.CapacityRange{RequiredBytes: 274877906944}, []diskv1beta1.VolumeCapability{}, map[string]string{"kind": "managed", "maxShares": "1", "skuName": "StandardSSD_LRS"}, nil, nil, nil)
+				_, err := crdProvisioner.CreateVolume(context.Background(), volumeName, &diskv1beta1.CapacityRange{RequiredBytes: 274877906944}, []diskv1beta1.VolumeCapability{}, map[string]string{"kind": "managed", "maxShares": "1", consts.SkuNameField: "StandardSSD_LRS"}, nil, nil, nil)
 				require.NoError(t, err)
 			},
 			testFunc: func(t *testing.T, volumeName, nodeName string) {
@@ -463,7 +463,7 @@ func TestAzVolumeAttachment(t *testing.T) {
 			volumeContext:    nil,
 			setUpFunc: func(t *testing.T, volumeName string) {
 				// create volume
-				_, err := crdProvisioner.CreateVolume(context.Background(), volumeName, &diskv1beta1.CapacityRange{RequiredBytes: 274877906944}, []diskv1beta1.VolumeCapability{}, map[string]string{"kind": "managed", "maxShares": "2", "skuName": "Premium_LRS"}, nil, nil, nil)
+				_, err := crdProvisioner.CreateVolume(context.Background(), volumeName, &diskv1beta1.CapacityRange{RequiredBytes: 274877906944}, []diskv1beta1.VolumeCapability{}, map[string]string{"kind": "managed", "maxShares": "2", consts.SkuNameField: "Premium_LRS"}, nil, nil, nil)
 				require.NoError(t, err)
 			},
 			testFunc: func(t *testing.T, volumeName, nodeName string) {
@@ -485,7 +485,7 @@ func TestAzVolumeAttachment(t *testing.T) {
 			volumeContext:    nil,
 			setUpFunc: func(t *testing.T, volumeName string) {
 				// create volume
-				_, err := crdProvisioner.CreateVolume(context.Background(), volumeName, &diskv1beta1.CapacityRange{RequiredBytes: 274877906944}, []diskv1beta1.VolumeCapability{}, map[string]string{"kind": "managed", "maxShares": "2", "skuName": "Premium_LRS"}, nil, nil, nil)
+				_, err := crdProvisioner.CreateVolume(context.Background(), volumeName, &diskv1beta1.CapacityRange{RequiredBytes: 274877906944}, []diskv1beta1.VolumeCapability{}, map[string]string{"kind": "managed", "maxShares": "2", consts.SkuNameField: "Premium_LRS"}, nil, nil, nil)
 				require.NoError(t, err)
 			},
 			testFunc: func(t *testing.T, volumeName, nodeName string) {
@@ -581,7 +581,7 @@ func TestAzVolumeAttachment(t *testing.T) {
 			volumeContext:    nil,
 			setUpFunc: func(t *testing.T, volumeName string) {
 				// create volume
-				_, err := crdProvisioner.CreateVolume(context.Background(), volumeName, &diskv1beta1.CapacityRange{RequiredBytes: 1099511627776}, []diskv1beta1.VolumeCapability{}, map[string]string{"kind": "managed", "maxShares": "3", "skuName": "Premium_LRS"}, nil, nil, nil)
+				_, err := crdProvisioner.CreateVolume(context.Background(), volumeName, &diskv1beta1.CapacityRange{RequiredBytes: 1099511627776}, []diskv1beta1.VolumeCapability{}, map[string]string{"kind": "managed", "maxShares": "3", consts.SkuNameField: "Premium_LRS"}, nil, nil, nil)
 				require.NoError(t, err)
 			},
 			testFunc: func(t *testing.T, volumeName, nodeName string) {
@@ -641,7 +641,7 @@ func TestAzVolumeAttachment(t *testing.T) {
 			volumeContext:    nil,
 			setUpFunc: func(t *testing.T, volumeName string) {
 				// create volume
-				_, err := crdProvisioner.CreateVolume(context.Background(), volumeName, &diskv1beta1.CapacityRange{RequiredBytes: 274877906944}, []diskv1beta1.VolumeCapability{}, map[string]string{"kind": "managed", "maxShares": "2", "skuName": "Premium_LRS"}, nil, nil, nil)
+				_, err := crdProvisioner.CreateVolume(context.Background(), volumeName, &diskv1beta1.CapacityRange{RequiredBytes: 274877906944}, []diskv1beta1.VolumeCapability{}, map[string]string{"kind": "managed", "maxShares": "2", consts.SkuNameField: "Premium_LRS"}, nil, nil, nil)
 				require.NoError(t, err)
 			},
 			testFunc: func(t *testing.T, volumeName, nodeName string) {
@@ -692,7 +692,7 @@ func TestAzVolumeAttachment(t *testing.T) {
 			volumeContext:    nil,
 			setUpFunc: func(t *testing.T, volumeName string) {
 				// create volume
-				_, err := crdProvisioner.CreateVolume(context.Background(), volumeName, &diskv1beta1.CapacityRange{RequiredBytes: 274877906944}, []diskv1beta1.VolumeCapability{}, map[string]string{"kind": "managed", "maxShares": "2", "skuName": "Premium_LRS"}, nil, nil, nil)
+				_, err := crdProvisioner.CreateVolume(context.Background(), volumeName, &diskv1beta1.CapacityRange{RequiredBytes: 274877906944}, []diskv1beta1.VolumeCapability{}, map[string]string{"kind": "managed", "maxShares": "2", consts.SkuNameField: "Premium_LRS"}, nil, nil, nil)
 				require.NoError(t, err)
 			},
 			testFunc: func(t *testing.T, volumeName, nodeName string) {

--- a/test/podFailover/controller/main.go
+++ b/test/podFailover/controller/main.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
+	consts "sigs.k8s.io/azuredisk-csi-driver/pkg/azureconstants"
 )
 
 const (
@@ -218,7 +219,7 @@ func createStorageClass(ctx context.Context, clientset *kubernetes.Clientset, ma
 			GenerateName: "pod-failover-sc-",
 		},
 		Provisioner:          "disk.csi.azure.com",
-		Parameters:           map[string]string{"skuname": "Premium_LRS", "maxShares": strconv.Itoa(maxShares), "cachingMode": "None"},
+		Parameters:           map[string]string{consts.SkuNameField: "Premium_LRS", "maxShares": strconv.Itoa(maxShares), "cachingMode": "None"},
 		ReclaimPolicy:        &reclaimPolicy,
 		AllowVolumeExpansion: &allowVolumeExpansion,
 	}

--- a/test/resources/deployment.go
+++ b/test/resources/deployment.go
@@ -20,11 +20,13 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"time"
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
@@ -134,7 +136,27 @@ func (t *TestDeployment) WaitForPodReady() {
 	framework.ExpectNoError(err)
 	t.Pods = []PodDetails{}
 	for _, pod := range pods.Items {
-		t.Pods = append(t.Pods, PodDetails{Name: pod.Name})
+		var podPersistentVolumes []VolumeDetails
+		for _, volume := range pod.Spec.Volumes {
+			if volume.VolumeSource.PersistentVolumeClaim != nil {
+				pvc, err := t.Client.CoreV1().PersistentVolumeClaims(t.Namespace.Name).Get(context.TODO(), volume.VolumeSource.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
+				framework.ExpectNoError(err)
+				accessMode := v1.ReadWriteOnce
+				if len(pvc.Spec.AccessModes) > 0 {
+					accessMode = pvc.Spec.AccessModes[0]
+				}
+				newVolume := VolumeDetails{
+					PersistentVolume: &v1.PersistentVolume{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: pvc.Spec.VolumeName,
+						},
+					},
+					VolumeAccessMode: accessMode,
+				}
+				podPersistentVolumes = append(podPersistentVolumes, newVolume)
+			}
+		}
+		t.Pods = append(t.Pods, PodDetails{Name: pod.Name, Volumes: podPersistentVolumes})
 	}
 	ch := make(chan error, len(t.Pods))
 	defer close(ch)
@@ -177,20 +199,60 @@ func (t *TestDeployment) DeletePodAndWait() {
 		}
 	}
 
-	for _, pod := range t.Pods {
-		e2elog.Logf("Waiting for pod %q in namespace %q to be fully deleted", pod.Name, t.Namespace.Name)
-		go func(client clientset.Interface, ns, podName string) {
-			err := e2epod.WaitForPodNoLongerRunningInNamespace(client, podName, ns)
-			ch <- err
-		}(t.Client, t.Namespace.Name, pod.Name)
+	conditionFunc := func(podName string, ch chan error) {
+		e2elog.Logf("Waiting for pod %q in namespace %q to be fully deleted", podName, t.Namespace.Name)
+		err := e2epod.WaitForPodNoLongerRunningInNamespace(t.Client, podName, t.Namespace.Name)
+		ch <- err
 	}
-	// Wait on all goroutines to report on pod terminating
+	t.WaitForPodStatus(conditionFunc)
+}
+
+func (t *TestDeployment) ForceDeletePod(podName string) error {
+	err := t.Client.CoreV1().Pods(t.Deployment.Namespace).Delete(context.Background(), podName, *metav1.NewDeleteOptions(0))
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	// remove pod from the deployment's pod list
+	pods := make([]PodDetails, len(t.Pods)-1)
+	i := 0
+	for _, tPod := range t.Pods {
+		if tPod.Name == podName {
+			continue
+		}
+		pods[i] = tPod
+		i++
+	}
+	t.Pods = pods
+	return nil
+}
+
+func (t *TestDeployment) WaitForPodTerminating(timeout time.Duration) {
+	conditionFunc := func(podName string, ch chan error) {
+		e2elog.Logf("Waiting for pod %q in namespace %q to start terminating", podName, t.Namespace.Name)
+		err := wait.PollImmediate(time.Duration(15)*time.Second, timeout, func() (bool, error) {
+			podObj, err := t.Client.CoreV1().Pods(t.Namespace.Name).Get(context.Background(), podName, metav1.GetOptions{})
+			if err != nil && !errors.IsNotFound(err) {
+				return false, err
+			}
+			return !podObj.DeletionTimestamp.IsZero(), nil
+		})
+		ch <- err
+	}
+	t.WaitForPodStatus(conditionFunc)
+}
+
+func (t *TestDeployment) WaitForPodStatus(conditionFunc func(podName string, ch chan error)) {
+	ch := make(chan error, len(t.Pods))
+
+	for _, pod := range t.Pods {
+		go conditionFunc(pod.Name, ch)
+	}
+
 	for _, pod := range t.Pods {
 		err := <-ch
-		if err != nil {
-			if !errors.IsNotFound(err) {
-				framework.ExpectNoError(fmt.Errorf("pod %q error waiting for delete: %v", pod.Name, err))
-			}
+		if err != nil && !errors.IsNotFound(err) {
+			framework.ExpectNoError(fmt.Errorf("pod %q error waiting for delete: %v", pod.Name, err))
 		}
 	}
 }

--- a/test/resources/pvc.go
+++ b/test/resources/pvc.go
@@ -160,6 +160,10 @@ func (t *TestPersistentVolumeClaim) Cleanup() {
 	// attempts may fail, as the volume is still attached to a node because
 	// kubelet is slowly cleaning up the previous pod, however it should succeed
 	// in a couple of minutes.
+	if t.PersistentVolume == nil {
+		t.PersistentVolume, err = t.Client.CoreV1().PersistentVolumes().Get(context.Background(), t.PersistentVolumeClaim.Spec.VolumeName, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+	}
 	if t.PersistentVolume.Spec.PersistentVolumeReclaimPolicy == v1.PersistentVolumeReclaimDelete {
 		ginkgo.By(fmt.Sprintf("waiting for claim's PV %q to be deleted", t.PersistentVolume.Name))
 		err := e2epv.WaitForPersistentVolumeDeleted(t.Client, t.PersistentVolume.Name, 5*time.Second, 10*time.Minute)

--- a/test/resources/resource_setup.go
+++ b/test/resources/resource_setup.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/e2e/framework"
 
+	consts "sigs.k8s.io/azuredisk-csi-driver/pkg/azureconstants"
 	testconsts "sigs.k8s.io/azuredisk-csi-driver/test/const"
 	"sigs.k8s.io/azuredisk-csi-driver/test/e2e/driver"
 )
@@ -49,6 +50,7 @@ func (pod *PodDetails) SetupWithDynamicVolumes(client clientset.Interface, names
 	cleanupFuncs := make([]func(), 0)
 	for n, v := range pod.Volumes {
 		tpvc, funcs := v.SetupDynamicPersistentVolumeClaim(client, namespace, csiDriver, storageClassParameters)
+		pod.Volumes[n].PersistentVolumeClaim = tpvc.PersistentVolumeClaim.DeepCopy()
 		cleanupFuncs = append(cleanupFuncs, funcs...)
 		ginkgo.By("setting up the pod")
 		if v.VolumeMode == Block {
@@ -74,13 +76,18 @@ func (pod *PodDetails) SetupWithDynamicMultipleVolumes(client clientset.Interfac
 	}
 	accountTypeCount := len(supportedStorageAccountTypes)
 	for n, v := range pod.Volumes {
-		storageClassParameters := map[string]string{"skuName": supportedStorageAccountTypes[n%accountTypeCount]}
+		storageClassParameters := map[string]string{consts.SkuNameField: supportedStorageAccountTypes[n%accountTypeCount]}
 		tpvc, funcs := v.SetupDynamicPersistentVolumeClaim(client, namespace, csiDriver, storageClassParameters)
+		pod.Volumes[n].PersistentVolumeClaim = tpvc.PersistentVolumeClaim.DeepCopy()
 		cleanupFuncs = append(cleanupFuncs, funcs...)
 		if v.VolumeMode == Block {
 			tpod.SetupRawBlockVolume(tpvc.PersistentVolumeClaim, fmt.Sprintf("%s%d", v.VolumeDevice.NameGenerate, n+1), v.VolumeDevice.DevicePath)
 		} else {
 			tpod.SetupVolume(tpvc.PersistentVolumeClaim, fmt.Sprintf("%s%d", v.VolumeMount.NameGenerate, n+1), fmt.Sprintf("%s%d", v.VolumeMount.MountPathGenerate, n+1), v.VolumeMount.ReadOnly)
+		}
+		if tpvc.PersistentVolume != nil {
+			klog.Infof("adding PV (%s) to pod (%s)", tpvc.PersistentVolume.Name, tpod.Pod.Name)
+			pod.Volumes[n].PersistentVolume = tpvc.PersistentVolume.DeepCopy()
 		}
 	}
 	return tpod, cleanupFuncs
@@ -138,7 +145,7 @@ func (pod *PodDetails) SetupDeployment(client clientset.Interface, namespace *v1
 		ginkgo.By("setting up the PVC")
 		tpvc := NewTestPersistentVolumeClaim(client, namespace, volume.ClaimSize, volume.VolumeMode, volume.VolumeAccessMode, &createdStorageClass)
 		tpvc.Create()
-		if volume.VolumeBindingMode == nil || *volume.VolumeBindingMode == storagev1.VolumeBindingImmediate {
+		if createdStorageClass.VolumeBindingMode == nil || *createdStorageClass.VolumeBindingMode == storagev1.VolumeBindingImmediate {
 			tpvc.WaitForBound()
 			tpvc.ValidateProvisionedPersistentVolume()
 		}

--- a/test/resources/volumes.go
+++ b/test/resources/volumes.go
@@ -40,7 +40,8 @@ type VolumeDetails struct {
 	VolumeDevice          VolumeDeviceDetails
 	VolumeAccessMode      v1.PersistentVolumeAccessMode
 	// Optional, used to get AzVolumeAttachments
-	PersistentVolume *v1.PersistentVolume
+	PersistentVolume      *v1.PersistentVolume
+	PersistentVolumeClaim *v1.PersistentVolumeClaim
 	// Optional, used with pre-provisioned volumes
 	VolumeID string
 	// Optional, used with PVCs created from snapshots or pvc
@@ -98,7 +99,7 @@ func (volume *VolumeDetails) SetupDynamicPersistentVolumeClaim(client clientset.
 	tpvc.Create()
 	cleanupFuncs = append(cleanupFuncs, tpvc.Cleanup)
 	// PV will not be ready until PVC is used in a pod when volumeBindingMode: WaitForFirstConsumer
-	if volume.VolumeBindingMode == nil || *volume.VolumeBindingMode == storagev1.VolumeBindingImmediate {
+	if storageClass.VolumeBindingMode == nil || *storageClass.VolumeBindingMode == storagev1.VolumeBindingImmediate {
 		tpvc.WaitForBound()
 		tpvc.ValidateProvisionedPersistentVolume()
 	}

--- a/test/scale/azdisk_scale_test.go
+++ b/test/scale/azdisk_scale_test.go
@@ -21,6 +21,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	consts "sigs.k8s.io/azuredisk-csi-driver/pkg/azureconstants"
 	testconsts "sigs.k8s.io/azuredisk-csi-driver/test/const"
 	"sigs.k8s.io/azuredisk-csi-driver/test/e2e/driver"
 	"sigs.k8s.io/azuredisk-csi-driver/test/resources"
@@ -76,7 +77,7 @@ func scaleTests(isMultiZone bool) {
 		test.CSIDriver = testDriver
 		test.Pod = pod
 		test.Replicas = 1000
-		test.StorageClassParameters = map[string]string{"skuName": "Premium_LRS", "maxShares": "1", "cachingmode": "None"}
+		test.StorageClassParameters = map[string]string{consts.SkuNameField: "Premium_LRS", "maxShares": "1", "cachingmode": "None"}
 
 		test.Run(cs, ns, schedulerName)
 	})
@@ -110,7 +111,7 @@ func scaleTests(isMultiZone bool) {
 		test.Pod = pod
 		test.Replicas = 1
 		test.PodCount = 1000
-		test.StorageClassParameters = map[string]string{"skuName": "StandardSSD_LRS", "maxShares": "2", "cachingmode": "None"}
+		test.StorageClassParameters = map[string]string{consts.SkuNameField: "StandardSSD_LRS", "maxShares": "2", "cachingmode": "None"}
 
 		test.Run(cs, ns, schedulerName)
 	})
@@ -175,7 +176,7 @@ func scaleTests(isMultiZone bool) {
 		test.Pod = pod
 		test.Replicas = volMountedOnPod
 		test.PodCount = 350
-		test.StorageClassParameters = map[string]string{"skuName": "Premium_LRS", "maxShares": "2", "cachingmode": "None"}
+		test.StorageClassParameters = map[string]string{consts.SkuNameField: "Premium_LRS", "maxShares": "2", "cachingmode": "None"}
 
 		test.Run(cs, ns, schedulerName)
 	})

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -197,7 +197,7 @@ func upgradeTest(isMultiZone bool) {
 			IsWindows: testconsts.IsWindowsCluster,
 		}
 
-		storageClassParameters := map[string]string{"skuName": "Premium_LRS", "maxShares": "1", "cachingmode": "None"}
+		storageClassParameters := map[string]string{consts.SkuNameField: "Premium_LRS", "maxShares": "1", "cachingmode": "None"}
 
 		tpod, cleanup := pod.SetupWithDynamicVolumes(cs, ns, testDriver, storageClassParameters, scheduler)
 		// defer must be called here for resources not get removed before using them


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
* e2e test relies on storage class parameters for many of its functionalities and the sku name field is handled case sensitive in these test utils when it should be case insensitive.
* This is causing certain bugs as below:
A ZRS disk is created for multi-az case but with storage class parameter sku name field hard coded.
https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/04aba1e20ce3598d77e359198e4579335eb27024/test/e2e/dynamic_provisioning_test.go#L1652
But because the test util expects `consts.SkuNameField`, which is in lowercase, as storageclass parameter key, we never end up setting the volume's binding mode to `VolumeBindingImmediate`
https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/04aba1e20ce3598d77e359198e4579335eb27024/test/e2e/driver/azuredisk_driver.go#L62-L64
* And for code manageability, hard coded values were replaced with constant except for one test case where it was left as is to verify that test util handles storage class parameters case insensitively.
* And some tester and test util functions were amended as they were relying on some invalid assumptions.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
This is not a v2 specific problem. Once the change is approved for v2, the commit can be cherry picked for v1 as well.

**Release note**:
```
none
```
