### PR TITLE
test: run k8s 1.24 external e2e test

### DIFF
--- a/test/external-e2e/run.sh
+++ b/test/external-e2e/run.sh
@@ -30,7 +30,7 @@ setup_e2e_binaries() {
     mkdir /tmp/csi-azuredisk
 
     # download k8s external e2e binary for kubernetes
-    curl -sL https://storage.googleapis.com/kubernetes-release/release/v1.23.5/kubernetes-test-linux-amd64.tar.gz --output e2e-tests.tar.gz
+    curl -sL https://storage.googleapis.com/kubernetes-release/release/v1.24.0/kubernetes-test-linux-amd64.tar.gz --output e2e-tests.tar.gz
     tar -xvf e2e-tests.tar.gz && rm e2e-tests.tar.gz
 
     # test on alternative driver name
@@ -54,6 +54,6 @@ setup_e2e_binaries
 trap print_logs EXIT
 
 ginkgo -p --progress --v -focus="External.Storage.*$DRIVER.csi.azure.com" \
-       -skip='\[Disruptive\]|should resize volume when PVC is edited while pod is using it|should check snapshot fields, check restore correctly works after modifying source data, check deletion' kubernetes/test/bin/e2e.test -- \
+       -skip='\[Disruptive\]|should resize volume when PVC is edited while pod is using it' kubernetes/test/bin/e2e.test -- \
        -storage.testdriver=$PROJECT_ROOT/test/external-e2e/manifest/testdriver.yaml \
        --kubeconfig=$KUBECONFIG

--- a/test/external-e2e/run.sh
+++ b/test/external-e2e/run.sh
@@ -34,7 +34,7 @@ setup_e2e_binaries() {
     tar -xvf e2e-tests.tar.gz && rm e2e-tests.tar.gz
 
     # test on alternative driver name
-    export EXTRA_HELM_OPTIONS="--set controller.disableAvailabilitySetNodes=true --set controller.replicas=1 --set driver.name=$DRIVER.csi.azure.com --set controller.name=csi-$DRIVER-controller --set linux.dsName=csi-$DRIVER-node --set windows.dsName=csi-$DRIVER-node-win --set driver.azureGoSDKLogLevel=INFO --set controller.vmssCacheTTLInSeconds=60"
+    export EXTRA_HELM_OPTIONS="--set controller.disableAvailabilitySetNodes=true --set controller.replicas=1 --set driver.name=$DRIVER.csi.azure.com --set controller.name=csi-$DRIVER-controller --set linux.dsName=csi-$DRIVER-node --set windows.dsName=csi-$DRIVER-node-win --set controller.vmssCacheTTLInSeconds=60"
     # install the azuredisk-csi-driver driver
     make e2e-bootstrap
     sed -i "s/csi-azuredisk-controller/csi-$DRIVER-controller/g" deploy/example/metrics/csi-azuredisk-controller-svc.yaml
@@ -54,6 +54,6 @@ setup_e2e_binaries
 trap print_logs EXIT
 
 ginkgo -p --progress --v -focus="External.Storage.*$DRIVER.csi.azure.com" \
-       -skip='\[Disruptive\]|should resize volume when PVC is edited while pod is using it' kubernetes/test/bin/e2e.test -- \
+       -skip='\[Disruptive\]|should resize volume when PVC is edited while pod is using it|should provision storage with any volume data source|should mount multiple PV pointing to the same storage on the same node' kubernetes/test/bin/e2e.test -- \
        -storage.testdriver=$PROJECT_ROOT/test/external-e2e/manifest/testdriver.yaml \
        --kubeconfig=$KUBECONFIG


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
test: run k8s 1.24 external e2e test

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
<details>

```
May  7 08:38:02.306: INFO: At 2022-05-07 08:32:59 +0000 UTC - event for pvc-mgxt9: {persistentvolume-controller } ProvisioningFailed: storageclass.storage.k8s.io "provisioning-8271" not found
May  7 08:38:02.306: INFO: At 2022-05-07 08:33:17 +0000 UTC - event for pod-3419fb7e-742f-44f7-998f-ad84034a3702: {kubelet k8s-agentpool1-88547994-vmss000001} FailedMount: MountVolume.SetUp failed for volume "pv-qnrsl" : rpc error: code = Internal desc = could not mount "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pv-qnrsl/globalmount" at "/var/lib/kubelet/pods/600eba78-9f98-4338-b337-4ec935cdc469/volumes/kubernetes.io~csi/pv-qnrsl/mount": mount failed: exit status 32
Mounting command: mount
Mounting arguments:  -o bind /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pv-qnrsl/globalmount /var/lib/kubelet/pods/600eba78-9f98-4338-b337-4ec935cdc469/volumes/kubernetes.io~csi/pv-qnrsl/mount
Output: mount: /var/lib/kubelet/pods/600eba78-9f98-4338-b337-4ec935cdc469/volumes/kubernetes.io~csi/pv-qnrsl/mount: special device /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pv-qnrsl/globalmount does not exist.
```

</details>

**Release note**:
```
none
```
