### PR TITLE
flake: pod affinity test needs to wait long for pods on Windows

### DIFF
--- a/test/e2e/testsuites/dynamically_provisioned_pod_affinity.go
+++ b/test/e2e/testsuites/dynamically_provisioned_pod_affinity.go
@@ -98,7 +98,12 @@ func (t *PodAffinity) Run(client clientset.Interface, namespace *v1.Namespace, s
 		tpod.Create()
 		defer tpod.Cleanup()
 		ginkgo.By("checking that the pod is running")
-		tpod.WaitForRunning()
+		if !t.Pods[0].IsWindows {
+			tpod.WaitForRunning()
+		} else {
+			// For some reason Windows CAP-Z clusters can take more than 5 minutes to pull the ServerCore image - wait long
+			tpod.WaitForRunningLong()
+		}
 
 		klog.Infof("volumes: %+v", pod.Spec.Volumes)
 		diskNames := make([]string, len(pod.Spec.Volumes))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind test
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

The pod affinity test needs to wait longer for pod startup because Windows CAP-Z clusters can take more than 5 minutes to pull the image.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
