### PR TITLE
[V2] fix: cache data loss issue on Windows when unmount disk

### DIFF
--- a/pkg/azuredisk/azure_common_windows.go
+++ b/pkg/azuredisk/azure_common_windows.go
@@ -81,9 +81,10 @@ func preparePublishPath(path string, m *mount.SafeFormatAndMount) error {
 }
 
 func CleanupMountPoint(path string, m *mount.SafeFormatAndMount, extensiveCheck bool) error {
-	// CSI proxy alpha does not support fixing the corrupted directory. So we will
-	// just do the unmount for now.
-	return m.Unmount(path)
+	if proxy, ok := m.Interface.(mounter.CSIProxyMounter); ok {
+		return proxy.Unmount(path)
+	}
+	return fmt.Errorf("could not cast to csi proxy class")
 }
 
 func getDevicePathWithMountPath(mountPath string, m *mount.SafeFormatAndMount) (string, error) {

--- a/pkg/provisioner/nodeprovisioner_windows.go
+++ b/pkg/provisioner/nodeprovisioner_windows.go
@@ -83,11 +83,10 @@ func (p *NodeProvisioner) PreparePublishPath(path string) error {
 
 // CleanupMountPoint unmounts the given path and deletes the remaining directory if successful.
 func (p *NodeProvisioner) CleanupMountPoint(path string, extensiveCheck bool) error {
-	// TODO - Is this OS-specific code needed anymore?
-
-	// CSI proxy alpha does not support fixing the corrupted directory. So we will
-	// just do the unmount for now.
-	return p.mounter.Unmount(path)
+	if proxy, ok := p.mounter.Interface.(mounter.CSIProxyMounter); ok {
+		return proxy.Unmount(path)
+	}
+	return fmt.Errorf("could not cast to csi proxy class")
 }
 
 // RescanVolume forces a re-read of a disk's partition table.

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -1525,7 +1525,6 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 	ginkgo.It("Should test pod failover with cordoning a node using ZRS", func() {
 		testutil.SkipIfUsingInTreeVolumePlugin()
 		testutil.SkipIfNotZRSSupported(location)
-		testutil.SkipIfTestingInWindowsCluster()
 
 		volume := resources.VolumeDetails{
 			ClaimSize: "10Gi",
@@ -1581,9 +1580,6 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool, schedulerNa
 			testutil.SkipIfNotZRSSupported(location)
 			skuName = "StandardSSD_ZRS"
 		}
-
-		// BUG: Issue #1349 Test case currently fails on Windows
-		testutil.SkipIfTestingInWindowsCluster()
 
 		azDiskClient, err := azDiskClientSet.NewForConfig(f.ClientConfig())
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

1. Ensures the volume cache is flushed to disk during unmount. (Merge of #1350 from master.)
2. Re-enable pod failover tests on Windows to debug failures.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #1349 

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
