### PR TITLE
[V2] fix: fix issue where file is read before written in e2e tests 🐞

### DIFF
--- a/test/const/test_consts.go
+++ b/test/const/test_consts.go
@@ -81,9 +81,10 @@ const (
 	// Description that will printed during tests
 	FailedConditionDescription = "Error status code"
 
-	Poll            = 2 * time.Second
-	PollLongTimeout = 5 * time.Minute
-	PollTimeout     = 10 * time.Minute
+	Poll                 = 2 * time.Second
+	PollLongTimeout      = 5 * time.Minute
+	PollTimeout          = 10 * time.Minute
+	PollForStringTimeout = 1 * time.Minute
 
 	testTolerationKey   = "test-toleration-key"
 	testTolerationValue = "test-toleration-value"

--- a/test/e2e/testsuites/dynamically_provisioned_delete_pod_tester.go
+++ b/test/e2e/testsuites/dynamically_provisioned_delete_pod_tester.go
@@ -17,8 +17,6 @@ limitations under the License.
 package testsuites
 
 import (
-	"time"
-
 	"sigs.k8s.io/azuredisk-csi-driver/test/e2e/driver"
 	"sigs.k8s.io/azuredisk-csi-driver/test/resources"
 
@@ -55,9 +53,8 @@ func (t *DynamicallyProvisionedDeletePodTest) Run(client clientset.Interface, na
 	tDeployment.WaitForPodReady()
 
 	if t.PodCheck != nil {
-		ginkgo.By("sleep 5s and then check pod exec")
-		time.Sleep(5 * time.Second)
-		tDeployment.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString)
+		ginkgo.By("check pod exec")
+		tDeployment.PollForStringInPodsExec(t.PodCheck.Cmd, t.PodCheck.ExpectedString)
 	}
 
 	ginkgo.By("deleting the pod for deployment")
@@ -67,9 +64,8 @@ func (t *DynamicallyProvisionedDeletePodTest) Run(client clientset.Interface, na
 	tDeployment.WaitForPodReady()
 
 	if t.PodCheck != nil {
-		ginkgo.By("sleep 5s and then check pod exec after pod restart again")
-		time.Sleep(5 * time.Second)
+		ginkgo.By("check pod exec after pod restart again")
 		// pod will be restarted so expect to see 2 instances of string
-		tDeployment.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString+t.PodCheck.ExpectedString)
+		tDeployment.PollForStringInPodsExec(t.PodCheck.Cmd, t.PodCheck.ExpectedString+t.PodCheck.ExpectedString)
 	}
 }

--- a/test/e2e/testsuites/dynamically_provisioned_pod_failover_tester.go
+++ b/test/e2e/testsuites/dynamically_provisioned_pod_failover_tester.go
@@ -17,8 +17,6 @@ limitations under the License.
 package testsuites
 
 import (
-	"time"
-
 	"github.com/onsi/ginkgo"
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -58,9 +56,8 @@ func (t *PodFailover) Run(client clientset.Interface, namespace *v1.Namespace, s
 	tDeployment.WaitForPodReady()
 
 	if t.PodCheck != nil {
-		ginkgo.By("sleep 3s and then check pod exec")
-		time.Sleep(3 * time.Second)
-		tDeployment.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString)
+		ginkgo.By("check pod exec")
+		tDeployment.PollForStringInPodsExec(t.PodCheck.Cmd, t.PodCheck.ExpectedString)
 	}
 
 	ginkgo.By("cordoning node 0")
@@ -80,9 +77,8 @@ func (t *PodFailover) Run(client clientset.Interface, namespace *v1.Namespace, s
 	tDeployment.WaitForPodReady()
 
 	if t.PodCheck != nil {
-		ginkgo.By("sleep 3s and then check pod exec")
-		time.Sleep(3 * time.Second)
+		ginkgo.By("check pod exec")
 		// pod will be restarted so expect to see 2 instances of string
-		tDeployment.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString+t.PodCheck.ExpectedString)
+		tDeployment.PollForStringInPodsExec(t.PodCheck.Cmd, t.PodCheck.ExpectedString+t.PodCheck.ExpectedString)
 	}
 }

--- a/test/e2e/testsuites/dynamically_provisioned_pod_failover_with_replicas_tester.go
+++ b/test/e2e/testsuites/dynamically_provisioned_pod_failover_with_replicas_tester.go
@@ -71,9 +71,8 @@ func (t *PodFailoverWithReplicas) Run(client clientset.Interface, namespace *v1.
 	tDeployment.WaitForPodReady()
 
 	if t.PodCheck != nil {
-		ginkgo.By("sleep 3s and then check pod exec")
-		time.Sleep(3 * time.Second)
-		tDeployment.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString)
+		ginkgo.By("check pod exec")
+		tDeployment.PollForStringInPodsExec(t.PodCheck.Cmd, t.PodCheck.ExpectedString)
 	}
 
 	//Check that AzVolumeAttachment resources were created correctly
@@ -144,10 +143,9 @@ func (t *PodFailoverWithReplicas) Run(client clientset.Interface, namespace *v1.
 	tDeployment.WaitForPodReady()
 
 	if t.PodCheck != nil {
-		ginkgo.By("sleep 3s and then check pod exec")
-		time.Sleep(3 * time.Second)
+		ginkgo.By("check pod exec")
 		// pod will be restarted so expect to see 2 instances of string
-		tDeployment.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString+t.PodCheck.ExpectedString)
+		tDeployment.PollForStringInPodsExec(t.PodCheck.Cmd, t.PodCheck.ExpectedString+t.PodCheck.ExpectedString)
 	}
 
 	ginkgo.By("Verifying that pod got created on the correct node.")

--- a/test/e2e/testsuites/dynamically_provisioned_shared_disk_tester.go
+++ b/test/e2e/testsuites/dynamically_provisioned_shared_disk_tester.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -66,9 +65,8 @@ func (t *DynamicallyProvisionedSharedDiskTester) Run(client clientset.Interface,
 	tDeployment.WaitForPodReady()
 
 	if t.PodCheck != nil {
-		ginkgo.By("sleep 5s and then check pod exec")
-		time.Sleep(5 * time.Second)
-		tDeployment.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString)
+		ginkgo.By("check pod exec")
+		tDeployment.PollForStringInPodsExec(t.PodCheck.Cmd, t.PodCheck.ExpectedString)
 	}
 
 	ginkgo.By("verifying shared attachment")

--- a/test/e2e/testsuites/dynamically_provisioned_statefulset_e2e_tester.go
+++ b/test/e2e/testsuites/dynamically_provisioned_statefulset_e2e_tester.go
@@ -51,9 +51,8 @@ func (t *DynamicallyProvisionedStatefulSetTest) Run(client clientset.Interface, 
 	framework.ExpectNoError(err)
 
 	if t.PodCheck != nil {
-		ginkgo.By("sleep 5s and then check pod exec")
-		time.Sleep(5 * time.Second)
-		tStatefulSet.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString)
+		ginkgo.By("check pod exec")
+		tStatefulSet.PollForStringInPodsExec(t.PodCheck.Cmd, t.PodCheck.ExpectedString)
 	}
 
 	ginkgo.By("deleting the pod for statefulset")
@@ -64,9 +63,8 @@ func (t *DynamicallyProvisionedStatefulSetTest) Run(client clientset.Interface, 
 	framework.ExpectNoError(err)
 
 	if t.PodCheck != nil {
-		ginkgo.By("sleep 5s and then check pod exec after pod restart again")
-		time.Sleep(5 * time.Second)
+		ginkgo.By("check pod exec after pod restart again")
 		// pod will be restarted so expect to see 2 instances of string
-		tStatefulSet.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString+t.PodCheck.ExpectedString)
+		tStatefulSet.PollForStringInPodsExec(t.PodCheck.Cmd, t.PodCheck.ExpectedString+t.PodCheck.ExpectedString)
 	}
 }

