### PR TITLE
[V2] feat: add replica creation after volumes are garbage collected and space is freed up 🌈

### DIFF
--- a/pkg/controller/node_availability.go
+++ b/pkg/controller/node_availability.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"sync/atomic"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -57,15 +56,9 @@ func (r *ReconcileNodeAvailability) Reconcile(ctx context.Context, request recon
 	if err == nil {
 		if !n.Spec.Unschedulable {
 			//Node is schedulable, proceed to attempt creation of replica attachment
-			if atomic.SwapInt32(&r.controllerSharedState.processingReplicaRequestQueue, 1) == 0 {
-				logger.Info("Node is now available. Will requeue failed replica creation requests.")
-				err := r.controllerSharedState.tryCreateFailedReplicas(ctx, nodeavailability)
-				atomic.StoreInt32(&r.controllerSharedState.processingReplicaRequestQueue, 0)
-				if err != nil {
-					return reconcile.Result{Requeue: false}, nil
-				}
-				return reconcile.Result{Requeue: false}, nil
-			}
+			logger.Info("Node is now available. Will requeue failed replica creation requests.")
+			r.controllerSharedState.tryCreateFailedReplicas(ctx, nodeavailability)
+			return reconcile.Result{Requeue: false}, nil
 		}
 	}
 	return reconcile.Result{Requeue: false}, err

--- a/test/e2e/testsuites/dynamically_provisioned_garbage_collection_replica_attachment_tester.go
+++ b/test/e2e/testsuites/dynamically_provisioned_garbage_collection_replica_attachment_tester.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testsuites
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/skipper"
+	"sigs.k8s.io/azuredisk-csi-driver/pkg/apis/azuredisk/v1beta1"
+	azDiskClientSet "sigs.k8s.io/azuredisk-csi-driver/pkg/apis/client/clientset/versioned"
+	consts "sigs.k8s.io/azuredisk-csi-driver/pkg/azureconstants"
+	testconsts "sigs.k8s.io/azuredisk-csi-driver/test/const"
+	"sigs.k8s.io/azuredisk-csi-driver/test/e2e/driver"
+	"sigs.k8s.io/azuredisk-csi-driver/test/resources"
+	nodeutil "sigs.k8s.io/azuredisk-csi-driver/test/utils/node"
+)
+
+// DynamicallyProvisionedScaleReplicasOnDetach will provision required PV(s), PVC(s) and Pod(s), enough to fill the available
+// spots for attachments on all the nodes. Another PVC will be added that will have to wait for a opening on a node to connect
+type DynamicallyProvisionedScaleReplicasOnDetach struct {
+	CSIDriver              driver.DynamicPVTestDriver
+	StatefulSetPod         resources.PodDetails
+	StorageClassParameters map[string]string
+	AzDiskClient           *azDiskClientSet.Clientset
+	NewPod                 resources.PodDetails
+}
+
+func (t *DynamicallyProvisionedScaleReplicasOnDetach) Run(client clientset.Interface, namespace *v1.Namespace, schedulerName string) {
+	nodes := nodeutil.ListNodeNames(client)
+	skipper.SkipUnlessAtLeast(len(nodes), 3, "Need at least 3 nodes to verify the test case.")
+
+	testPod := resources.TestPod{
+		Client: client,
+	}
+	csiNode, err := client.StorageV1().CSINodes().Get(context.Background(), nodes[0], metav1.GetOptions{})
+	framework.ExpectNoError(err, "Expected to successfully get the CSI node using the API.")
+
+	numReplicas, ok := getNumReplicasFromCSINode(csiNode)
+	framework.ExpectEqual(ok, true, "Expected to find %s.", consts.DefaultDriverName)
+	framework.Logf("numReplicas is %d", numReplicas)
+
+	// Cordoning all but two nodes
+	for _, node := range nodes[2:] {
+		node := node
+		framework.Logf("Cordoning %s.", node)
+		testPod.SetNodeUnschedulable(node, true)
+		defer func() {
+			framework.Logf("Uncordoning %s", node)
+			testPod.SetNodeUnschedulable(node, false)
+		}()
+	}
+
+	tStorageClass, storageCleanup := t.StatefulSetPod.CreateStorageClass(client, namespace, t.CSIDriver, t.StorageClassParameters)
+	defer storageCleanup()
+
+	labels := map[string]string{"group": "delete-for-replica-scaleup"}
+	tStatefulSet, cleanupStatefulSet := t.StatefulSetPod.SetupStatefulset(client, namespace, t.CSIDriver, schedulerName, numReplicas, &tStorageClass, labels)
+	isStatefulSetCleanupDone := false
+
+	// Wrap the stateful set cleanup; we want to call this at a specific time but also call it in case of failure.
+	wrappedCleanup := func() {
+		if !isStatefulSetCleanupDone {
+			cleanupStatefulSet(testconsts.PollTimeout)
+			isStatefulSetCleanupDone = true
+		}
+	}
+	defer wrappedCleanup()
+
+	tStatefulSet.Create()
+	// Check that AzVolumeAttachment resources were created correctly
+	ginkgo.By("Verifying that the stateful set attachments are successful.")
+	verifyStatefulSetAttachments := func() (bool, []v1beta1.AzVolumeAttachment, error) {
+		return t.getStatefulSetAttachmentStatus(client, namespace, tStatefulSet)
+	}
+	failedAttachments, err := t.pollForFailedAttachments(verifyStatefulSetAttachments)
+	framework.ExpectEmpty(failedAttachments, "Expected there to be no failed attachments.")
+	framework.ExpectNoError(err, "Expected the stateful set to have successful attachments.")
+	framework.Logf("Stateful set replica attachments verified successfully.")
+
+	ginkgo.By("Creating a pod with volume.")
+	// Uncordon a node for the primary attachment
+	testPod.SetNodeUnschedulable(nodes[2], false)
+	framework.Logf("Uncordoning %s.", nodes[2])
+	tpod, cleanupFuncs := t.NewPod.SetupWithDynamicVolumes(client, namespace, t.CSIDriver, t.StorageClassParameters, schedulerName)
+	for _, cleanupFunc := range cleanupFuncs {
+		defer cleanupFunc()
+	}
+
+	ginkgo.By("Deploying the pod.")
+	tpod.Create()
+	defer tpod.Cleanup()
+	ginkgo.By("Checking that the pod is running.")
+	tpod.WaitForRunning()
+	t.NewPod.Name = tpod.Pod.Name
+
+	ginkgo.By("Verifying that new pod was not able to create any replica attachments.")
+	err = t.pollForReplicaFailedEvent(client, namespace)
+	framework.ExpectNoError(err, "Expected to find failed replica event for %s.", t.NewPod.Name)
+
+	ginkgo.By("Cleaning up the stateful set to free up attachments.")
+	wrappedCleanup()
+
+	ginkgo.By("Verifying that the new pod has successful replica attachment.")
+	verifyPodAttachment := func() (bool, []v1beta1.AzVolumeAttachment, error) {
+		isVerified, _, failedAttachments, err := resources.VerifySuccessfulAzVolumeAttachments(t.NewPod, t.AzDiskClient, t.StorageClassParameters, client, namespace)
+		return isVerified, failedAttachments, err
+	}
+	failedAttachments, err = t.pollForFailedAttachments(verifyPodAttachment)
+	framework.ExpectEmpty(failedAttachments, "Expected there to be no failed attachments.")
+	framework.ExpectNoError(err, "Expected the new pod to have successful attachments.")
+}
+
+// Get the maximum number of unique volumes managed by the CSI driver that can be used on a node
+func getNumReplicasFromCSINode(csiNode *storagev1.CSINode) (int, bool) {
+	for _, driver := range csiNode.Spec.Drivers {
+		if driver.Name == consts.DefaultDriverName {
+			return int(*driver.Allocatable.Count), true
+		}
+	}
+	return 0, false
+}
+
+func (t *DynamicallyProvisionedScaleReplicasOnDetach) pollForReplicaFailedEvent(client clientset.Interface, namespace *v1.Namespace) error {
+	nameSelector := fields.OneTermEqualSelector("involvedObject.name", t.NewPod.Name).String()
+	listOptions := metav1.ListOptions{FieldSelector: nameSelector, TypeMeta: metav1.TypeMeta{Kind: "Pod"}}
+	err := wait.PollImmediate(testconsts.Poll, testconsts.PollTimeout, func() (bool, error) {
+		events, err := client.CoreV1().Events(namespace.Name).List(context.TODO(), listOptions)
+		if err != nil {
+			return false, err
+		}
+		for _, event := range events.Items {
+			if event.Reason == consts.ReplicaAttachmentFailedEvent {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	return err
+}
+
+// Verifies that the stateful set has successful attachments for all pods
+func (t *DynamicallyProvisionedScaleReplicasOnDetach) pollForFailedAttachments(verifyFunc func() (bool, []v1beta1.AzVolumeAttachment, error)) ([]v1beta1.AzVolumeAttachment, error) {
+	var finalFailedAttachments []v1beta1.AzVolumeAttachment
+	err := wait.PollImmediate(testconsts.Poll, testconsts.PollTimeout, func() (bool, error) {
+		allAttached, failedAttachments, err := verifyFunc()
+		finalFailedAttachments = failedAttachments
+		return allAttached, err
+	})
+	return finalFailedAttachments, err
+}
+
+// Iterates over all pods in the stateful set to verify attachments for each pod
+func (t *DynamicallyProvisionedScaleReplicasOnDetach) getStatefulSetAttachmentStatus(client clientset.Interface, namespace *v1.Namespace, tStatefulSet *resources.TestStatefulset) (bool, []v1beta1.AzVolumeAttachment, error) {
+	allAttached := true
+	var failedAttachments []v1beta1.AzVolumeAttachment
+	for _, pod := range tStatefulSet.AllPods {
+		isAttached, _, podFailedReplicaAttachments, err := resources.VerifySuccessfulAzVolumeAttachments(pod, t.AzDiskClient, t.StorageClassParameters, client, namespace)
+		failedAttachments = append(failedAttachments, podFailedReplicaAttachments...)
+		allAttached = allAttached && isAttached
+		if err != nil {
+			return allAttached, failedAttachments, err
+		}
+	}
+	return allAttached, failedAttachments, nil
+}

--- a/test/resources/utils.go
+++ b/test/resources/utils.go
@@ -37,7 +37,6 @@ import (
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	diskv1beta1 "sigs.k8s.io/azuredisk-csi-driver/pkg/apis/azuredisk/v1beta1"
 	azDiskClientSet "sigs.k8s.io/azuredisk-csi-driver/pkg/apis/client/clientset/versioned"
-	"sigs.k8s.io/azuredisk-csi-driver/pkg/azureconstants"
 	consts "sigs.k8s.io/azuredisk-csi-driver/pkg/azureconstants"
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/azureutils"
 	testconsts "sigs.k8s.io/azuredisk-csi-driver/test/const"
@@ -139,7 +138,7 @@ func getAzVolumeAttachmentsForPV(persistentVolume *v1.PersistentVolume, client c
 	if err != nil {
 		ginkgo.Fail("failed to get persistent volume diskname")
 	}
-	azVolumeAttachments, err := azDiskClient.DiskV1beta1().AzVolumeAttachments(azureconstants.DefaultAzureDiskCrdNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: labels.Set(map[string]string{azureconstants.VolumeNameLabel: diskname}).String()})
+	azVolumeAttachments, err := azDiskClient.DiskV1beta1().AzVolumeAttachments(consts.DefaultAzureDiskCrdNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: labels.Set(map[string]string{consts.VolumeNameLabel: diskname}).String()})
 	if err != nil {
 		ginkgo.Fail("failed while getting replica attachments")
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
"After volumes are garbage collected and attachment capacity opens up on a node, prompts an attempt to create previously failed replicas." - from original PR #1244 

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

## Clarification on PR

I removed passing is copying `ctx` into the closure because it is not need. It passed in `deletionCtx` as `ctx` but `workflowCtx` is passed into `r.controllerSharedState.garbageCollectReplicas`. Because of this, I investigated this. Copying it into the closure is not needed because `context.Context` is immutable and the closure does not change the variable outside of its scope.
https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/8cf65b5d12eb5e075b8e5ecc295c2df5576864b9/pkg/controller/replica.go#L155-L164
## Small fixes
I noticed some small issues while working on the code, so I fixed them. I think ideally it might be split into a different PR, but I don't want to introduce unnecessary overhead to get these changes in:

There was a double import, so I chose to use `diskv1beta` instead of `v1beta`, which is used more frequently in the file:
https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/8cf65b5d12eb5e075b8e5ecc295c2df5576864b9/pkg/controller/common.go#L44-L45

Same thing here, however with `azureconstants` => `consts`, which is used throughout the project:
https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/8cf65b5d12eb5e075b8e5ecc295c2df5576864b9/test/resources/utils.go#L40-L41

This test won't call cleanups if there's a panic during the test.
https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/8cf65b5d12eb5e075b8e5ecc295c2df5576864b9/test/e2e/testsuites/dynamically_provisioned_azuredisk_detach_tester.go#L107-L109


This changes a copy of `volume` rather than the one in the struct, so this is a no-op (this feature of go `range` loops surprised me as well). I removed it because of this, and the test is running ok without it. 
https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/8cf65b5d12eb5e075b8e5ecc295c2df5576864b9/test/e2e/dynamic_provisioning_test.go#L358-L368




**Release note**:
```
none
```
