### PR TITLE
[V2] chore: Add ability to point at different image for servercore 🔧

### DIFF
--- a/pkg/azurediskplugin/Windows.Dockerfile
+++ b/pkg/azurediskplugin/Windows.Dockerfile
@@ -1,7 +1,8 @@
 ARG ARCH=amd64
 ARG OSVERSION
-FROM --platform=linux/${ARCH} gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-${ARCH}-${OSVERSION} as core
-
+ARG SERVERCORE_IMAGE=gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-${ARCH}-${OSVERSION}
+ARG SERVERCORE_PLATFORM=linux/${ARCH}
+FROM --platform=${SERVERCORE_PLATFORM} ${SERVERCORE_IMAGE} as core
 FROM mcr.microsoft.com/windows/nanoserver:${OSVERSION}
 COPY --from=core /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently, we depend on "cached" version servercore from the GCR to build the driver image for Windows. Most Go programs require only the binaries from nanoserver, but also one binary (NetApi32) from servercore. "servercore" is very large, so we pull from the "cached" version to speed up builds. This cached version is built by the kubernetes repo for the linux/amd64 and linux/arm64 platforms.

However, in ADO, we are only able to pull from MCR images. In order to provide this functionality while preserving the speedup from using the servercore-cache outside of ADO, I added the `SERVERCORE_IMAGE` and `SERVERCORE_PLATFORM` build-args to let me set `SERVERCORE_PLATFORM=windows/amd64` and `SERVERCORE_IMAGE=mcr.microsoft.com/windows/servercore`.


**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
