### PR TITLE
chore: add node-role.kubernetes.io/control-plane to csi-snapshot-controller

### DIFF
--- a/deploy/csi-snapshot-controller.yaml
+++ b/deploy/csi-snapshot-controller.yaml
@@ -27,6 +27,10 @@ spec:
           operator: "Equal"
           value: "true"
           effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Equal"
+          value: "true"
+          effect: "NoSchedule"
       containers:
         - name: csi-snapshot-controller
           image: mcr.microsoft.com/oss/kubernetes-csi/snapshot-controller:v5.0.1


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

As per [KEP 2067](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md), `node-role.kubernetes.io/master` taint is replaced with `node-role.kubernetes.io/control-plane`. However, the csi-snapshot-controller is using `node-role.kubernetes.io/controlplane` toleration (note that `controlplane` doesn't have a period). This PR proposes a fix for this issue by adding a new `node-role.kubernetes.io/control-plane` toleration while keeping the old one because of backward compatibility.

**Which issue(s) this PR fixes**:
None

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

This PR updates only "template" manifests. Should we also update manifests for existing releases?

**Release note**:
```
none
```