### PR TITLE
[V2] test: add junit test output to scale test 🔧

### DIFF
--- a/test/scale/scale_test.go
+++ b/test/scale/scale_test.go
@@ -19,10 +19,12 @@ package scale
 import (
 	"context"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
 	"github.com/onsi/gomega"
 	"k8s.io/kubernetes/test/e2e/framework"
 	testconsts "sigs.k8s.io/azuredisk-csi-driver/test/const"
@@ -133,5 +135,10 @@ var _ = ginkgo.AfterSuite(func() {
 
 func TestScale(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "AzureDisk CSI Driver Scale Tests")
+	reportDir := os.Getenv(testconsts.ReportDirEnvVar)
+	if reportDir == "" {
+		reportDir = testconsts.DefaultReportDir
+	}
+	r := []ginkgo.Reporter{reporters.NewJUnitReporter(path.Join(reportDir, "junit_01.xml"))}
+	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "AzureDisk CSI Driver Scale Tests", r)
 }


### PR DESCRIPTION
**What type of PR is this?**
In order to show test output for the scale test in Azure Dev Ops, I need a JUnit XML file output. The E2E tests currently write a JUnit XML file in a similar way.

/kind test

**What this PR does / why we need it**:
I read the report directory (ARTIFACTS environment variable) and write out a junit_01.xml file. This is similar to the use of the JUnit reporter in the e2e tests. 

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
