### PR TITLE
[V2] fix: Fix CRI update on error recovery

### DIFF
--- a/pkg/controller/azvolume.go
+++ b/pkg/controller/azvolume.go
@@ -197,8 +197,8 @@ func (r *ReconcileAzVolume) triggerCreate(ctx context.Context, azVolume *azdiskv
 			}
 		}
 
-		// UpdateCRIWithRetry should be called on a context w/o timeout when called in a separate goroutine as it is not going to be retriggered and leave the CRI in unrecoverable transient state instead.
-		_ = azureutils.UpdateCRIWithRetry(goCtx, nil, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, azVolume, updateFunc, consts.ForcedUpdateMaxNetRetry, updateMode)
+		//nolint:contextcheck // final status update of the CRI must occur even when the current context's deadline passes.
+		_ = azureutils.UpdateCRIWithRetry(context.Background(), nil, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, azVolume, updateFunc, consts.ForcedUpdateMaxNetRetry, updateMode)
 	}()
 
 	// wait for the workflow in goroutine to be created
@@ -350,8 +350,8 @@ func (r *ReconcileAzVolume) triggerDelete(ctx context.Context, azVolume *azdiskv
 				}
 			}
 
-			// UpdateCRIWithRetry should be called on a context w/o timeout when called in a separate goroutine as it is not going to be retriggered and leave the CRI in unrecoverable transient state instead.
-			_ = azureutils.UpdateCRIWithRetry(goCtx, nil, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, azVolume, updateFunc, consts.ForcedUpdateMaxNetRetry, updateMode)
+			//nolint:contextcheck // final status update of the CRI must occur even when the current context's deadline passes.
+			_ = azureutils.UpdateCRIWithRetry(context.Background(), nil, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, azVolume, updateFunc, consts.ForcedUpdateMaxNetRetry, updateMode)
 		}()
 		<-waitCh
 	} else {
@@ -422,8 +422,8 @@ func (r *ReconcileAzVolume) triggerUpdate(ctx context.Context, azVolume *azdiskv
 			}
 		}
 
-		// UpdateCRIWithRetry should be called on a context w/o timeout when called in a separate goroutine as it is not going to be retriggered and leave the CRI in unrecoverable transient state instead.
-		_ = azureutils.UpdateCRIWithRetry(goCtx, nil, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, azVolume, updateFunc, consts.ForcedUpdateMaxNetRetry, azureutils.UpdateCRIStatus)
+		//nolint:contextcheck // final status update of the CRI must occur even when the current context's deadline passes.
+		_ = azureutils.UpdateCRIWithRetry(context.Background(), nil, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, azVolume, updateFunc, consts.ForcedUpdateMaxNetRetry, azureutils.UpdateCRIStatus)
 	}()
 	<-waitCh
 

--- a/pkg/controller/azvolume.go
+++ b/pkg/controller/azvolume.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/workflow"
 
 	consts "sigs.k8s.io/azuredisk-csi-driver/pkg/azureconstants"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -145,7 +146,7 @@ func (r *ReconcileAzVolume) triggerCreate(ctx context.Context, azVolume *azdiskv
 	}
 
 	// update state
