### PR TITLE
[V2] fix: fix issue where in/out param pointer was being written to, causing race condition🐞

### DIFF
--- a/pkg/azureutils/azure_disk_utils.go
+++ b/pkg/azureutils/azure_disk_utils.go
@@ -895,28 +895,30 @@ func UpdateCRIWithRetry(ctx context.Context, informerFactory azurediskInformers.
 		var objForUpdate client.Object
 		switch target := obj.(type) {
 		case *diskv1beta1.AzVolume:
+			updateTarget := &diskv1beta1.AzVolume{}
 			if informerFactory != nil {
-				target, err = informerFactory.Disk().V1beta1().AzVolumes().Lister().AzVolumes(target.Namespace).Get(objName)
+				updateTarget, err = informerFactory.Disk().V1beta1().AzVolumes().Lister().AzVolumes(target.Namespace).Get(objName)
 			} else if cachedClient != nil {
-				err = cachedClient.Get(ctx, types.NamespacedName{Namespace: target.Namespace, Name: objName}, target)
+				err = cachedClient.Get(ctx, types.NamespacedName{Namespace: target.Namespace, Name: objName}, updateTarget)
 			} else {
-				target, err = azDiskClient.DiskV1beta1().AzVolumes(target.Namespace).Get(ctx, objName, metav1.GetOptions{})
+				updateTarget, err = azDiskClient.DiskV1beta1().AzVolumes(target.Namespace).Get(ctx, objName, metav1.GetOptions{})
 			}
 			if err == nil {
-				objForUpdate = target
-				copyForUpdate = target.DeepCopy()
+				objForUpdate = updateTarget
+				copyForUpdate = updateTarget.DeepCopy()
 			}
 		case *diskv1beta1.AzVolumeAttachment:
+			updateTarget := &diskv1beta1.AzVolumeAttachment{}
 			if informerFactory != nil {
-				target, err = informerFactory.Disk().V1beta1().AzVolumeAttachments().Lister().AzVolumeAttachments(target.Namespace).Get(objName)
+				updateTarget, err = informerFactory.Disk().V1beta1().AzVolumeAttachments().Lister().AzVolumeAttachments(target.Namespace).Get(objName)
 			} else if cachedClient != nil {
-				err = cachedClient.Get(ctx, types.NamespacedName{Namespace: target.Namespace, Name: objName}, target)
+				err = cachedClient.Get(ctx, types.NamespacedName{Namespace: target.Namespace, Name: objName}, updateTarget)
 			} else {
-				target, err = azDiskClient.DiskV1beta1().AzVolumeAttachments(target.Namespace).Get(ctx, objName, metav1.GetOptions{})
+				updateTarget, err = azDiskClient.DiskV1beta1().AzVolumeAttachments(target.Namespace).Get(ctx, objName, metav1.GetOptions{})
 			}
 			if err == nil {
-				objForUpdate = target
-				copyForUpdate = target.DeepCopy()
+				objForUpdate = updateTarget
+				copyForUpdate = updateTarget.DeepCopy()
 			}
 		default:
 			return status.Errorf(codes.Internal, "object (%v) not supported.", reflect.TypeOf(target))


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind failing-test

**What this PR does / why we need it**:
This PR fixes an issue where the `TestAttachDetachReconcile` and `TestAzVolumeControllerReconcile` unit tests are failing sporadically. This occurs mostly during the macOS build, but it is easy to trigger the race condition on Linux as well (at least on my machine).

You might execute the following commands to validate the fix:
```fish
for i in (seq 1 100); /usr/local/go/bin/go test -timeout 10m -run '^TestAttachDetachReconcile$' sigs.k8s.io/azuredisk-csi-driver/pkg/controller -race -count=1; end
for i in (seq 1 100); /usr/local/go/bin/go test -timeout 10m -run '^TestAzVolumeControllerReconcile$' sigs.k8s.io/azuredisk-csi-driver/pkg/controller -race -count=1; end
```

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
This issue occurs because a pointer to `azVolumeAttachment` is passed down to the `triggerAttach` and `triggerDetach` methods.  https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/8cf65b5d12eb5e075b8e5ecc295c2df5576864b9/pkg/controller/attach_detach.go#L106-L114

These methods call `UpdateCRIWithRetry`, which uses the same pointer as a in/out parameter in a go routine:
https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/8cf65b5d12eb5e075b8e5ecc295c2df5576864b9/pkg/azureutils/azure_disk_utils.go#L913

This causes simultaneous reads/writes to the same pointer, which triggers the race condition warning in the unit test.

**Release note**:
```
none
```
