### PR TITLE
[WIP] [V2] test: Revert to Standard_DS2_v2 due to resize failures on Standard_D2s_v3

### DIFF
--- a/test/e2e/manifest/single-az.json
+++ b/test/e2e/manifest/single-az.json
@@ -30,13 +30,13 @@
         "masterProfile": {
             "count": 1,
             "dnsPrefix": "{dnsPrefix}",
-            "vmSize": "Standard_D2s_v3"
+            "vmSize": "Standard_DS2_v2"
         },
         "agentPoolProfiles": [
             {
                 "name": "agentpool1",
                 "count": 3,
-                "vmSize": "Standard_D2s_v3",
+                "vmSize": "Standard_DS2_v2",
                 "availabilityProfile": "AvailabilitySet",
                 "distro": "aks-ubuntu-18.04"
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

We have been observing the following live resize failure on the V2 driver but not on V1. The V2 driver tests are currently using Standard_D2s_v3 VMs while the V1 tests use Standard_DS2_v2. Switching the V2 VM configuration to match.

```log
May  6 21:07:49.294: INFO: At 2022-05-06 20:59:19 +0000 UTC - event for 1-azuredisk-volume-tester-qbfht-0: {external-resizer disk.csi.azure.com } VolumeResizeFailed: resize volume "pvc-d9aaaec5-14c3-4085-8ef2-0b8c7d0e698c" by resizer "disk.csi.azure.com" failed: rpc error: code = Internal desc = failed to update AzVolume CRI: rpc error: code = Internal desc = rpc error: code = Internal desc = failed to resize disk(/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/kubetest-fdcrt3id/providers/Microsoft.Compute/disks/pvc-d9aaaec5-14c3-4085-8ef2-0b8c7d0e698c) with error(Retriable: true, RetryAfter: 0s, HTTPStatusCode: -1, RawError: Code="LiveResizeStorageClientFailure" Message="Error resizing disk pvc-d9aaaec5-14c3-4085-8ef2-0b8c7d0e698c while it is attached to running VM(s) /subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/kubetest-fdcrt3id/providers/Microsoft.Compute/virtualMachines/k8s-agentpool1-16262853-1.")
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