-	updateFunc := func(obj interface{}) error {
+	updateFunc := func(obj client.Object) error {
 		azv := obj.(*azdiskv1beta2.AzVolume)
 		_, err := r.updateState(azv, azdiskv1beta2.VolumeCreating, normalUpdate)
 		return err
@@ -169,12 +170,12 @@ func (r *ReconcileAzVolume) triggerCreate(ctx context.Context, azVolume *azdiskv
 		cloudCtx, cloudCancel := context.WithTimeout(goCtx, cloudTimeout)
 		defer cloudCancel()
 
-		var updateFunc func(interface{}) error
+		var updateFunc azureutils.UpdateCRIFunc
 		var response *azdiskv1beta2.AzVolumeStatusDetail
 		response, createErr = r.createVolume(cloudCtx, azVolume)
 		updateMode := azureutils.UpdateCRIStatus
 		if createErr != nil {
-			updateFunc = func(obj interface{}) error {
+			updateFunc = func(obj client.Object) error {
 				azv := obj.(*azdiskv1beta2.AzVolume)
 				azv = r.updateError(azv, createErr)
 				azv = r.deleteFinalizer(azv, map[string]bool{consts.AzVolumeFinalizer: true})
@@ -185,7 +186,7 @@ func (r *ReconcileAzVolume) triggerCreate(ctx context.Context, azVolume *azdiskv
 		} else {
 			// create operation queue for the volume
 			r.controllerSharedState.createOperationQueue(azVolume.Name)
-			updateFunc = func(obj interface{}) error {
+			updateFunc = func(obj client.Object) error {
 				azv := obj.(*azdiskv1beta2.AzVolume)
 				if response == nil {
 					return status.Errorf(codes.Internal, "non-nil AzVolumeStatusDetail expected but nil given")
@@ -235,7 +236,7 @@ func (r *ReconcileAzVolume) triggerDelete(ctx context.Context, azVolume *azdiskv
 		if _, ok := r.stateLock.LoadOrStore(azVolume.Name, nil); ok {
 			return getOperationRequeueError("delete", azVolume)
 		}
-		updateFunc := func(obj interface{}) error {
+		updateFunc := func(obj client.Object) error {
 			azv := obj.(*azdiskv1beta2.AzVolume)
 			_, derr := r.updateState(azv, azdiskv1beta2.VolumeDeleting, normalUpdate)
 			return derr
@@ -269,7 +270,7 @@ func (r *ReconcileAzVolume) triggerDelete(ctx context.Context, azVolume *azdiskv
 				return derr
 			}
 
-			var updateFunc func(interface{}) error
+			var updateFunc azureutils.UpdateCRIFunc
 			var err error
 			updateMode := azureutils.UpdateCRIStatus
 
@@ -277,7 +278,7 @@ func (r *ReconcileAzVolume) triggerDelete(ctx context.Context, azVolume *azdiskv
 			var attachments []azdiskv1beta2.AzVolumeAttachment
 			attachments, err = r.controllerSharedState.cleanUpAzVolumeAttachmentByVolume(deleteCtx, azVolume.Name, azvolume, all, mode)
 			if err != nil {
-				updateFunc = func(obj interface{}) error {
+				updateFunc = func(obj client.Object) error {
 					return reportError(obj, err)
 				}
 			} else {
@@ -289,7 +290,7 @@ func (r *ReconcileAzVolume) triggerDelete(ctx context.Context, azVolume *azdiskv
 				for i, attachment := range attachments {
 					waiter, err := r.controllerSharedState.conditionWatcher.NewConditionWaiter(deleteCtx, watcher.AzVolumeAttachmentType, attachment.Name, verifyObjectDeleted)
 					if err != nil {
-						updateFunc = func(obj interface{}) error {
+						updateFunc = func(obj client.Object) error {
 							return reportError(obj, err)
 						}
 						break
@@ -319,7 +320,7 @@ func (r *ReconcileAzVolume) triggerDelete(ctx context.Context, azVolume *azdiskv
 						}
 					}
 					err = status.Errorf(codes.Internal, strings.Join(errMsgs, ", "))
-					updateFunc = func(obj interface{}) error {
+					updateFunc = func(obj client.Object) error {
 						return reportError(obj, err)
 					}
 				}
@@ -333,7 +334,7 @@ func (r *ReconcileAzVolume) triggerDelete(ctx context.Context, azVolume *azdiskv
 					deleteErr = r.deleteVolume(cloudCtx, azVolume)
 				}
 				if deleteErr != nil {
-					updateFunc = func(obj interface{}) error {
+					updateFunc = func(obj client.Object) error {
 						azv := obj.(*azdiskv1beta2.AzVolume)
 						azv = r.updateError(azv, deleteErr)
 						_, derr := r.updateState(azv, azdiskv1beta2.VolumeDeletionFailed, forceUpdate)
@@ -341,7 +342,7 @@ func (r *ReconcileAzVolume) triggerDelete(ctx context.Context, azVolume *azdiskv
 					}
 				} else {
 					updateMode = azureutils.UpdateAll
-					updateFunc = func(obj interface{}) error {
+					updateFunc = func(obj client.Object) error {
 						azv := obj.(*azdiskv1beta2.AzVolume)
 						_ = r.deleteFinalizer(azv, map[string]bool{consts.AzVolumeFinalizer: true})
 						return nil
@@ -354,7 +355,7 @@ func (r *ReconcileAzVolume) triggerDelete(ctx context.Context, azVolume *azdiskv
 		}()
 		<-waitCh
 	} else {
-		updateFunc := func(obj interface{}) error {
+		updateFunc := func(obj client.Object) error {
 			azv := obj.(*azdiskv1beta2.AzVolume)
 			_ = r.deleteFinalizer(azv, map[string]bool{consts.AzVolumeFinalizer: true})
 			return nil
@@ -377,7 +378,7 @@ func (r *ReconcileAzVolume) triggerUpdate(ctx context.Context, azVolume *azdiskv
 		err = getOperationRequeueError("update", azVolume)
 		return err
 	}
-	updateFunc := func(obj interface{}) error {
+	updateFunc := func(obj client.Object) error {
 		azv := obj.(*azdiskv1beta2.AzVolume)
 		_, derr := r.updateState(azv, azdiskv1beta2.VolumeUpdating, normalUpdate)
 		return derr
@@ -399,18 +400,18 @@ func (r *ReconcileAzVolume) triggerUpdate(ctx context.Context, azVolume *azdiskv
 		cloudCtx, cloudCancel := context.WithTimeout(goCtx, cloudTimeout)
 		defer cloudCancel()
 
-		var updateFunc func(interface{}) error
+		var updateFunc azureutils.UpdateCRIFunc
 		var response *azdiskv1beta2.AzVolumeStatusDetail
 		response, updateErr = r.expandVolume(cloudCtx, azVolume)
 		if updateErr != nil {
-			updateFunc = func(obj interface{}) error {
+			updateFunc = func(obj client.Object) error {
 				azv := obj.(*azdiskv1beta2.AzVolume)
 				azv = r.updateError(azv, updateErr)
 				_, derr := r.updateState(azv, azdiskv1beta2.VolumeUpdateFailed, forceUpdate)
 				return derr
 			}
 		} else {
-			updateFunc = func(obj interface{}) error {
+			updateFunc = func(obj client.Object) error {
 				azv := obj.(*azdiskv1beta2.AzVolume)
 				if response == nil {
 					return status.Errorf(codes.Internal, "non-nil AzVolumeStatusDetail expected but nil given")
@@ -555,7 +556,7 @@ func (r *ReconcileAzVolume) recoverAzVolume(ctx context.Context, recoveredAzVolu
 		go func(azv azdiskv1beta2.AzVolume, azvMap *sync.Map) {
 			defer wg.Done()
 			var targetState azdiskv1beta2.AzVolumeState
-			updateFunc := func(obj interface{}) error {
+			updateFunc := func(obj client.Object) error {
 				var err error
 				azv := obj.(*azdiskv1beta2.AzVolume)
 				// add a recover annotation to the CRI so that reconciliation can be triggered for the CRI even if CRI's current state == target state

--- a/pkg/controller/replica.go
+++ b/pkg/controller/replica.go
@@ -92,7 +92,7 @@ func (r *ReconcileReplica) Reconcile(ctx context.Context, request reconcile.Requ
 		if objectDeletionRequested(azVolumeAttachment) {
 			switch azVolumeAttachment.Status.State {
 			case azdiskv1beta2.DetachmentFailed:
-				if err := azureutils.UpdateCRIWithRetry(ctx, nil, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, azVolumeAttachment, func(obj interface{}) error {
+				if err := azureutils.UpdateCRIWithRetry(ctx, nil, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, azVolumeAttachment, func(obj client.Object) error {
 					azVolumeAttachment := obj.(*azdiskv1beta2.AzVolumeAttachment)
 					_, err = updateState(azVolumeAttachment, azdiskv1beta2.ForceDetachPending, normalUpdate)
 					return err

--- a/pkg/controller/volumeattachment.go
+++ b/pkg/controller/volumeattachment.go
@@ -30,6 +30,7 @@ import (
 
 	azdiskv1beta2 "sigs.k8s.io/azuredisk-csi-driver/pkg/apis/azuredisk/v1beta2"
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/azureutils"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -90,7 +91,7 @@ func (r *ReconcileVolumeAttachment) Reconcile(ctx context.Context, request recon
 		return reconcileReturnOnError(ctx, &volumeAttachment, "get azvolumeattachment", err, r.controllerRetryInfo)
 	}
 
-	updateFunc := func(obj interface{}) error {
+	updateFunc := func(obj client.Object) error {
 		azv := obj.(*azdiskv1beta2.AzVolumeAttachment)
 		// Update the annotation of AzVolumeAttachment with volumeAttachment name
 		azv.Status.Annotations = azureutils.AddToMap(azv.Status.Annotations, consts.VolumeAttachmentKey, volumeAttachment.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind regression

**What this PR does / why we need it**:

1. Improves type safety of `azureutils.UpdateCRIWithRetry` and fix usage of `azureutils.AppendUpdateFunc` so that update functions are chained correctly. Update function chains are used on the operation error recovery path. The previous implementation wasn't chaining correctly and prevented retries of failed operations from succeeded.
2. Ensures the final CRI status update occurs when the operation context is cancelled, or its deadline is exceeded.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
