### PR TITLE
[V2] chore: add BYO storage class for pod-failover tests

### DIFF
--- a/test/podFailover/automation-run.yaml
+++ b/test/podFailover/automation-run.yaml
@@ -76,4 +76,5 @@ spec:
         - "--test-name=$(TEST_NAME)"
         - "--auth-enabled=$(AUTH_ENABLED)"
         - "--all-pods-on-one-node=$(BOOL_ALL_PODS_ON_SAME_NODE)"
+        - "--storage-class-name=$(STORAGE_CLASS_NAME)"
       restartPolicy: Never

--- a/test/podFailover/controller/main.go
+++ b/test/podFailover/controller/main.go
@@ -64,6 +64,7 @@ var (
 	delayBeforeFailover    = flag.Int("delay-before-failover", 0, "Time in seconds for which the controller should wait before failing the pod")
 	deployAllPodsOnOneNode = flag.Bool("all-pods-on-one-node", false, "Specify whether to deploy all the pods on the same node")
 	testName               = flag.String("test-name", "default-test-run", "The name of the test to be used as metrics label to distinguish metrics sent from multiple test runs")
+	storageClassName       = flag.String("storage-class-name", "", "Name of storage class if provisioning beforehand")
 )
 
 func main() {
@@ -89,10 +90,15 @@ func main() {
 	if deleteNamespace {
 		defer deleteTestNamespace(ctx, clientset)
 	}
-	scName, err := createStorageClass(ctx, clientset, *maxShares)
-	if err != nil {
-		klog.Errorf("Error occurred while creating storageClass: %v", err)
-		return
+	var scName string
+	if *storageClassName != "" {
+		scName = *storageClassName
+	} else {
+		scName, err = createStorageClass(ctx, clientset, *maxShares)
+		if err != nil {
+			klog.Errorf("Error occurred while creating storageClass: %v", err)
+			return
+		}
 	}
 	defer deleteStorageClass(ctx, clientset, scName)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind test


**What this PR does / why we need it**:

adding the ability to use a pre-created storage class in pod-failover tests
to widen the platforms that can be tested by the pod-failover tests

For example adding the ability to BYO storage class allows testing to be done
on AzDisk and AzStor without having to build many different images

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