--- a/test/e2e/testsuites/pre_provisioned_shared_disk_tester.go
+++ b/test/e2e/testsuites/pre_provisioned_shared_disk_tester.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -66,9 +65,8 @@ func (t *PreProvisionedSharedDiskTester) Run(client clientset.Interface, namespa
 	tDeployment.WaitForPodReady()
 
 	if t.PodCheck != nil {
-		ginkgo.By("sleep 5s and then check pod exec")
-		time.Sleep(5 * time.Second)
-		tDeployment.Exec(t.PodCheck.Cmd, t.PodCheck.ExpectedString)
+		ginkgo.By("check pod exec")
+		tDeployment.PollForStringInPodsExec(t.PodCheck.Cmd, t.PodCheck.ExpectedString)
 	}
 
 	ginkgo.By("verifying shared attachment")

--- a/test/resources/deployment.go
+++ b/test/resources/deployment.go
@@ -173,11 +173,16 @@ func (t *TestDeployment) WaitForPodReady() {
 	}
 }
 
-func (t *TestDeployment) Exec(command []string, expectedString string) {
-	for _, pod := range t.Pods {
-		_, err := framework.LookForStringInPodExec(t.Namespace.Name, pod.Name, command, expectedString, testconsts.ExecTimeout)
-		framework.ExpectNoError(err)
+func (t *TestDeployment) podNames() []string {
+	names := make([]string, 0, len(t.Pods))
+	for _, podDetails := range t.Pods {
+		names = append(names, podDetails.Name)
 	}
+	return names
+}
+
+func (t *TestDeployment) PollForStringInPodsExec(command []string, expectedString string) {
+	pollForStringInPodsExec(t.Namespace.Name, t.podNames(), command, expectedString)
 }
 
 func (t *TestDeployment) DeletePodAndWait() {

--- a/test/resources/statefulset.go
+++ b/test/resources/statefulset.go
@@ -182,11 +182,8 @@ func (t *TestStatefulset) WaitForPodReadyOrFail() error {
 	return err
 }
 
-func (t *TestStatefulset) Exec(command []string, expectedString string) {
-	for _, podName := range t.PodNames {
-		_, err := framework.LookForStringInPodExec(t.Namespace.Name, podName, command, expectedString, testconsts.ExecTimeout)
-		framework.ExpectNoError(err)
-	}
+func (t *TestStatefulset) PollForStringInPodsExec(command []string, expectedString string) {
+	pollForStringInPodsExec(t.Namespace.Name, t.PodNames, command, expectedString)
 }
 
 func (t *TestStatefulset) DeletePodAndWait() {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind flake

**What this PR does / why we need it**:
This change fixes a test issue in the several e2e tests, where we are looking for a file in pods to contain a certain string. The `framework.LookForStringInPodExec` method fails the test automatically if the command executed has a non-zero exit code. This can happen if the pod has not completed writing to the file. 

There are some additional methods like `framework.RunHostCmd` that we might consider using, but these assume the pod is running Linux. Because of this, I decided to roll our own method.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
I changed name from `Exec` => `PollForStringInPodsExec` to make it clearer that the command passed in will be executed multiple times.

There is some duplicated code in `test/resources/deployment.go` and `test/resources/statefulset.go`, but I think it is better to do this in a separate PR if we want to refactor that. 

Fixes e2e test failure symptoms similar to this:
```
{ Failure /home/prow/go/src/sigs.k8s.io/azuredisk-csi-driver/test/e2e/dynamic_provisioning_test.go:436
Unexpected error:
    <exec.CodeExitError>: {
        Err: <*errors.errorString | 0xc0000a3740>{
            s: "error running /usr/local/bin/kubectl --server=https://kubetest-wuw9nwbh.westus2.cloudapp.azure.com --kubeconfig=/root/tmp1662410290/kubeconfig/kubeconfig.westus2.json --namespace=azuredisk-4663 exec azuredisk-volume-tester-p797m-6495d86c45-74zxb --namespace=azuredisk-4663 -- cmd /c type C:\\mnt\\test-1\\data.txt:\nCommand stdout:\n\nstderr:\nThe system cannot find the file specified.\r\ncommand terminated with exit code 1\n\nerror:\nexit status 1",
        },
        Code: 1,
    }
    error running /usr/local/bin/kubectl --server=https://kubetest-wuw9nwbh.westus2.cloudapp.azure.com --kubeconfig=/root/tmp1662410290/kubeconfig/kubeconfig.westus2.json --namespace=azuredisk-4663 exec azuredisk-volume-tester-p797m-6495d86c45-74zxb --namespace=azuredisk-4663 -- cmd /c type C:\mnt\test-1\data.txt:
    Command stdout:
    
    stderr:
    The system cannot find the file specified.
    command terminated with exit code 1
    
    error:
    exit status 1
occurred
/home/prow/go/src/sigs.k8s.io/azuredisk-csi-driver/vendor/k8s.io/kubernetes/test/e2e/framework/util.go:603}
```

**Release note**:
```
none
```
