### PR TITLE
[V2] [WIP] feat: add rate limiter latency metric to find throttling

### DIFF
--- a/vendor/sigs.k8s.io/controller-runtime/pkg/metrics/client_go_adapter.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/metrics/client_go_adapter.go
@@ -82,6 +82,22 @@ var (
 		Help:      "Number of HTTP requests, partitioned by status code, method, and host.",
 	}, []string{"code", "method", "host"})
 
+	// client metrics. 
+
+	// TODO: double check implementation
+	RateLimiterLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem:	RestClientSubsystem,
+		Name:		LatencyKey, 
+		Help:		"Rate limiter latency in seconds. Broken down by verb and URL.",
+		Buckets:	prometheus.ExponentialBuckets(0.001, 2, 10),
+	}, []string{"verb", "url"})
+
+	rateLimiterResult = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem:	RestClientSubsystem,
+		Name:		ResultKey,
+		Help: 		"Number of HTTP requests, partitioned by status code, method, and host.",
+	}, []string{"code", "method", "host"})
+
 	// reflector metrics.
 
 	// TODO(directxman12): update these to be histograms once the metrics overhaul KEP
@@ -145,10 +161,12 @@ func init() {
 func registerClientMetrics() {
 	// register the metrics with our registry
 	Registry.MustRegister(requestResult)
+	Registry.MustRegister(rateLimiterResult)
 
 	// register the metrics with client-go
 	clientmetrics.Register(clientmetrics.RegisterOpts{
 		RequestResult: &resultAdapter{metric: requestResult},
+		RateLimiterResult: &resultAdapter{metrics: rateLimiterResult},
 	})
 }
 

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/metrics/client_go_adapter.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/metrics/client_go_adapter.go
@@ -82,21 +82,15 @@ var (
 		Help:      "Number of HTTP requests, partitioned by status code, method, and host.",
 	}, []string{"code", "method", "host"})
 
-	// client metrics. 
+	// client metrics.
 
 	// TODO: double check implementation
 	RateLimiterLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Subsystem:	RestClientSubsystem,
-		Name:		LatencyKey, 
-		Help:		"Rate limiter latency in seconds. Broken down by verb and URL.",
-		Buckets:	prometheus.ExponentialBuckets(0.001, 2, 10),
+		Subsystem: RestClientSubsystem,
+		Name:      LatencyKey,
+		Help:      "Rate limiter latency in seconds. Broken down by verb and URL.",
+		Buckets:   prometheus.ExponentialBuckets(0.001, 2, 10),
 	}, []string{"verb", "url"})
-
-	rateLimiterResult = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Subsystem:	RestClientSubsystem,
-		Name:		ResultKey,
-		Help: 		"Number of HTTP requests, partitioned by status code, method, and host.",
-	}, []string{"code", "method", "host"})
 
 	// reflector metrics.
 
@@ -161,12 +155,12 @@ func init() {
 func registerClientMetrics() {
 	// register the metrics with our registry
 	Registry.MustRegister(requestResult)
-	Registry.MustRegister(rateLimiterResult)
+	Registry.MustRegister(RateLimiterLatency)
 
 	// register the metrics with client-go
 	clientmetrics.Register(clientmetrics.RegisterOpts{
-		RequestResult: &resultAdapter{metric: requestResult},
-		RateLimiterResult: &resultAdapter{metrics: rateLimiterResult},
+		RequestResult:      &resultAdapter{metric: requestResult},
+		RateLimiterLatency: &LatencyAdapter{metric: RateLimiterLatency},
 	})
 }
 


### PR DESCRIPTION
**What type of PR is this?**

**What this PR does / why we need it:**

- The `RateLimiterLatency` metric creates a new `HistogramVec` Prometheus metric to measure throttling in the driver
- Uses the metric library in client-go to enable and register the new metric

**Which issue(s) this PR fixes:**

Fixes #

**Requirements:**

- [ ]  uses [conventional commit messages](https://www.conventionalcommits.org/)

- [ ]  includes documentation

- [ ]  adds unit tests

- [ ]  tested upgrade from previous version

**Special notes for your reviewer:

Release note:**