### PR TITLE
[V2] chore: Move SharedState struct and related functions to shared_state.go

### DIFF
--- a/pkg/controller/attach_detach.go
+++ b/pkg/controller/attach_detach.go
@@ -63,12 +63,12 @@ Attach Detach controller is responsible for
  3. detaching volume upon deletions marked with certain annotations
 */
 type ReconcileAttachDetach struct {
+	*SharedState
 	logger            logr.Logger
 	crdDetacher       CrdDetacher
 	cloudDiskAttacher CloudDiskAttachDetacher
 	stateLock         *sync.Map
 	retryInfo         *retryInfo
-	*sharedState
 }
 
 var _ reconcile.Reconciler = &ReconcileAttachDetach{}
@@ -742,14 +742,14 @@ func (r *ReconcileAttachDetach) recoverAzVolumeAttachment(ctx context.Context, r
 	return nil
 }
 
-func NewAttachDetachController(mgr manager.Manager, cloudDiskAttacher CloudDiskAttachDetacher, crdDetacher CrdDetacher, controllerSharedState *sharedState) (*ReconcileAttachDetach, error) {
+func NewAttachDetachController(mgr manager.Manager, cloudDiskAttacher CloudDiskAttachDetacher, crdDetacher CrdDetacher, controllerSharedState *SharedState) (*ReconcileAttachDetach, error) {
 	logger := mgr.GetLogger().WithValues("controller", "azvolumeattachment")
 	reconciler := ReconcileAttachDetach{
 		crdDetacher:       crdDetacher,
 		cloudDiskAttacher: cloudDiskAttacher,
 		stateLock:         &sync.Map{},
 		retryInfo:         newRetryInfo(),
-		sharedState:       controllerSharedState,
+		SharedState:       controllerSharedState,
 		logger:            logger,
 	}
 
@@ -778,7 +778,7 @@ func NewAttachDetachController(mgr manager.Manager, cloudDiskAttacher CloudDiskA
 }
 
 // waitForVolumeAttachmentNAme waits for the VolumeAttachment name to be updated in the azVolumeAttachmentVaMap by the volumeattachment controller
-func (c *sharedState) waitForVolumeAttachmentName(ctx context.Context, azVolumeAttachment *azdiskv1beta2.AzVolumeAttachment) (string, error) {
+func (c *SharedState) waitForVolumeAttachmentName(ctx context.Context, azVolumeAttachment *azdiskv1beta2.AzVolumeAttachment) (string, error) {
 	var vaName string
 	err := wait.PollImmediateUntilWithContext(ctx, consts.DefaultPollingRate, func(ctx context.Context) (bool, error) {
 		val, exists := c.azVolumeAttachmentToVaMap.Load(azVolumeAttachment.Name)

--- a/pkg/controller/attach_detach.go
+++ b/pkg/controller/attach_detach.go
@@ -63,12 +63,12 @@ Attach Detach controller is responsible for
  3. detaching volume upon deletions marked with certain annotations
 */
 type ReconcileAttachDetach struct {
-	logger                logr.Logger
-	crdDetacher           CrdDetacher
-	cloudDiskAttacher     CloudDiskAttachDetacher
-	controllerSharedState *SharedState
-	stateLock             *sync.Map
-	retryInfo             *retryInfo
+	logger            logr.Logger
+	crdDetacher       CrdDetacher
+	cloudDiskAttacher CloudDiskAttachDetacher
+	stateLock         *sync.Map
+	retryInfo         *retryInfo
+	*sharedState
 }
 
 var _ reconcile.Reconciler = &ReconcileAttachDetach{}
@@ -86,14 +86,14 @@ var allowedTargetAttachmentStates = map[string][]string{
 }
 
 func (r *ReconcileAttachDetach) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	if !r.controllerSharedState.isRecoveryComplete() {
+	if !r.isRecoveryComplete() {
 		return reconcile.Result{Requeue: true}, nil
 	}
 
-	azVolumeAttachment, err := azureutils.GetAzVolumeAttachment(ctx, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, request.Name, request.Namespace, true)
+	azVolumeAttachment, err := azureutils.GetAzVolumeAttachment(ctx, r.cachedClient, r.azClient, request.Name, request.Namespace, true)
 	// if object is not found, it means the object has been deleted. Log the deletion and do not requeue
 	if errors.IsNotFound(err) {
-		r.controllerSharedState.azVolumeAttachmentToVaMap.Delete(request.Name)
+		r.azVolumeAttachmentToVaMap.Delete(request.Name)
 		return reconcileReturnOnSuccess(request.Name, r.retryInfo)
 	} else if err != nil {
 		azVolumeAttachment.Name = request.Name
@@ -152,7 +152,7 @@ func (r *ReconcileAttachDetach) triggerAttach(ctx context.Context, azVolumeAttac
 	}
 
 	var azVolume *azdiskv1beta2.AzVolume
-	if azVolume, err = azureutils.GetAzVolume(ctx, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, strings.ToLower(azVolumeAttachment.Spec.VolumeName), r.controllerSharedState.objectNamespace, true); err != nil {
+	if azVolume, err = azureutils.GetAzVolume(ctx, r.cachedClient, r.azClient, strings.ToLower(azVolumeAttachment.Spec.VolumeName), r.objectNamespace, true); err != nil {
 		if errors.IsNotFound(err) {
 			w.Logger().V(5).Infof("Aborting attach operation for AzVolumeAttachment (%s): AzVolume (%s) not found", azVolumeAttachment.Name, azVolumeAttachment.Spec.VolumeName)
 			err = nil
@@ -173,7 +173,7 @@ func (r *ReconcileAttachDetach) triggerAttach(ctx context.Context, azVolumeAttac
 	}
 
 	var updatedObj client.Object
-	if updatedObj, err = azureutils.UpdateCRIWithRetry(ctx, nil, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, azVolumeAttachment, updateFunc, consts.NormalUpdateMaxNetRetry, azureutils.UpdateCRIStatus); err != nil {
+	if updatedObj, err = azureutils.UpdateCRIWithRetry(ctx, nil, r.cachedClient, r.azClient, azVolumeAttachment, updateFunc, consts.NormalUpdateMaxNetRetry, azureutils.UpdateCRIStatus); err != nil {
 		return err
 	}
 	azVolumeAttachment = updatedObj.(*azdiskv1beta2.AzVolumeAttachment)
@@ -196,7 +196,7 @@ func (r *ReconcileAttachDetach) triggerAttach(ctx context.Context, azVolumeAttac
 		var pods []v1.Pod
 		if azVolumeAttachment.Spec.RequestedRole == azdiskv1beta2.ReplicaRole {
 			var err error
-			pods, err = r.controllerSharedState.getPodsFromVolume(goCtx, r.controllerSharedState.cachedClient, azVolumeAttachment.Spec.VolumeName)
+			pods, err = r.getPodsFromVolume(goCtx, r.cachedClient, azVolumeAttachment.Spec.VolumeName)
 			if err != nil {
 				goWorkflow.Logger().Error(err, "failed to list pods for volume")
 			}
@@ -220,7 +220,7 @@ func (r *ReconcileAttachDetach) triggerAttach(ctx context.Context, azVolumeAttac
 		handleError = func() {
 			if len(pods) > 0 {
 				for _, pod := range pods {
-					r.controllerSharedState.eventRecorder.Eventf(pod.DeepCopyObject(), v1.EventTypeWarning, consts.ReplicaAttachmentFailedEvent, "Replica mount for volume %s failed to be attached to node %s with error: %v", azVolumeAttachment.Spec.VolumeName, azVolumeAttachment.Spec.NodeName, attachErr)
+					r.eventRecorder.Eventf(pod.DeepCopyObject(), v1.EventTypeWarning, consts.ReplicaAttachmentFailedEvent, "Replica mount for volume %s failed to be attached to node %s with error: %v", azVolumeAttachment.Spec.VolumeName, azVolumeAttachment.Spec.NodeName, attachErr)
 				}
 			}
 
@@ -232,7 +232,7 @@ func (r *ReconcileAttachDetach) triggerAttach(ctx context.Context, azVolumeAttac
 				goWorkflow.Logger().Infof("Dangling attach detected for %s", currentNodeName)
 
 				// check if AzVolumeAttachment exists for the existing attachment
-				_, err := r.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(r.controllerSharedState.objectNamespace).Get(cloudCtx, currentAttachmentName, metav1.GetOptions{})
+				_, err := r.azClient.DiskV1beta2().AzVolumeAttachments(r.objectNamespace).Get(cloudCtx, currentAttachmentName, metav1.GetOptions{})
 				var detachErr error
 				if errors.IsNotFound(err) {
 					// AzVolumeAttachment doesn't exist so we only need to detach disk from cloud
@@ -265,14 +265,14 @@ func (r *ReconcileAttachDetach) triggerAttach(ctx context.Context, azVolumeAttac
 				return uerr
 			}
 			//nolint:contextcheck // final status update of the CRI must occur even when the current context's deadline passes.
-			_, _ = azureutils.UpdateCRIWithRetry(goCtx, nil, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, azVolumeAttachment, updateFunc, consts.ForcedUpdateMaxNetRetry, azureutils.UpdateCRIStatus)
+			_, _ = azureutils.UpdateCRIWithRetry(goCtx, nil, r.cachedClient, r.azClient, azVolumeAttachment, updateFunc, consts.ForcedUpdateMaxNetRetry, azureutils.UpdateCRIStatus)
 		}
 		handleSuccess = func(asyncComplete bool) {
 			// Publish event to indicate attachment success
 			if asyncComplete {
 				if len(pods) > 0 {
 					for _, pod := range pods {
-						r.controllerSharedState.eventRecorder.Eventf(pod.DeepCopyObject(), v1.EventTypeNormal, consts.ReplicaAttachmentSuccessEvent, "Replica mount for volume %s successfully attached to node %s", azVolumeAttachment.Spec.VolumeName, azVolumeAttachment.Spec.NodeName)
+						r.eventRecorder.Eventf(pod.DeepCopyObject(), v1.EventTypeNormal, consts.ReplicaAttachmentSuccessEvent, "Replica mount for volume %s successfully attached to node %s", azVolumeAttachment.Spec.VolumeName, azVolumeAttachment.Spec.NodeName)
 					}
 				}
 			}
@@ -290,7 +290,7 @@ func (r *ReconcileAttachDetach) triggerAttach(ctx context.Context, azVolumeAttac
 			if asyncComplete && azVolumeAttachment.Spec.RequestedRole == azdiskv1beta2.PrimaryRole {
 				_ = r.updateVolumeAttachmentWithResult(goCtx, azVolumeAttachment)
 			}
-			updatedObj, _ = azureutils.UpdateCRIWithRetry(goCtx, nil, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, azVolumeAttachment, updateFunc, consts.ForcedUpdateMaxNetRetry, azureutils.UpdateCRIStatus)
+			updatedObj, _ = azureutils.UpdateCRIWithRetry(goCtx, nil, r.cachedClient, r.azClient, azVolumeAttachment, updateFunc, consts.ForcedUpdateMaxNetRetry, azureutils.UpdateCRIStatus)
 			azVolumeAttachment = updatedObj.(*azdiskv1beta2.AzVolumeAttachment)
 		}
 
@@ -322,7 +322,7 @@ func (r *ReconcileAttachDetach) triggerDetach(ctx context.Context, azVolumeAttac
 		}
 
 		var updatedObj client.Object
-		if updatedObj, err = azureutils.UpdateCRIWithRetry(ctx, nil, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, azVolumeAttachment, updateFunc, consts.NormalUpdateMaxNetRetry, azureutils.UpdateCRIStatus); err != nil {
+		if updatedObj, err = azureutils.UpdateCRIWithRetry(ctx, nil, r.cachedClient, r.azClient, azVolumeAttachment, updateFunc, consts.NormalUpdateMaxNetRetry, azureutils.UpdateCRIStatus); err != nil {
 			return err
 		}
 		azVolumeAttachment = updatedObj.(*azdiskv1beta2.AzVolumeAttachment)
@@ -359,7 +359,7 @@ func (r *ReconcileAttachDetach) triggerDetach(ctx context.Context, azVolumeAttac
 				updateMode = azureutils.UpdateCRI
 			}
 			//nolint:contextcheck // final status update of the CRI must occur even when the current context's deadline passes.
-			_, _ = azureutils.UpdateCRIWithRetry(goCtx, nil, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, azVolumeAttachment, updateFunc, consts.ForcedUpdateMaxNetRetry, updateMode)
+			_, _ = azureutils.UpdateCRIWithRetry(goCtx, nil, r.cachedClient, r.azClient, azVolumeAttachment, updateFunc, consts.ForcedUpdateMaxNetRetry, updateMode)
 		}()
 		<-waitCh
 	} else {
@@ -369,7 +369,7 @@ func (r *ReconcileAttachDetach) triggerDetach(ctx context.Context, azVolumeAttac
 			_ = r.deleteFinalizer(azv)
 			return nil
 		}
-		if _, err = azureutils.UpdateCRIWithRetry(ctx, nil, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, azVolumeAttachment, updateFunc, consts.NormalUpdateMaxNetRetry, azureutils.UpdateCRI); err != nil {
+		if _, err = azureutils.UpdateCRIWithRetry(ctx, nil, r.cachedClient, r.azClient, azVolumeAttachment, updateFunc, consts.NormalUpdateMaxNetRetry, azureutils.UpdateCRI); err != nil {
 			return err
 		}
 	}
@@ -391,7 +391,7 @@ func (r *ReconcileAttachDetach) promote(ctx context.Context, azVolumeAttachment 
 		_ = updateRole(azv, azdiskv1beta2.PrimaryRole)
 		return nil
 	}
-	if _, err = azureutils.UpdateCRIWithRetry(ctx, nil, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, azVolumeAttachment, updateFunc, consts.NormalUpdateMaxNetRetry, azureutils.UpdateCRIStatus); err != nil {
+	if _, err = azureutils.UpdateCRIWithRetry(ctx, nil, r.cachedClient, r.azClient, azVolumeAttachment, updateFunc, consts.NormalUpdateMaxNetRetry, azureutils.UpdateCRIStatus); err != nil {
 		return err
 	}
 	return nil
@@ -411,7 +411,7 @@ func (r *ReconcileAttachDetach) demote(ctx context.Context, azVolumeAttachment *
 		return nil
 	}
 
-	if _, err = azureutils.UpdateCRIWithRetry(ctx, nil, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, azVolumeAttachment, updateFunc, consts.NormalUpdateMaxNetRetry, azureutils.UpdateCRIStatus); err != nil {
+	if _, err = azureutils.UpdateCRIWithRetry(ctx, nil, r.cachedClient, r.azClient, azVolumeAttachment, updateFunc, consts.NormalUpdateMaxNetRetry, azureutils.UpdateCRIStatus); err != nil {
 		return err
 	}
 	return nil
@@ -419,7 +419,7 @@ func (r *ReconcileAttachDetach) demote(ctx context.Context, azVolumeAttachment *
 
 func (r *ReconcileAttachDetach) updateVolumeAttachmentWithResult(ctx context.Context, azVolumeAttachment *azdiskv1beta2.AzVolumeAttachment) error {
 	var vaName string
-	vaName, err := r.controllerSharedState.waitForVolumeAttachmentName(ctx, azVolumeAttachment)
+	vaName, err := r.waitForVolumeAttachmentName(ctx, azVolumeAttachment)
 	if err != nil {
 		return err
 	}
@@ -434,7 +434,7 @@ func (r *ReconcileAttachDetach) updateVolumeAttachmentWithResult(ctx context.Con
 		return nil
 	}
 	va := storagev1.VolumeAttachment{ObjectMeta: metav1.ObjectMeta{Name: vaName}}
-	_, err = azureutils.UpdateCRIWithRetry(ctx, nil, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, &va, vaUpdateFunc, consts.ForcedUpdateMaxNetRetry, azureutils.UpdateCRIStatus)
+	_, err = azureutils.UpdateCRIWithRetry(ctx, nil, r.cachedClient, r.azClient, &va, vaUpdateFunc, consts.ForcedUpdateMaxNetRetry, azureutils.UpdateCRIStatus)
 	return err
 }
 
@@ -555,7 +555,7 @@ func updateState(azVolumeAttachment *azdiskv1beta2.AzVolumeAttachment, state azd
 func (r *ReconcileAttachDetach) recreateAzVolumeAttachment(ctx context.Context, syncedVolumeAttachments map[string]bool, volumesToSync map[string]bool) (map[string]bool, map[string]bool, error) {
 	w, _ := workflow.GetWorkflowFromContext(ctx)
 	// Get all volumeAttachments
-	volumeAttachments, err := r.controllerSharedState.kubeClient.StorageV1().VolumeAttachments().List(ctx, metav1.ListOptions{})
+	volumeAttachments, err := r.kubeClient.StorageV1().VolumeAttachments().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return syncedVolumeAttachments, volumesToSync, err
 	}
@@ -573,19 +573,19 @@ func (r *ReconcileAttachDetach) recreateAzVolumeAttachment(ctx context.Context, 
 		if syncedVolumeAttachments[volumeAttachment.Name] {
 			continue
 		}
-		if volumeAttachment.Spec.Attacher == r.controllerSharedState.driverName {
+		if volumeAttachment.Spec.Attacher == r.driverName {
 			volumeName := volumeAttachment.Spec.Source.PersistentVolumeName
 			if volumeName == nil {
 				continue
 			}
 			// get PV and retrieve diskName
-			pv, err := r.controllerSharedState.kubeClient.CoreV1().PersistentVolumes().Get(ctx, *volumeName, metav1.GetOptions{})
+			pv, err := r.kubeClient.CoreV1().PersistentVolumes().Get(ctx, *volumeName, metav1.GetOptions{})
 			if err != nil {
 				w.Logger().Errorf(err, "failed to get PV (%s)", *volumeName)
 				return syncedVolumeAttachments, volumesToSync, err
 			}
 
-			if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != r.controllerSharedState.driverName {
+			if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != r.driverName {
 				continue
 			}
 			volumesToSync[pv.Spec.CSI.VolumeHandle] = true
@@ -598,7 +598,7 @@ func (r *ReconcileAttachDetach) recreateAzVolumeAttachment(ctx context.Context, 
 			}
 			nodeName := volumeAttachment.Spec.NodeName
 			azVolumeAttachmentName := azureutils.GetAzVolumeAttachmentName(diskName, nodeName)
-			r.controllerSharedState.azVolumeAttachmentToVaMap.Store(azVolumeAttachmentName, volumeAttachment.Name)
+			r.azVolumeAttachmentToVaMap.Store(azVolumeAttachmentName, volumeAttachment.Name)
 
 			desiredAzVolumeAttachment := &azdiskv1beta2.AzVolumeAttachment{
 				ObjectMeta: metav1.ObjectMeta{
@@ -620,12 +620,12 @@ func (r *ReconcileAttachDetach) recreateAzVolumeAttachment(ctx context.Context, 
 				},
 			}
 			// check if the CRI exists already
-			azVolumeAttachment, err := azureutils.GetAzVolumeAttachment(ctx, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, azVolumeAttachmentName, r.controllerSharedState.objectNamespace, false)
+			azVolumeAttachment, err := azureutils.GetAzVolumeAttachment(ctx, r.cachedClient, r.azClient, azVolumeAttachmentName, r.objectNamespace, false)
 			if err != nil {
 				if errors.IsNotFound(err) {
 					w.Logger().Infof("Recreating AzVolumeAttachment(%s)", azVolumeAttachmentName)
 
-					azVolumeAttachment, err = r.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(r.controllerSharedState.objectNamespace).Create(ctx, desiredAzVolumeAttachment, metav1.CreateOptions{})
+					azVolumeAttachment, err = r.azClient.DiskV1beta2().AzVolumeAttachments(r.objectNamespace).Create(ctx, desiredAzVolumeAttachment, metav1.CreateOptions{})
 					if err != nil {
 						w.Logger().Errorf(err, "failed to create AzVolumeAttachment (%s) for volume (%s) and node (%s): %v", azVolumeAttachmentName, *volumeName, nodeName, err)
 						return syncedVolumeAttachments, volumesToSync, err
@@ -641,7 +641,7 @@ func (r *ReconcileAttachDetach) recreateAzVolumeAttachment(ctx context.Context, 
 				azVolumeAttachment.Annotations = desiredAzVolumeAttachment.Annotations
 				azVolumeAttachment.Finalizers = desiredAzVolumeAttachment.Finalizers
 
-				azVolumeAttachment, err = r.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(r.controllerSharedState.objectNamespace).Update(ctx, azVolumeAttachment, metav1.UpdateOptions{})
+				azVolumeAttachment, err = r.azClient.DiskV1beta2().AzVolumeAttachments(r.objectNamespace).Update(ctx, azVolumeAttachment, metav1.UpdateOptions{})
 				if err != nil {
 					w.Logger().Errorf(err, "failed to update AzVolumeAttachment (%s) for volume (%s) and node (%s): %v", azVolumeAttachmentName, *volumeName, nodeName, err)
 					return syncedVolumeAttachments, volumesToSync, err
@@ -658,7 +658,7 @@ func (r *ReconcileAttachDetach) recreateAzVolumeAttachment(ctx context.Context, 
 				}
 			}
 			// update status
-			_, err = r.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(r.controllerSharedState.objectNamespace).UpdateStatus(ctx, azVolumeAttachment, metav1.UpdateOptions{})
+			_, err = r.azClient.DiskV1beta2().AzVolumeAttachments(r.objectNamespace).UpdateStatus(ctx, azVolumeAttachment, metav1.UpdateOptions{})
 			if err != nil {
 				w.Logger().Errorf(err, "failed to update status of AzVolumeAttachment (%s) for volume (%s) and node (%s): %v", azVolumeAttachmentName, *volumeName, nodeName, err)
 				return syncedVolumeAttachments, volumesToSync, err
@@ -674,7 +674,7 @@ func (r *ReconcileAttachDetach) recoverAzVolumeAttachment(ctx context.Context, r
 	w, _ := workflow.GetWorkflowFromContext(ctx)
 
 	// list all AzVolumeAttachment
-	azVolumeAttachments, err := r.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(r.controllerSharedState.objectNamespace).List(ctx, metav1.ListOptions{})
+	azVolumeAttachments, err := r.azClient.DiskV1beta2().AzVolumeAttachments(r.objectNamespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		w.Logger().Error(err, "failed to get list of existing AzVolumeAttachment CRI in controller recovery stage")
 		return err
@@ -724,7 +724,7 @@ func (r *ReconcileAttachDetach) recoverAzVolumeAttachment(ctx context.Context, r
 				targetState = azv.Status.State
 			}
 
-			if _, err := azureutils.UpdateCRIWithRetry(ctx, nil, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, &azv, updateFunc, consts.ForcedUpdateMaxNetRetry, updateMode); err != nil {
+			if _, err := azureutils.UpdateCRIWithRetry(ctx, nil, r.cachedClient, r.azClient, &azv, updateFunc, consts.ForcedUpdateMaxNetRetry, updateMode); err != nil {
 				w.Logger().Errorf(err, "failed to update AzVolumeAttachment (%s) for recovery", azv.Name)
 			} else {
 				// if update succeeded, add the CRI to the recoveryComplete list
@@ -742,15 +742,15 @@ func (r *ReconcileAttachDetach) recoverAzVolumeAttachment(ctx context.Context, r
 	return nil
 }
 
-func NewAttachDetachController(mgr manager.Manager, cloudDiskAttacher CloudDiskAttachDetacher, crdDetacher CrdDetacher, controllerSharedState *SharedState) (*ReconcileAttachDetach, error) {
+func NewAttachDetachController(mgr manager.Manager, cloudDiskAttacher CloudDiskAttachDetacher, crdDetacher CrdDetacher, controllerSharedState *sharedState) (*ReconcileAttachDetach, error) {
 	logger := mgr.GetLogger().WithValues("controller", "azvolumeattachment")
 	reconciler := ReconcileAttachDetach{
-		crdDetacher:           crdDetacher,
-		cloudDiskAttacher:     cloudDiskAttacher,
-		stateLock:             &sync.Map{},
-		retryInfo:             newRetryInfo(),
-		controllerSharedState: controllerSharedState,
-		logger:                logger,
+		crdDetacher:       crdDetacher,
+		cloudDiskAttacher: cloudDiskAttacher,
+		stateLock:         &sync.Map{},
+		retryInfo:         newRetryInfo(),
+		sharedState:       controllerSharedState,
+		logger:            logger,
 	}
 
 	c, err := controller.New("azvolumeattachment-controller", mgr, controller.Options{
@@ -778,7 +778,7 @@ func NewAttachDetachController(mgr manager.Manager, cloudDiskAttacher CloudDiskA
 }
 
 // waitForVolumeAttachmentNAme waits for the VolumeAttachment name to be updated in the azVolumeAttachmentVaMap by the volumeattachment controller
-func (c *SharedState) waitForVolumeAttachmentName(ctx context.Context, azVolumeAttachment *azdiskv1beta2.AzVolumeAttachment) (string, error) {
+func (c *sharedState) waitForVolumeAttachmentName(ctx context.Context, azVolumeAttachment *azdiskv1beta2.AzVolumeAttachment) (string, error) {
 	var vaName string
 	err := wait.PollImmediateUntilWithContext(ctx, consts.DefaultPollingRate, func(ctx context.Context) (bool, error) {
 		val, exists := c.azVolumeAttachmentToVaMap.Load(azVolumeAttachment.Name)

--- a/pkg/controller/attach_detach_test.go
+++ b/pkg/controller/attach_detach_test.go
@@ -46,7 +46,7 @@ func NewTestAttachDetachController(controller *gomock.Controller, namespace stri
 		cloudDiskAttacher: mockattachmentprovisioner.NewMockCloudDiskAttachDetacher(controller),
 		stateLock:         &sync.Map{},
 		retryInfo:         newRetryInfo(),
-		sharedState:       controllerSharedState,
+		SharedState:       controllerSharedState,
 		logger:            klogr.New(),
 	}
 }

--- a/pkg/controller/attach_detach_test.go
+++ b/pkg/controller/attach_detach_test.go
@@ -43,16 +43,16 @@ func NewTestAttachDetachController(controller *gomock.Controller, namespace stri
 	controllerSharedState := initState(mockclient.NewMockClient(controller), azdiskfakes.NewSimpleClientset(azDiskObjs...), fakev1.NewSimpleClientset(kubeObjs...), objects...)
 
 	return &ReconcileAttachDetach{
-		cloudDiskAttacher:     mockattachmentprovisioner.NewMockCloudDiskAttachDetacher(controller),
-		stateLock:             &sync.Map{},
-		retryInfo:             newRetryInfo(),
-		controllerSharedState: controllerSharedState,
-		logger:                klogr.New(),
+		cloudDiskAttacher: mockattachmentprovisioner.NewMockCloudDiskAttachDetacher(controller),
+		stateLock:         &sync.Map{},
+		retryInfo:         newRetryInfo(),
+		sharedState:       controllerSharedState,
+		logger:            klogr.New(),
 	}
 }
 
 func mockClientsAndAttachmentProvisioner(controller *ReconcileAttachDetach) {
-	mockClients(controller.controllerSharedState.cachedClient.(*mockclient.MockClient), controller.controllerSharedState.azClient, controller.controllerSharedState.kubeClient)
+	mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 
 	controller.cloudDiskAttacher.(*mockattachmentprovisioner.MockCloudDiskAttachDetacher).EXPECT().
 		PublishVolume(gomock.Any(), testManagedDiskURI0, gomock.Any(), gomock.Any()).
@@ -96,7 +96,7 @@ func TestAttachDetachReconcile(t *testing.T) {
 					newVolumeAttachment,
 					newAttachment)
 
-				controller.controllerSharedState.azVolumeAttachmentToVaMap.Store(newAttachment.Name, newVolumeAttachment.Name)
+				controller.azVolumeAttachmentToVaMap.Store(newAttachment.Name, newVolumeAttachment.Name)
 
 				mockClientsAndAttachmentProvisioner(controller)
 
@@ -107,7 +107,7 @@ func TestAttachDetachReconcile(t *testing.T) {
 				require.False(t, result.Requeue)
 
 				conditionFunc := func() (bool, error) {
-					azVolumeAttachment, localError := controller.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(testPrimaryAzVolumeAttachment0.Namespace).Get(context.TODO(), testPrimaryAzVolumeAttachment0.Name, metav1.GetOptions{})
+					azVolumeAttachment, localError := controller.azClient.DiskV1beta2().AzVolumeAttachments(testPrimaryAzVolumeAttachment0.Namespace).Get(context.TODO(), testPrimaryAzVolumeAttachment0.Name, metav1.GetOptions{})
 					if localError != nil {
 						return false, nil
 					}
@@ -144,7 +144,7 @@ func TestAttachDetachReconcile(t *testing.T) {
 				require.False(t, result.Requeue)
 
 				conditionFunc := func() (bool, error) {
-					azVolumeAttachment, localError := controller.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(testPrimaryAzVolumeAttachment0.Namespace).Get(context.TODO(), testPrimaryAzVolumeAttachment0.Name, metav1.GetOptions{})
+					azVolumeAttachment, localError := controller.azClient.DiskV1beta2().AzVolumeAttachments(testPrimaryAzVolumeAttachment0.Namespace).Get(context.TODO(), testPrimaryAzVolumeAttachment0.Name, metav1.GetOptions{})
 					return azVolumeAttachment.Status.State != azdiskv1beta2.Attached && azVolumeAttachment.Status.State != azdiskv1beta2.Attaching, localError
 				}
 
@@ -178,7 +178,7 @@ func TestAttachDetachReconcile(t *testing.T) {
 				require.False(t, result.Requeue)
 
 				conditionFunc := func() (bool, error) {
-					azVolumeAttachment, localError := controller.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(testPrimaryAzVolumeAttachment0.Namespace).Get(context.TODO(), testPrimaryAzVolumeAttachment0.Name, metav1.GetOptions{})
+					azVolumeAttachment, localError := controller.azClient.DiskV1beta2().AzVolumeAttachments(testPrimaryAzVolumeAttachment0.Namespace).Get(context.TODO(), testPrimaryAzVolumeAttachment0.Name, metav1.GetOptions{})
 					return len(azVolumeAttachment.Finalizers) == 0, localError
 				}
 
@@ -209,7 +209,7 @@ func TestAttachDetachReconcile(t *testing.T) {
 					newVolumeAttachment,
 					newAttachment)
 
-				controller.controllerSharedState.azVolumeAttachmentToVaMap.Store(newAttachment.Name, newVolumeAttachment.Name)
+				controller.azVolumeAttachmentToVaMap.Store(newAttachment.Name, newVolumeAttachment.Name)
 
 				mockClientsAndAttachmentProvisioner(controller)
 
@@ -219,7 +219,7 @@ func TestAttachDetachReconcile(t *testing.T) {
 				require.NoError(t, err)
 				require.False(t, result.Requeue)
 
-				azVolumeAttachment, localError := controller.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(testReplicaAzVolumeAttachment.Namespace).Get(context.TODO(), testReplicaAzVolumeAttachment.Name, metav1.GetOptions{})
+				azVolumeAttachment, localError := controller.azClient.DiskV1beta2().AzVolumeAttachments(testReplicaAzVolumeAttachment.Namespace).Get(context.TODO(), testReplicaAzVolumeAttachment.Name, metav1.GetOptions{})
 				require.NoError(t, localError)
 				require.NotNil(t, azVolumeAttachment)
 				require.NotNil(t, azVolumeAttachment.Status.Detail)
@@ -263,7 +263,7 @@ func TestAttachDetachRecover(t *testing.T) {
 			verifyFunc: func(t *testing.T, controller *ReconcileAttachDetach, err error) {
 				require.NoError(t, err)
 
-				azVolumeAttachments, localErr := controller.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).List(context.TODO(), metav1.ListOptions{})
+				azVolumeAttachments, localErr := controller.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).List(context.TODO(), metav1.ListOptions{})
 				require.NoError(t, localErr)
 				require.Len(t, azVolumeAttachments.Items, 1)
 			},
@@ -290,12 +290,12 @@ func TestAttachDetachRecover(t *testing.T) {
 			verifyFunc: func(t *testing.T, controller *ReconcileAttachDetach, err error) {
 				require.NoError(t, err)
 
-				azVolumeAttachment, localErr := controller.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).Get(context.TODO(), testPrimaryAzVolumeAttachment0Name, metav1.GetOptions{})
+				azVolumeAttachment, localErr := controller.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).Get(context.TODO(), testPrimaryAzVolumeAttachment0Name, metav1.GetOptions{})
 				require.NoError(t, localErr)
 				require.Equal(t, azVolumeAttachment.Status.State, azdiskv1beta2.AttachmentPending)
 				require.Contains(t, azVolumeAttachment.Status.Annotations, consts.RecoverAnnotation)
 
-				azVolumeAttachment, localErr = controller.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).Get(context.TODO(), testPrimaryAzVolumeAttachment1Name, metav1.GetOptions{})
+				azVolumeAttachment, localErr = controller.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).Get(context.TODO(), testPrimaryAzVolumeAttachment1Name, metav1.GetOptions{})
 				require.NoError(t, localErr)
 				require.Equal(t, azVolumeAttachment.Status.State, azdiskv1beta2.Attached)
 				require.Contains(t, azVolumeAttachment.Status.Annotations, consts.RecoverAnnotation)

--- a/pkg/controller/azdrivernode.go
+++ b/pkg/controller/azdrivernode.go
@@ -40,8 +40,8 @@ import (
 
 // ReconcileAzDriverNode reconciles AzDriverNode
 type ReconcileAzDriverNode struct {
+	*SharedState
 	logger logr.Logger
-	*sharedState
 }
 
 // Implement reconcile.Reconciler so the controller can reconcile objects
@@ -88,7 +88,7 @@ func (r *ReconcileAzDriverNode) Recover(ctx context.Context) error {
 	defer func() { w.Finish(err) }()
 
 	var nodes *azdiskv1beta2.AzDriverNodeList
-	if nodes, err = r.controllerSharedState.azClient.DiskV1beta2().AzDriverNodes(r.controllerSharedState.objectNamespace).List(ctx, metav1.ListOptions{}); err != nil {
+	if nodes, err = r.azClient.DiskV1beta2().AzDriverNodes(r.objectNamespace).List(ctx, metav1.ListOptions{}); err != nil {
 		if errors.IsNotFound(err) {
 			return nil
 		}
@@ -98,7 +98,7 @@ func (r *ReconcileAzDriverNode) Recover(ctx context.Context) error {
 	for _, node := range nodes.Items {
 		updated := node.DeepCopy()
 		updated.Annotations = azureutils.AddToMap(updated.Annotations, consts.RecoverAnnotation, "azDriverNode")
-		if _, err = r.controllerSharedState.azClient.DiskV1beta2().AzDriverNodes(r.controllerSharedState.objectNamespace).Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+		if _, err = r.azClient.DiskV1beta2().AzDriverNodes(r.objectNamespace).Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
 			return err
 		}
 	}
@@ -106,10 +106,10 @@ func (r *ReconcileAzDriverNode) Recover(ctx context.Context) error {
 }
 
 // NewAzDriverNodeController initializes azdrivernode-controller
-func NewAzDriverNodeController(mgr manager.Manager, controllerSharedState *sharedState) (*ReconcileAzDriverNode, error) {
+func NewAzDriverNodeController(mgr manager.Manager, controllerSharedState *SharedState) (*ReconcileAzDriverNode, error) {
 	logger := mgr.GetLogger().WithValues("controller", "azdrivernode")
 	reconciler := ReconcileAzDriverNode{
-		sharedState: controllerSharedState,
+		SharedState: controllerSharedState,
 		logger:      logger,
 	}
 

--- a/pkg/controller/azdrivernode_test.go
+++ b/pkg/controller/azdrivernode_test.go
@@ -40,7 +40,7 @@ func NewTestAzDriverNodeController(controller *gomock.Controller, namespace stri
 	controllerSharedState := initState(mockclient.NewMockClient(controller), azdiskfakes.NewSimpleClientset(azDiskObjs...), nil, objects...)
 
 	return &ReconcileAzDriverNode{
-		sharedState: controllerSharedState,
+		SharedState: controllerSharedState,
 		logger:      klogr.New(),
 	}
 }

--- a/pkg/controller/azdrivernode_test.go
+++ b/pkg/controller/azdrivernode_test.go
@@ -40,8 +40,8 @@ func NewTestAzDriverNodeController(controller *gomock.Controller, namespace stri
 	controllerSharedState := initState(mockclient.NewMockClient(controller), azdiskfakes.NewSimpleClientset(azDiskObjs...), nil, objects...)
 
 	return &ReconcileAzDriverNode{
-		controllerSharedState: controllerSharedState,
-		logger:                klogr.New(),
+		sharedState: controllerSharedState,
+		logger:      klogr.New(),
 	}
 }
 
@@ -62,7 +62,7 @@ func TestAzDriverNodeControllerReconcile(t *testing.T) {
 					&testAzDriverNode0,
 					&testAzDriverNode1)
 
-				controller.controllerSharedState.cachedClient.(*mockclient.MockClient).EXPECT().
+				controller.cachedClient.(*mockclient.MockClient).EXPECT().
 					Get(gomock.Any(), testNode1Request.NamespacedName, gomock.Any()).
 					Return(testNode1NotFoundError)
 
@@ -72,7 +72,7 @@ func TestAzDriverNodeControllerReconcile(t *testing.T) {
 				require.NoError(t, err)
 				require.False(t, result.Requeue)
 
-				_, err2 := controller.controllerSharedState.azClient.DiskV1beta2().AzDriverNodes(testNamespace).Get(context.TODO(), testNode1Name, metav1.GetOptions{})
+				_, err2 := controller.azClient.DiskV1beta2().AzDriverNodes(testNamespace).Get(context.TODO(), testNode1Name, metav1.GetOptions{})
 				require.EqualValues(t, testAzDriverNode1NotFoundError, err2)
 			},
 		},
@@ -90,12 +90,12 @@ func TestAzDriverNodeControllerReconcile(t *testing.T) {
 					&testPersistentVolume0,
 				)
 
-				controller.controllerSharedState.cachedClient.(*mockclient.MockClient).EXPECT().
+				controller.cachedClient.(*mockclient.MockClient).EXPECT().
 					Get(gomock.Any(), testNode1Request.NamespacedName, gomock.Any()).
 					Return(testNode1NotFoundError).
 					AnyTimes()
 
-				mockClients(controller.controllerSharedState.cachedClient.(*mockclient.MockClient), controller.controllerSharedState.azClient, nil)
+				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, nil)
 
 				return controller
 			},
@@ -103,13 +103,13 @@ func TestAzDriverNodeControllerReconcile(t *testing.T) {
 				require.NoError(t, err)
 				require.False(t, result.Requeue)
 
-				_, err2 := controller.controllerSharedState.azClient.DiskV1beta2().AzDriverNodes(testNamespace).Get(context.TODO(), testNode1Name, metav1.GetOptions{})
+				_, err2 := controller.azClient.DiskV1beta2().AzDriverNodes(testNamespace).Get(context.TODO(), testNode1Name, metav1.GetOptions{})
 				require.EqualValues(t, testAzDriverNode1NotFoundError, err2)
 
 				nodeRequirement, _ := azureutils.CreateLabelRequirements(consts.NodeNameLabel, selection.Equals, testNode1Name)
 				labelSelector := labels.NewSelector().Add(*nodeRequirement)
 				conditionFunc := func() (bool, error) {
-					attachments, _ := controller.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector.String()})
+					attachments, _ := controller.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector.String()})
 					return len(attachments.Items) == 0, nil
 				}
 				err = wait.PollImmediate(verifyCRIInterval, verifyCRITimeout, conditionFunc)
@@ -126,7 +126,7 @@ func TestAzDriverNodeControllerReconcile(t *testing.T) {
 					&testAzDriverNode0,
 					&testAzDriverNode1)
 
-				controller.controllerSharedState.cachedClient.(*mockclient.MockClient).EXPECT().
+				controller.cachedClient.(*mockclient.MockClient).EXPECT().
 					Get(gomock.Any(), testNode1Request.NamespacedName, gomock.Any()).
 					Return(nil).
 					AnyTimes()
@@ -137,7 +137,7 @@ func TestAzDriverNodeControllerReconcile(t *testing.T) {
 				require.NoError(t, err)
 				require.False(t, result.Requeue)
 
-				_, err2 := controller.controllerSharedState.azClient.DiskV1beta2().AzDriverNodes(testNamespace).Get(context.TODO(), testNode1Name, metav1.GetOptions{})
+				_, err2 := controller.azClient.DiskV1beta2().AzDriverNodes(testNamespace).Get(context.TODO(), testNode1Name, metav1.GetOptions{})
 				require.NoError(t, err2)
 			},
 		},
@@ -151,7 +151,7 @@ func TestAzDriverNodeControllerReconcile(t *testing.T) {
 					&testAzDriverNode0,
 					&testAzDriverNode1)
 
-				controller.controllerSharedState.cachedClient.(*mockclient.MockClient).EXPECT().
+				controller.cachedClient.(*mockclient.MockClient).EXPECT().
 					Get(gomock.Any(), testNode1Request.NamespacedName, gomock.Any()).
 					Return(testNode1ServerTimeoutError).
 					AnyTimes()
@@ -162,7 +162,7 @@ func TestAzDriverNodeControllerReconcile(t *testing.T) {
 				require.EqualValues(t, testNode1ServerTimeoutError, err)
 				require.True(t, result.Requeue)
 
-				_, err2 := controller.controllerSharedState.azClient.DiskV1beta2().AzDriverNodes(testNamespace).Get(context.TODO(), testNode1Name, metav1.GetOptions{})
+				_, err2 := controller.azClient.DiskV1beta2().AzDriverNodes(testNamespace).Get(context.TODO(), testNode1Name, metav1.GetOptions{})
 				require.NoError(t, err2)
 			},
 		},

--- a/pkg/controller/azvolume_test.go
+++ b/pkg/controller/azvolume_test.go
@@ -49,7 +49,7 @@ func NewTestAzVolumeController(controller *gomock.Controller, namespace string, 
 		volumeProvisioner: mockvolumeprovisioner.NewMockVolumeProvisioner(controller),
 		stateLock:         &sync.Map{},
 		retryInfo:         newRetryInfo(),
-		sharedState:       controllerSharedState,
+		SharedState:       controllerSharedState,
 		logger:            klogr.New(),
 	}
 }

--- a/pkg/controller/azvolume_test.go
+++ b/pkg/controller/azvolume_test.go
@@ -46,16 +46,16 @@ func NewTestAzVolumeController(controller *gomock.Controller, namespace string, 
 	controllerSharedState := initState(mockclient.NewMockClient(controller), azdiskfakes.NewSimpleClientset(azDiskObjs...), fakev1.NewSimpleClientset(kubeObjs...), objects...)
 
 	return &ReconcileAzVolume{
-		volumeProvisioner:     mockvolumeprovisioner.NewMockVolumeProvisioner(controller),
-		stateLock:             &sync.Map{},
-		retryInfo:             newRetryInfo(),
-		controllerSharedState: controllerSharedState,
-		logger:                klogr.New(),
+		volumeProvisioner: mockvolumeprovisioner.NewMockVolumeProvisioner(controller),
+		stateLock:         &sync.Map{},
+		retryInfo:         newRetryInfo(),
+		sharedState:       controllerSharedState,
+		logger:            klogr.New(),
 	}
 }
 
 func mockClientsAndVolumeProvisioner(controller *ReconcileAzVolume) {
-	mockClients(controller.controllerSharedState.cachedClient.(*mockclient.MockClient), controller.controllerSharedState.azClient, controller.controllerSharedState.kubeClient)
+	mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 
 	controller.volumeProvisioner.(*mockvolumeprovisioner.MockVolumeProvisioner).EXPECT().
 		CreateVolume(gomock.Any(), testPersistentVolume0Name, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -91,7 +91,7 @@ func mockClientsAndVolumeProvisioner(controller *ReconcileAzVolume) {
 			if err != nil {
 				return nil, err
 			}
-			azVolume, err := controller.controllerSharedState.azClient.DiskV1beta2().AzVolumes(testNamespace).Get(ctx, volumeName, metav1.GetOptions{})
+			azVolume, err := controller.azClient.DiskV1beta2().AzVolumes(testNamespace).Get(ctx, volumeName, metav1.GetOptions{})
 			if err != nil {
 				return nil, err
 			}
@@ -133,7 +133,7 @@ func TestAzVolumeControllerReconcile(t *testing.T) {
 				require.False(t, result.Requeue)
 
 				conditionFunc := func() (bool, error) {
-					azVolume, localError := controller.controllerSharedState.azClient.DiskV1beta2().AzVolumes(testAzVolume0.Namespace).Get(context.TODO(), testAzVolume0.Name, metav1.GetOptions{})
+					azVolume, localError := controller.azClient.DiskV1beta2().AzVolumes(testAzVolume0.Namespace).Get(context.TODO(), testAzVolume0.Name, metav1.GetOptions{})
 					if localError != nil {
 						return false, nil
 					}
@@ -169,7 +169,7 @@ func TestAzVolumeControllerReconcile(t *testing.T) {
 				require.NoError(t, err)
 				require.False(t, result.Requeue)
 				conditionFunc := func() (bool, error) {
-					azVolume, localError := controller.controllerSharedState.azClient.DiskV1beta2().AzVolumes(testAzVolume0.Namespace).Get(context.TODO(), testAzVolume0.Name, metav1.GetOptions{})
+					azVolume, localError := controller.azClient.DiskV1beta2().AzVolumes(testAzVolume0.Namespace).Get(context.TODO(), testAzVolume0.Name, metav1.GetOptions{})
 					if localError != nil {
 						return false, nil
 					}
@@ -210,7 +210,7 @@ func TestAzVolumeControllerReconcile(t *testing.T) {
 				require.NoError(t, err)
 				require.False(t, result.Requeue)
 				conditionFunc := func() (bool, error) {
-					azVolume, localError := controller.controllerSharedState.azClient.DiskV1beta2().AzVolumes(testAzVolume0.Namespace).Get(context.TODO(), testAzVolume0.Name, metav1.GetOptions{})
+					azVolume, localError := controller.azClient.DiskV1beta2().AzVolumes(testAzVolume0.Namespace).Get(context.TODO(), testAzVolume0.Name, metav1.GetOptions{})
 					return len(azVolume.Finalizers) == 0, localError
 				}
 				conditionError := wait.PollImmediate(verifyCRIInterval, verifyCRITimeout, conditionFunc)
@@ -252,14 +252,14 @@ func TestAzVolumeControllerReconcile(t *testing.T) {
 				labelSelector := labels.NewSelector().Add(*req)
 				checkAzVolumeAttachmentDeletion := func() (bool, error) {
 					var attachments azdiskv1beta2.AzVolumeAttachmentList
-					err := controller.controllerSharedState.cachedClient.List(context.Background(), &attachments, &client.ListOptions{LabelSelector: labelSelector})
+					err := controller.cachedClient.List(context.Background(), &attachments, &client.ListOptions{LabelSelector: labelSelector})
 					return len(attachments.Items) == 0, err
 				}
 				err = wait.PollImmediate(verifyCRIInterval, verifyCRITimeout, checkAzVolumeAttachmentDeletion)
 				require.NoError(t, err)
 				checkAzVolumeDeletion := func() (bool, error) {
 					var azVolume azdiskv1beta2.AzVolume
-					err := controller.controllerSharedState.cachedClient.Get(context.Background(), types.NamespacedName{Namespace: controller.controllerSharedState.objectNamespace, Name: testPersistentVolume0Name}, &azVolume)
+					err := controller.cachedClient.Get(context.Background(), types.NamespacedName{Namespace: controller.objectNamespace, Name: testPersistentVolume0Name}, &azVolume)
 					return len(azVolume.Finalizers) == 0, err
 				}
 				err = wait.PollImmediate(verifyCRIInterval, verifyCRITimeout, checkAzVolumeDeletion)
@@ -306,7 +306,7 @@ func TestAzVolumeControllerRecover(t *testing.T) {
 			},
 			verifyFunc: func(t *testing.T, controller *ReconcileAzVolume, err error) {
 				require.NoError(t, err)
-				azVolumes, err := controller.controllerSharedState.azClient.DiskV1beta2().AzVolumes(testNamespace).List(context.TODO(), metav1.ListOptions{})
+				azVolumes, err := controller.azClient.DiskV1beta2().AzVolumes(testNamespace).List(context.TODO(), metav1.ListOptions{})
 				require.NoError(t, err)
 				require.Len(t, azVolumes.Items, 2)
 			},
@@ -333,12 +333,12 @@ func TestAzVolumeControllerRecover(t *testing.T) {
 			verifyFunc: func(t *testing.T, controller *ReconcileAzVolume, err error) {
 				require.NoError(t, err)
 
-				azVolume, localErr := controller.controllerSharedState.azClient.DiskV1beta2().AzVolumes(testNamespace).Get(context.TODO(), testPersistentVolume0Name, metav1.GetOptions{})
+				azVolume, localErr := controller.azClient.DiskV1beta2().AzVolumes(testNamespace).Get(context.TODO(), testPersistentVolume0Name, metav1.GetOptions{})
 				require.NoError(t, localErr)
 				require.Equal(t, azVolume.Status.State, azdiskv1beta2.VolumeOperationPending)
 				require.Contains(t, azVolume.Status.Annotations, consts.RecoverAnnotation)
 
-				azVolume, localErr = controller.controllerSharedState.azClient.DiskV1beta2().AzVolumes(testNamespace).Get(context.TODO(), testPersistentVolume1Name, metav1.GetOptions{})
+				azVolume, localErr = controller.azClient.DiskV1beta2().AzVolumes(testNamespace).Get(context.TODO(), testPersistentVolume1Name, metav1.GetOptions{})
 				require.NoError(t, localErr)
 				require.Equal(t, azVolume.Status.State, azdiskv1beta2.VolumeCreated)
 				require.Contains(t, azVolume.Status.Annotations, consts.RecoverAnnotation)

--- a/pkg/controller/common.go
+++ b/pkg/controller/common.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -32,8 +31,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
-	crdClientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -43,21 +41,16 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
 	azdiskv1beta2 "sigs.k8s.io/azuredisk-csi-driver/pkg/apis/azuredisk/v1beta2"
-	azdisk "sigs.k8s.io/azuredisk-csi-driver/pkg/apis/client/clientset/versioned"
-	azdiskinformers "sigs.k8s.io/azuredisk-csi-driver/pkg/apis/client/informers/externalversions"
+
 	consts "sigs.k8s.io/azuredisk-csi-driver/pkg/azureconstants"
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/azureutils"
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/provisioner"
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/util"
-	"sigs.k8s.io/azuredisk-csi-driver/pkg/watcher"
+
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/workflow"
 
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/client-go/kubernetes"
 	cache "k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/util/retry"
-	"k8s.io/kubernetes/pkg/features"
+
 	"sigs.k8s.io/cloud-provider-azure/pkg/provider"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -237,536 +230,29 @@ func newLockableEntry(entry interface{}) *lockableEntry {
 	}
 }
 
-type SharedState struct {
-	recoveryComplete              uint32
-	driverName                    string
-	objectNamespace               string
-	topologyKey                   string
-	podToClaimsMap                sync.Map
-	podToInlineMap                sync.Map
-	claimToPodsMap                sync.Map
-	volumeToClaimMap              sync.Map
-	claimToVolumeMap              sync.Map
-	azVolumeAttachmentToVaMap     sync.Map
-	pvToVolumeMap                 sync.Map
-	podLocks                      sync.Map
-	visitedVolumes                sync.Map
-	volumeOperationQueues         sync.Map
-	cleanUpMap                    sync.Map
-	priorityReplicaRequestsQueue  *VolumeReplicaRequestsPriorityQueue
-	processingReplicaRequestQueue int32
-	eventRecorder                 record.EventRecorder
-	cachedClient                  client.Client
-	azClient                      azdisk.Interface
-	kubeClient                    kubernetes.Interface
-	crdClient                     crdClientset.Interface
-	conditionWatcher              *watcher.ConditionWatcher
-}
-
-func NewSharedState(driverName, objectNamespace, topologyKey string, eventRecorder record.EventRecorder, cachedClient client.Client, azClient azdisk.Interface, kubeClient kubernetes.Interface, crdClient crdClientset.Interface) *SharedState {
-	newSharedState := &SharedState{driverName: driverName, objectNamespace: objectNamespace, topologyKey: topologyKey, eventRecorder: eventRecorder, cachedClient: cachedClient, azClient: azClient, kubeClient: kubeClient, crdClient: crdClient, conditionWatcher: watcher.New(context.Background(), azClient, azdiskinformers.NewSharedInformerFactory(azClient, consts.DefaultInformerResync), objectNamespace)}
-	newSharedState.createReplicaRequestsQueue()
-	return newSharedState
-}
-
-func (c *SharedState) isRecoveryComplete() bool {
-	return atomic.LoadUint32(&c.recoveryComplete) == 1
-}
-
-func (c *SharedState) MarkRecoveryComplete() {
-	atomic.StoreUint32(&c.recoveryComplete, 1)
-}
-
-func (c *SharedState) DeleteAPIVersion(ctx context.Context, deleteVersion string) error {
-	w, _ := workflow.GetWorkflowFromContext(ctx)
-	crdNames := []string{consts.AzDriverNodeCRDName, consts.AzVolumeCRDName, consts.AzVolumeAttachmentCRDName}
-	for _, crdName := range crdNames {
-		err := retry.RetryOnConflict(retry.DefaultBackoff,
-			func() error {
-				crd, err := c.crdClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crdName, metav1.GetOptions{})
-				if err != nil {
-					if apiErrors.IsNotFound(err) {
-						return err
-					}
-					return nil
-				}
-
-				updated := crd.DeepCopy()
-				var storedVersions []string
-				// remove version from status stored versions
-				for _, version := range updated.Status.StoredVersions {
-					if version == deleteVersion {
-						continue
-					}
-					storedVersions = append(storedVersions, version)
-				}
-				updated.Status.StoredVersions = storedVersions
-				crd, err = c.crdClient.ApiextensionsV1().CustomResourceDefinitions().UpdateStatus(ctx, updated, metav1.UpdateOptions{})
-				if err != nil {
-					// log the error and continue
-					return err
-				}
-				return nil
-			})
-
-		if err != nil {
-			w.Logger().Errorf(err, "failed to delete %s api version from CRD (%s)", deleteVersion, crdName)
-		}
-
-		// Uncomment when the all deployments have rolled over to v1beta1.
-		// updated = crd.DeepCopy()
-		// // remove version from spec versions
-		// var specVersions []crdv1.CustomResourceDefinitionVersion
-		// for _, version := range updated.Spec.Versions {
-		// 	if version.Name == deleteVersion {
-		// 		continue
-		// 	}
-		// 	specVersions = append(specVersions, version)
-		// }
-		// updated.Spec.Versions = specVersions
-
-		// // update the crd
-		// crd, err = c.crdClient.ApiextensionsV1().CustomResourceDefinitions().Update(ctx, updated, metav1.UpdateOptions{})
-		// if err != nil {
-		// 	// log the error and continue
-		// 	w.Logger().Errorf(err, "failed to remove %s spec version from CRD (%s)", deleteVersion, crd.Name)
-		// 	continue
-		// }
-	}
-	return nil
-}
-
-func (c *SharedState) createOperationQueue(volumeName string) {
-	_, _ = c.volumeOperationQueues.LoadOrStore(volumeName, newLockableEntry(newOperationQueue()))
-}
-
-func (c *SharedState) addToOperationQueue(ctx context.Context, volumeName string, requester operationRequester, operationFunc func(context.Context) error, isReplicaGarbageCollection bool) {
-	// It is expected for caller to provide parent workflow via context.
-	// The child workflow will be created below and be fed to the queued operation for necessary workflow information.
-	ctx, w := workflow.New(ctx, workflow.WithDetails(consts.VolumeNameLabel, volumeName))
-
-	v, ok := c.volumeOperationQueues.Load(volumeName)
-	if !ok {
-		return
-	}
-	lockable := v.(*lockableEntry)
-	lockable.Lock()
-
-	isFirst := lockable.entry.(*operationQueue).Len() <= 0
-	_ = lockable.entry.(*operationQueue).PushBack(&replicaOperation{
-		ctx:       ctx,
-		requester: requester,
-		operationFunc: func(ctx context.Context) (err error) {
-			defer func() {
-				if !shouldRequeueReplicaOperation(isReplicaGarbageCollection, err) {
-					w.Finish(err)
-				}
-			}()
-			err = operationFunc(ctx)
-			return
-		},
-		isReplicaGarbageCollection: isReplicaGarbageCollection,
-	})
-	lockable.Unlock()
-
-	// if first operation, start goroutine
-	if isFirst {
-		go func() {
-			lockable.Lock()
-			for {
-				operationQueue := lockable.entry.(*operationQueue)
-				// pop the first operation
-				front := operationQueue.Front()
-				operation := front.Value.(*replicaOperation)
-				lockable.Unlock()
-
-				// only run the operation if the operation requester is not enlisted in blacklist
-				if !operationQueue.gcExclusionList.has(operation.requester) {
-					if err := operation.operationFunc(operation.ctx); err != nil {
-						if shouldRequeueReplicaOperation(operation.isReplicaGarbageCollection, err) {
-							// if failed, push it to the end of the queue
-							lockable.Lock()
-							if operationQueue.isActive {
-								operationQueue.PushBack(operation)
-							}
-							lockable.Unlock()
-						}
-					}
-				}
-
-				lockable.Lock()
-				operationQueue.remove(front)
-				// there is no entry remaining, exit the loop
-				if operationQueue.Front() == nil {
-					break
-				}
-			}
-			lockable.Unlock()
-		}()
-	}
-}
-
 func shouldRequeueReplicaOperation(isReplicaGarbageCollection bool, err error) bool {
 	return !isReplicaGarbageCollection || !errors.Is(err, context.Canceled)
 }
 
-func (c *SharedState) deleteOperationQueue(volumeName string) {
-	v, ok := c.volumeOperationQueues.LoadAndDelete(volumeName)
-	// if operation queue has already been deleted, return
-	if !ok {
-		return
-	}
-	// clear the queue in case, there still is an entry in queue
-	lockable := v.(*lockableEntry)
-	lockable.Lock()
-	lockable.entry.(*operationQueue).Init()
-	lockable.Unlock()
-}
-
-func (c *SharedState) closeOperationQueue(volumeName string) func() {
-	v, ok := c.volumeOperationQueues.Load(volumeName)
-	if !ok {
-		return nil
-	}
-	lockable := v.(*lockableEntry)
-
-	lockable.Lock()
-	lockable.entry.(*operationQueue).isActive = false
-	lockable.entry.(*operationQueue).Init()
-	return lockable.Unlock
-}
-
-func (c *SharedState) addToGcExclusionList(volumeName string, target operationRequester) {
-	v, ok := c.volumeOperationQueues.Load(volumeName)
-	if !ok {
-		return
-	}
-	lockable := v.(*lockableEntry)
-	lockable.Lock()
-	lockable.entry.(*operationQueue).gcExclusionList.add(target)
-	lockable.Unlock()
-}
-
-func (c *SharedState) removeFromExclusionList(volumeName string, target operationRequester) {
-	v, ok := c.volumeOperationQueues.Load(volumeName)
-	if !ok {
-		return
-	}
-	lockable := v.(*lockableEntry)
-	lockable.Lock()
-	delete(lockable.entry.(*operationQueue).gcExclusionList, target)
-	lockable.Unlock()
-}
-
-func (c *SharedState) dequeueGarbageCollection(volumeName string) {
-	v, ok := c.volumeOperationQueues.Load(volumeName)
-	if !ok {
-		return
-	}
-	lockable := v.(*lockableEntry)
-	lockable.Lock()
-	queue := lockable.entry.(*operationQueue)
-	// look for garbage collection operation in the queue and remove from queue
-	var next *list.Element
-	for cur := queue.Front(); cur != nil; cur = next {
-		next = cur.Next()
-		if cur.Value.(*replicaOperation).isReplicaGarbageCollection {
-			queue.remove(cur)
-		}
-	}
-	lockable.Unlock()
-}
-
-func (c *SharedState) getVolumesFromPod(ctx context.Context, podName string) ([]string, error) {
-	w, _ := workflow.GetWorkflowFromContext(ctx)
-
-	var claims []string
-	w.Logger().V(5).Infof("Getting requested volumes for pod (%s).", podName)
-	value, ok := c.podToClaimsMap.Load(podName)
-	if !ok {
-		return nil, status.Errorf(codes.NotFound, "unable to find an entry for pod (%s) in podToClaims map", podName)
-	}
-	claims, ok = value.([]string)
-	if !ok {
-		return nil, status.Errorf(codes.Internal, "wrong output type: expected []string")
-	}
-
-	volumes := []string{}
-	for _, claim := range claims {
-		value, ok := c.claimToVolumeMap.Load(claim)
-		if !ok {
-			// the pvc entry is not an azure resource
-			w.Logger().V(5).Infof("Requested volume %s for pod %s is not an azure resource", value, podName)
-			continue
-		}
-		volume, ok := value.(string)
-		if !ok {
-			return nil, status.Errorf(codes.Internal, "wrong output type: expected string")
-		}
-		volumes = append(volumes, volume)
-		w.Logger().V(5).Infof("Requested volumes for pod %s are now the following: Volumes: %v, Len: %d", podName, volumes, len(volumes))
-	}
-	return volumes, nil
-}
-
-func (c *SharedState) getPodsFromVolume(ctx context.Context, client client.Client, volumeName string) ([]v1.Pod, error) {
-	w, _ := workflow.GetWorkflowFromContext(ctx)
-	pods, err := c.getPodNamesFromVolume(volumeName)
-	if err != nil {
-		return nil, err
-	}
-	podObjs := []v1.Pod{}
-	for _, pod := range pods {
-		namespace, name, err := parseQualifiedName(pod)
-		if err != nil {
-			w.Logger().Errorf(err, "cannot get podObj for pod (%s)", pod)
-			continue
-		}
-		var podObj v1.Pod
-		if err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &podObj); err != nil {
-			return nil, err
-		}
-		podObjs = append(podObjs, podObj)
-	}
-	return podObjs, nil
-}
-
-func (c *SharedState) getPodNamesFromVolume(volumeName string) ([]string, error) {
-	v, ok := c.volumeToClaimMap.Load(volumeName)
-	if !ok {
-		return nil, status.Errorf(codes.NotFound, "no bound persistent volume claim was found for AzVolume (%s)", volumeName)
-	}
-	claimName, ok := v.(string)
-	if !ok {
-		return nil, status.Errorf(codes.Internal, "volumeToClaimMap should should hold string")
-	}
-
-	value, ok := c.claimToPodsMap.Load(claimName)
-	if !ok {
-		return nil, status.Errorf(codes.NotFound, "no pods found for PVC (%s)", claimName)
-	}
-	lockable, ok := value.(*lockableEntry)
-	if !ok {
-		return nil, status.Errorf(codes.Internal, "claimToPodsMap should hold lockable entry")
-	}
-
-	lockable.RLock()
-	defer lockable.RUnlock()
-
-	podMap, ok := lockable.entry.(set)
-	if !ok {
-		return nil, status.Errorf(codes.Internal, "claimToPodsMap entry should hold a set")
-	}
-
-	pods := make([]string, len(podMap))
-	i := 0
-	for v := range podMap {
-		pod := v.(string)
-		pods[i] = pod
-		i++
-	}
-
-	return pods, nil
-}
-
-func (c *SharedState) getVolumesForPodObjs(ctx context.Context, pods []v1.Pod) ([]string, error) {
-	volumes := []string{}
-	for _, pod := range pods {
-		podVolumes, err := c.getVolumesFromPod(ctx, getQualifiedName(pod.Namespace, pod.Name))
-		if err != nil {
-			return nil, err
-		}
-		volumes = append(volumes, podVolumes...)
-	}
-	return volumes, nil
-}
-
-func (c *SharedState) addPod(ctx context.Context, pod *v1.Pod, updateOption updateWithLock) error {
-	w, _ := workflow.GetWorkflowFromContext(ctx)
-	podKey := getQualifiedName(pod.Namespace, pod.Name)
-	v, _ := c.podLocks.LoadOrStore(podKey, &sync.Mutex{})
-
-	w.Logger().V(5).Infof("Adding pod %s to shared map with keyName %s.", pod.Name, podKey)
-	podLock := v.(*sync.Mutex)
-	if updateOption == acquireLock {
-		podLock.Lock()
-		defer podLock.Unlock()
-	}
-	w.Logger().V(5).Infof("Pod spec of pod %s is: %+v. With volumes: %+v", pod.Name, pod.Spec, pod.Spec.Volumes)
-
-	// If the claims already exist for the podKey, add them to a set
-	value, _ := c.podToClaimsMap.LoadOrStore(podKey, []string{})
-	claims := value.([]string)
-	claimSet := set{}
-	for _, claim := range claims {
-		claimSet.add(claim)
-	}
-
-	for _, volume := range pod.Spec.Volumes {
-		// TODO: investigate if we need special support for CSI ephemeral volume or generic ephemeral volume
-		// if csiMigration is enabled and there is an inline volume, create AzVolume CRI for the inline volume.
-		if utilfeature.DefaultFeatureGate.Enabled(features.CSIMigration) &&
-			utilfeature.DefaultFeatureGate.Enabled(features.CSIMigrationAzureDisk) &&
-			volume.AzureDisk != nil {
-			// inline volume: create AzVolume resource
-			w.Logger().V(5).Infof("Creating AzVolume instance for inline volume %s.", volume.AzureDisk.DiskName)
-			if err := c.createAzVolumeFromInline(ctx, volume.AzureDisk); err != nil {
-				return err
-			}
-			v, exists := c.podToInlineMap.Load(podKey)
-			var inlines []string
-			if exists {
-				inlines = v.([]string)
-			}
-			inlines = append(inlines, volume.AzureDisk.DiskName)
-			c.podToInlineMap.Store(podKey, inlines)
-		}
-		if volume.PersistentVolumeClaim == nil {
-			w.Logger().V(5).Infof("Pod %s: Skipping Volume %s. No persistent volume exists.", pod.Name, volume)
-			continue
-		}
-		namespacedClaimName := getQualifiedName(pod.Namespace, volume.PersistentVolumeClaim.ClaimName)
-		if _, ok := c.claimToVolumeMap.Load(namespacedClaimName); !ok {
-			// Log message if the Pod status is Running
-			if pod.Status.Phase == v1.PodRunning {
-				w.Logger().V(5).Infof("Skipping Pod %s. Volume %s not csi. Driver: %+v", pod.Name, volume.Name, volume.CSI)
-			}
-			continue
-		}
-		w.Logger().V(5).Infof("Pod %s. Volume %v is csi.", pod.Name, volume)
-		claimSet.add(namespacedClaimName)
-		v, _ := c.claimToPodsMap.LoadOrStore(namespacedClaimName, newLockableEntry(set{}))
-
-		lockable := v.(*lockableEntry)
-		lockable.Lock()
-		pods := lockable.entry.(set)
-		if !pods.has(podKey) {
-			pods.add(podKey)
-		}
-		// No need to restore the amended set to claimToPodsMap because set is a reference type
-		lockable.Unlock()
-
-		w.Logger().V(5).Infof("Storing pod %s and claim %s to claimToPodsMap map.", pod.Name, namespacedClaimName)
-	}
-	w.Logger().V(5).Infof("Storing pod %s and claim %s to podToClaimsMap map.", pod.Name, claims)
-
-	allClaims := []string{}
-	for key := range claimSet {
-		allClaims = append(allClaims, key.(string))
-	}
-	c.podToClaimsMap.Store(podKey, allClaims)
-	return nil
-}
-
-func (c *SharedState) deletePod(ctx context.Context, podKey string) error {
-	w, _ := workflow.GetWorkflowFromContext(ctx)
-	value, exists := c.podLocks.LoadAndDelete(podKey)
-	if !exists {
-		return nil
-	}
-	podLock := value.(*sync.Mutex)
-	podLock.Lock()
-	defer podLock.Unlock()
-
-	value, exists = c.podToInlineMap.LoadAndDelete(podKey)
-	if exists {
-		inlines := value.([]string)
-
-		for _, inline := range inlines {
-			if err := c.azClient.DiskV1beta2().AzVolumes(c.objectNamespace).Delete(ctx, inline, metav1.DeleteOptions{}); err != nil && !apiErrors.IsNotFound(err) {
-				w.Logger().Errorf(err, "failed to delete AzVolume (%s) for inline (%s): %v", inline, inline, err)
-				return err
-			}
-		}
-	}
-
-	value, exists = c.podToClaimsMap.LoadAndDelete(podKey)
-	if !exists {
-		return nil
-	}
-	claims := value.([]string)
-
-	for _, claim := range claims {
-		value, ok := c.claimToPodsMap.Load(claim)
-		if !ok {
-			w.Logger().Errorf(nil, "No pods found for PVC (%s)", claim)
-		}
-
-		// Scope the duration that we hold the lockable lock using a function.
-		func() {
-			lockable, ok := value.(*lockableEntry)
-			if !ok {
-				w.Logger().Error(nil, "claimToPodsMap should hold lockable entry")
-				return
-			}
-
-			lockable.Lock()
-			defer lockable.Unlock()
-
-			podSet, ok := lockable.entry.(set)
-			if !ok {
-				w.Logger().Error(nil, "claimToPodsMap entry should hold a set")
-			}
-
-			podSet.remove(podKey)
-			if len(podSet) == 0 {
-				c.claimToPodsMap.Delete(claim)
-			}
-		}()
-	}
-	return nil
-}
-
-func (c *SharedState) addVolumeAndClaim(azVolumeName, pvName, pvClaimName string) {
-	c.pvToVolumeMap.Store(pvName, azVolumeName)
-	c.volumeToClaimMap.Store(azVolumeName, pvClaimName)
-	c.claimToVolumeMap.Store(pvClaimName, azVolumeName)
-}
-
-func (c *SharedState) deletePV(pvName string) {
-	c.pvToVolumeMap.Delete(pvName)
-}
-
-func (c *SharedState) deleteVolumeAndClaim(azVolumeName string) {
-	v, ok := c.volumeToClaimMap.LoadAndDelete(azVolumeName)
-	if ok {
-		pvClaimName := v.(string)
-		c.claimToVolumeMap.Delete(pvClaimName)
-	}
-}
-
-func (c *SharedState) markVolumeVisited(azVolumeName string) {
-	c.visitedVolumes.Store(azVolumeName, struct{}{})
-}
-
-func (c *SharedState) unmarkVolumeVisited(azVolumeName string) {
-	c.visitedVolumes.Delete(azVolumeName)
-}
-
-func (c *SharedState) isVolumeVisited(azVolumeName string) bool {
-	_, visited := c.visitedVolumes.Load(azVolumeName)
-	return visited
-}
-
 type filterPlugin interface {
 	name() string
-	setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, sharedState *SharedState)
+	setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, state *sharedState)
 	filter(ctx context.Context, nodes []v1.Node) ([]v1.Node, error)
 }
 
 // interPodAffinityFilter selects nodes that either meets inter-pod affinity rules or has replica mounts of volumes of pods with matching labels
 type interPodAffinityFilter struct {
-	pods        []v1.Pod
-	sharedState *SharedState
+	pods  []v1.Pod
+	state *sharedState
 }
 
 func (p *interPodAffinityFilter) name() string {
 	return "inter-pod affinity filter"
 }
 
-func (p *interPodAffinityFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, sharedState *SharedState) {
+func (p *interPodAffinityFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, state *sharedState) {
 	p.pods = pods
-	p.sharedState = sharedState
+	p.state = state
 }
 
 func (p *interPodAffinityFilter) filter(ctx context.Context, nodes []v1.Node) ([]v1.Node, error) {
@@ -800,7 +286,7 @@ func (p *interPodAffinityFilter) filter(ctx context.Context, nodes []v1.Node) ([
 				if len(podAffinity.Namespaces) > 0 {
 					for _, namespace := range podAffinity.Namespaces {
 						podList := &v1.PodList{}
-						if err = p.sharedState.cachedClient.List(ctx, podList, &client.ListOptions{LabelSelector: podAffinities, Namespace: namespace}); err != nil {
+						if err = p.state.cachedClient.List(ctx, podList, &client.ListOptions{LabelSelector: podAffinities, Namespace: namespace}); err != nil {
 							w.Logger().Errorf(err, "failed to retrieve pod list: %v", err)
 							continue
 						}
@@ -808,7 +294,7 @@ func (p *interPodAffinityFilter) filter(ctx context.Context, nodes []v1.Node) ([
 					}
 				} else {
 					podList := &v1.PodList{}
-					if err = p.sharedState.cachedClient.List(ctx, podList, &client.ListOptions{LabelSelector: podAffinities}); err != nil {
+					if err = p.state.cachedClient.List(ctx, podList, &client.ListOptions{LabelSelector: podAffinities}); err != nil {
 						w.Logger().Errorf(err, "failed to retrieve pod list: %v", err)
 						continue
 					}
@@ -822,9 +308,9 @@ func (p *interPodAffinityFilter) filter(ctx context.Context, nodes []v1.Node) ([
 				}
 
 				// add nodes, to which replica attachments of matching pods' volumes are attached, to replicaNodes
-				if volumes, err := p.sharedState.getVolumesForPodObjs(ctx, pods); err == nil {
+				if volumes, err := p.state.getVolumesForPodObjs(ctx, pods); err == nil {
 					for _, volume := range volumes {
-						attachments, err := azureutils.GetAzVolumeAttachmentsForVolume(ctx, p.sharedState.cachedClient, volume, azureutils.ReplicaOnly)
+						attachments, err := azureutils.GetAzVolumeAttachmentsForVolume(ctx, p.state.cachedClient, volume, azureutils.ReplicaOnly)
 						if err != nil {
 							continue
 						}
@@ -853,7 +339,7 @@ func (p *interPodAffinityFilter) filter(ctx context.Context, nodes []v1.Node) ([
 				qualifiedLabelSet := map[string]set{}
 				for node := range nodesWithSelectedPods {
 					var nodeInstance v1.Node
-					if err = p.sharedState.cachedClient.Get(ctx, types.NamespacedName{Name: node.(string)}, &nodeInstance); err != nil {
+					if err = p.state.cachedClient.Get(ctx, types.NamespacedName{Name: node.(string)}, &nodeInstance); err != nil {
 						w.Logger().Errorf(err, "failed to get node (%s)", node.(string))
 						continue
 					}
@@ -909,17 +395,17 @@ func (p *interPodAffinityFilter) filter(ctx context.Context, nodes []v1.Node) ([
 }
 
 type interPodAntiAffinityFilter struct {
-	pods        []v1.Pod
-	sharedState *SharedState
+	pods  []v1.Pod
+	state *sharedState
 }
 
 func (p *interPodAntiAffinityFilter) name() string {
 	return "inter-pod anti-affinity filter"
 }
 
-func (p *interPodAntiAffinityFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, sharedState *SharedState) {
+func (p *interPodAntiAffinityFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, state *sharedState) {
 	p.pods = pods
-	p.sharedState = sharedState
+	p.state = state
 }
 
 func (p *interPodAntiAffinityFilter) filter(ctx context.Context, nodes []v1.Node) ([]v1.Node, error) {
@@ -953,7 +439,7 @@ func (p *interPodAntiAffinityFilter) filter(ctx context.Context, nodes []v1.Node
 				if len(podAntiAffinity.Namespaces) > 0 {
 					for _, namespace := range podAntiAffinity.Namespaces {
 						podList := &v1.PodList{}
-						if err = p.sharedState.cachedClient.List(ctx, podList, &client.ListOptions{LabelSelector: podAntiAffinities, Namespace: namespace}); err != nil {
+						if err = p.state.cachedClient.List(ctx, podList, &client.ListOptions{LabelSelector: podAntiAffinities, Namespace: namespace}); err != nil {
 							w.Logger().Errorf(err, "failed to retrieve pod list: %v", err)
 							continue
 						}
@@ -961,7 +447,7 @@ func (p *interPodAntiAffinityFilter) filter(ctx context.Context, nodes []v1.Node
 					}
 				} else {
 					podList := &v1.PodList{}
-					if err = p.sharedState.cachedClient.List(ctx, podList, &client.ListOptions{LabelSelector: podAntiAffinities}); err != nil {
+					if err = p.state.cachedClient.List(ctx, podList, &client.ListOptions{LabelSelector: podAntiAffinities}); err != nil {
 						w.Logger().Errorf(err, "failed to retrieve pod list: %v", err)
 						continue
 					}
@@ -976,7 +462,7 @@ func (p *interPodAntiAffinityFilter) filter(ctx context.Context, nodes []v1.Node
 				qualifiedLabelSet := map[string]set{}
 				for node := range nodesWithSelectedPods {
 					var nodeInstance v1.Node
-					if err = p.sharedState.cachedClient.Get(ctx, types.NamespacedName{Name: node.(string)}, &nodeInstance); err != nil {
+					if err = p.state.cachedClient.Get(ctx, types.NamespacedName{Name: node.(string)}, &nodeInstance); err != nil {
 						w.Logger().Errorf(err, "failed to get node (%s)", node.(string))
 						continue
 					}
@@ -1033,7 +519,7 @@ func (p *podTolerationFilter) name() string {
 	return "pod toleration filter"
 }
 
-func (p *podTolerationFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, sharedState *SharedState) {
+func (p *podTolerationFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, state *sharedState) {
 	p.pods = pods
 }
 
@@ -1104,7 +590,7 @@ func (p *podNodeAffinityFilter) name() string {
 	return "pod node-affinity filter"
 }
 
-func (p *podNodeAffinityFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, sharedState *SharedState) {
+func (p *podNodeAffinityFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, state *sharedState) {
 	p.pods = pods
 }
 
@@ -1143,17 +629,17 @@ func (p *podNodeAffinityFilter) filter(ctx context.Context, nodes []v1.Node) ([]
 }
 
 type podNodeSelectorFilter struct {
-	pods        []v1.Pod
-	sharedState *SharedState
+	pods  []v1.Pod
+	state *sharedState
 }
 
 func (p *podNodeSelectorFilter) name() string {
 	return "pod node-selector filter"
 }
 
-func (p *podNodeSelectorFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, sharedState *SharedState) {
+func (p *podNodeSelectorFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, state *sharedState) {
 	p.pods = pods
-	p.sharedState = sharedState
+	p.state = state
 }
 
 func (p *podNodeSelectorFilter) filter(ctx context.Context, nodes []v1.Node) ([]v1.Node, error) {
@@ -1195,7 +681,7 @@ func (v *volumeNodeSelectorFilter) name() string {
 	return "volume node-selector filter"
 }
 
-func (v *volumeNodeSelectorFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, sharedState *SharedState) {
+func (v *volumeNodeSelectorFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, state *sharedState) {
 	v.persistentVolumes = persistentVolumes
 }
 
@@ -1242,29 +728,29 @@ func (v *volumeNodeSelectorFilter) filter(ctx context.Context, nodes []v1.Node) 
 
 type nodeScorerPlugin interface {
 	name() string
-	setup(pods []v1.Pod, volumes []string, sharedState *SharedState)
+	setup(pods []v1.Pod, volumes []string, state *sharedState)
 	score(ctx context.Context, nodeScores map[string]int) (map[string]int, error)
 }
 
 type scoreByNodeCapacity struct {
-	volumes     []string
-	sharedState *SharedState
+	volumes []string
+	state   *sharedState
 }
 
 func (s *scoreByNodeCapacity) name() string {
 	return "score by node capacity"
 }
 
-func (s *scoreByNodeCapacity) setup(pods []v1.Pod, volumes []string, sharedState *SharedState) {
+func (s *scoreByNodeCapacity) setup(pods []v1.Pod, volumes []string, state *sharedState) {
 	s.volumes = volumes
-	s.sharedState = sharedState
+	s.state = state
 }
 
 func (s *scoreByNodeCapacity) score(ctx context.Context, nodeScores map[string]int) (map[string]int, error) {
 	ctx, w := workflow.New(ctx, workflow.WithDetails("score-plugin", s.name()))
 	defer w.Finish(nil)
 	for nodeName, score := range nodeScores {
-		remainingCapacity, err := azureutils.GetNodeRemainingDiskCount(ctx, s.sharedState.cachedClient, nodeName)
+		remainingCapacity, err := azureutils.GetNodeRemainingDiskCount(ctx, s.state.cachedClient, nodeName)
 		if err != nil {
 			// if failed to get node's remaining capacity, remove the node from the candidate list and proceed
 			w.Logger().Errorf(err, "failed to get remaining capacity of node (%s)", nodeName)
@@ -1284,24 +770,24 @@ func (s *scoreByNodeCapacity) score(ctx context.Context, nodeScores map[string]i
 }
 
 type scoreByReplicaCount struct {
-	volumes     []string
-	sharedState *SharedState
+	volumes []string
+	state   *sharedState
 }
 
 func (s *scoreByReplicaCount) name() string {
 	return "score by replica count"
 }
 
-func (s *scoreByReplicaCount) setup(pods []v1.Pod, volumes []string, sharedState *SharedState) {
+func (s *scoreByReplicaCount) setup(pods []v1.Pod, volumes []string, state *sharedState) {
 	s.volumes = volumes
-	s.sharedState = sharedState
+	s.state = state
 }
 
 func (s *scoreByReplicaCount) score(ctx context.Context, nodeScores map[string]int) (map[string]int, error) {
 	ctx, w := workflow.New(ctx, workflow.WithDetails("score-plugin", s.name()))
 	defer w.Finish(nil)
 	for _, volume := range s.volumes {
-		azVolumeAttachments, err := azureutils.GetAzVolumeAttachmentsForVolume(ctx, s.sharedState.cachedClient, volume, azureutils.AllRoles)
+		azVolumeAttachments, err := azureutils.GetAzVolumeAttachmentsForVolume(ctx, s.state.cachedClient, volume, azureutils.AllRoles)
 		if err != nil {
 			w.Logger().V(5).Errorf(err, "Error listing AzVolumeAttachments for azvolume %s", volume)
 			continue
@@ -1318,281 +804,6 @@ func (s *scoreByReplicaCount) score(ctx context.Context, nodeScores map[string]i
 		}
 	}
 	return nodeScores, nil
-}
-
-func (c *SharedState) getRankedNodesForReplicaAttachments(ctx context.Context, volumes []string, podObjs []v1.Pod) ([]string, error) {
-	var err error
-	ctx, w := workflow.New(ctx)
-	defer func() { w.Finish(err) }()
-
-	w.Logger().V(5).Info("Getting ranked list of nodes for creating AzVolumeAttachments")
-
-	nodeList := &v1.NodeList{}
-	if err := c.cachedClient.List(ctx, nodeList); err != nil {
-		return nil, err
-	}
-
-	var selectedNodeObjs []v1.Node
-	selectedNodeObjs, err = c.selectNodesPerTopology(ctx, nodeList.Items, podObjs, volumes)
-	if err != nil {
-		w.Logger().Errorf(err, "failed to select nodes for volumes (%+v)", volumes)
-		return nil, err
-	}
-
-	selectedNodes := make([]string, len(selectedNodeObjs))
-	for i, selectedNodeObj := range selectedNodeObjs {
-		selectedNodes[i] = selectedNodeObj.Name
-	}
-
-	w.Logger().V(5).Infof("Selected nodes (%+v) for replica AzVolumeAttachments for volumes (%+v)", selectedNodes, volumes)
-	return selectedNodes, nil
-}
-
-func (c *SharedState) filterNodes(ctx context.Context, nodes []v1.Node, pods []v1.Pod, volumes []string) ([]v1.Node, error) {
-	var err error
-	ctx, w := workflow.New(ctx)
-	defer func() { w.Finish(err) }()
-
-	pvs := make([]*v1.PersistentVolume, len(volumes))
-	for i, volume := range volumes {
-		var azVolume *azdiskv1beta2.AzVolume
-		azVolume, err = azureutils.GetAzVolume(ctx, c.cachedClient, c.azClient, volume, c.objectNamespace, true)
-		if err != nil {
-			w.Logger().V(5).Errorf(err, "AzVolume for volume %s is not found.", volume)
-			return nil, err
-		}
-
-		var pv v1.PersistentVolume
-		if err = c.cachedClient.Get(ctx, types.NamespacedName{Name: azVolume.Spec.PersistentVolume}, &pv); err != nil {
-			return nil, err
-		}
-		pvs[i] = &pv
-	}
-
-	var filterPlugins = []filterPlugin{
-		&interPodAffinityFilter{},
-		&interPodAntiAffinityFilter{},
-		&podTolerationFilter{},
-		&podNodeAffinityFilter{},
-		&podNodeSelectorFilter{},
-		&volumeNodeSelectorFilter{},
-	}
-
-	filteredNodes := nodes
-	for _, filterPlugin := range filterPlugins {
-		filterPlugin.setup(pods, pvs, c)
-		if updatedFilteredNodes, err := filterPlugin.filter(ctx, filteredNodes); err != nil {
-			w.Logger().Errorf(err, "failed to filter node with filter plugin (%s). Ignoring filtered results.", filterPlugin.name())
-		} else {
-			filteredNodes = updatedFilteredNodes
-			nodeStrs := make([]string, len(filteredNodes))
-			for i, filteredNode := range filteredNodes {
-				nodeStrs[i] = filteredNode.Name
-			}
-			w.Logger().V(2).Infof("Filtered node list from filter plugin (%s): %+v", filterPlugin.name(), nodeStrs)
-		}
-	}
-
-	return filteredNodes, nil
-}
-
-func (c *SharedState) prioritizeNodes(ctx context.Context, pods []v1.Pod, volumes []string, nodes []v1.Node) []v1.Node {
-	ctx, w := workflow.New(ctx)
-	defer w.Finish(nil)
-
-	nodeScores := map[string]int{}
-	for _, node := range nodes {
-		nodeScores[node.Name] = 0
-	}
-
-	var nodeScorerPlugins = []nodeScorerPlugin{
-		&scoreByNodeCapacity{},
-		&scoreByReplicaCount{},
-	}
-
-	for _, nodeScorerPlugin := range nodeScorerPlugins {
-		nodeScorerPlugin.setup(pods, volumes, c)
-		if updatedNodeScores, err := nodeScorerPlugin.score(ctx, nodeScores); err != nil {
-			w.Logger().Errorf(err, "failed to score nodes by node scorer (%s)", nodeScorerPlugin.name())
-		} else {
-			// update node scores if scorer plugin returned success
-			nodeScores = updatedNodeScores
-		}
-	}
-
-	// normalize score
-	numFiltered := 0
-	for _, node := range nodes {
-		if _, exists := nodeScores[node.Name]; !exists {
-			nodeScores[node.Name] = -1
-			numFiltered++
-		}
-	}
-
-	sort.Slice(nodes[:], func(i, j int) bool {
-		return nodeScores[nodes[i].Name] > nodeScores[nodes[j].Name]
-	})
-
-	return nodes[:len(nodes)-numFiltered]
-}
-
-func (c *SharedState) filterAndSortNodes(ctx context.Context, nodes []v1.Node, pods []v1.Pod, volumes []string) ([]v1.Node, error) {
-	var err error
-	ctx, w := workflow.New(ctx)
-	defer func() { w.Finish(err) }()
-
-	var filteredNodes []v1.Node
-	filteredNodes, err = c.filterNodes(ctx, nodes, pods, volumes)
-	if err != nil {
-		w.Logger().Errorf(err, "failed to filter nodes for volumes (%+v): %v", volumes, err)
-		return nil, err
-	}
-	sortedNodes := c.prioritizeNodes(ctx, pods, volumes, filteredNodes)
-	return sortedNodes, nil
-}
-
-func (c *SharedState) selectNodesPerTopology(ctx context.Context, nodes []v1.Node, pods []v1.Pod, volumes []string) ([]v1.Node, error) {
-	var err error
-	ctx, w := workflow.New(ctx)
-	defer func() { w.Finish(err) }()
-
-	selectedNodes := []v1.Node{}
-	numReplicas := 0
-
-	// disperse node topology if possible
-	compatibleZonesSet := set{}
-	var primaryNode string
-	for i, volume := range volumes {
-		var azVolume *azdiskv1beta2.AzVolume
-		azVolume, err = azureutils.GetAzVolume(ctx, c.cachedClient, c.azClient, volume, c.objectNamespace, true)
-		if err != nil {
-			err = status.Errorf(codes.Aborted, "failed to get AzVolume CRI (%s)", volume)
-			return nil, err
-		}
-
-		numReplicas = max(numReplicas, azVolume.Spec.MaxMountReplicaCount)
-		w.Logger().V(5).Infof("Number of requested replicas for Azvolume (%s) is: %d. Max replica count is: %d.",
-			volume, numReplicas, azVolume.Spec.MaxMountReplicaCount)
-
-		var pv v1.PersistentVolume
-		if err = c.cachedClient.Get(ctx, types.NamespacedName{Name: azVolume.Spec.PersistentVolume}, &pv); err != nil {
-			return nil, err
-		}
-
-		if pv.Spec.NodeAffinity == nil || pv.Spec.NodeAffinity.Required == nil {
-			continue
-		}
-
-		// Find the intersection of the zones for all the volumes
-		topologyKey := c.topologyKey
-		if i == 0 {
-			compatibleZonesSet = getSupportedZones(pv.Spec.NodeAffinity.Required.NodeSelectorTerms, topologyKey)
-		} else {
-			listOfZones := getSupportedZones(pv.Spec.NodeAffinity.Required.NodeSelectorTerms, topologyKey)
-			for key := range compatibleZonesSet {
-				if !listOfZones.has(key) {
-					compatibleZonesSet.remove(key)
-				}
-			}
-		}
-
-		// find primary node if not already found
-		if primaryNode == "" {
-			if primaryAttachment, err := azureutils.GetAzVolumeAttachmentsForVolume(ctx, c.cachedClient, volume, azureutils.PrimaryOnly); err != nil || len(primaryAttachment) == 0 {
-				continue
-			} else {
-				primaryNode = primaryAttachment[0].Spec.NodeName
-			}
-		}
-	}
-
-	var compatibleZones []string
-	if len(compatibleZonesSet) > 0 {
-		for key := range compatibleZonesSet {
-			compatibleZones = append(compatibleZones, key.(string))
-		}
-	}
-
-	if len(compatibleZones) == 0 {
-		selectedNodes, err = c.filterAndSortNodes(ctx, nodes, pods, volumes)
-		if err != nil {
-			err = status.Errorf(codes.Aborted, "failed to select nodes for volumes (%+v): %v", volumes, err)
-			return nil, err
-		}
-	} else {
-		w.Logger().V(5).Infof("The list of zones to select nodes from is: %s", strings.Join(compatibleZones, ","))
-
-		var primaryNodeZone string
-		if primaryNode != "" {
-			nodeObj := &v1.Node{}
-			err = c.cachedClient.Get(ctx, types.NamespacedName{Name: primaryNode}, nodeObj)
-			if err != nil {
-				w.Logger().Errorf(err, "failed to retrieve the primary node")
-			}
-
-			var ok bool
-			if primaryNodeZone, ok = nodeObj.Labels[consts.WellKnownTopologyKey]; ok {
-				w.Logger().V(5).Infof("failed to find zone annotations for primary node")
-			}
-		}
-
-		nodeSelector := labels.NewSelector()
-		zoneRequirement, _ := labels.NewRequirement(consts.WellKnownTopologyKey, selection.In, compatibleZones)
-		nodeSelector = nodeSelector.Add(*zoneRequirement)
-
-		compatibleNodes := &v1.NodeList{}
-		if err = c.cachedClient.List(ctx, compatibleNodes, &client.ListOptions{LabelSelector: nodeSelector}); err != nil {
-			err = status.Errorf(codes.Aborted, "failed to retrieve node list: %v", err)
-			return nodes, err
-		}
-
-		// Create a zone to node map
-		zoneToNodeMap := map[string][]v1.Node{}
-		for _, node := range compatibleNodes.Items {
-			zoneName := node.Labels[consts.WellKnownTopologyKey]
-			zoneToNodeMap[zoneName] = append(zoneToNodeMap[zoneName], node)
-		}
-
-		// Get prioritized nodes per zone
-		nodesPerZone := [][]v1.Node{}
-		primaryZoneNodes := []v1.Node{}
-		totalCount := 0
-		for zone, nodeList := range zoneToNodeMap {
-			var sortedNodes []v1.Node
-			sortedNodes, err = c.filterAndSortNodes(ctx, nodeList, pods, volumes)
-			if err != nil {
-				err = status.Errorf(codes.Aborted, "failed to select nodes for volumes (%+v): %v", volumes, err)
-				return nil, err
-			}
-
-			totalCount += len(sortedNodes)
-			if zone == primaryNodeZone {
-				primaryZoneNodes = sortedNodes
-				continue
-			}
-			nodesPerZone = append(nodesPerZone, sortedNodes)
-		}
-		// Append the nodes from the zone of the primary node at last
-		if len(primaryZoneNodes) > 0 {
-			nodesPerZone = append(nodesPerZone, primaryZoneNodes)
-		}
-		// Select the nodes from each of the zones one by one and append to the list
-		i, j, countSoFar := 0, 0, 0
-		for len(selectedNodes) < numReplicas && countSoFar < totalCount {
-			if len(nodesPerZone[i]) > j {
-				selectedNodes = append(selectedNodes, nodesPerZone[i][j])
-				countSoFar++
-			}
-			if i < len(nodesPerZone)-1 {
-				i++
-			} else {
-				i = 0
-				j++
-			}
-		}
-	}
-
-	return selectedNodes[:min(len(selectedNodes), numReplicas)], nil
 }
 
 func getSupportedZones(nodeSelectorTerms []v1.NodeSelectorTerm, topologyKey string) set {
@@ -1614,180 +825,6 @@ func getSupportedZones(nodeSelectorTerms []v1.NodeSelectorTerm, topologyKey stri
 		}
 	}
 	return supportedZones
-}
-
-func (c *SharedState) getNodesWithReplica(ctx context.Context, volumeName string) ([]string, error) {
-	w, _ := workflow.GetWorkflowFromContext(ctx)
-	w.Logger().V(5).Infof("Getting nodes with replica AzVolumeAttachments for volume %s.", volumeName)
-	azVolumeAttachments, err := azureutils.GetAzVolumeAttachmentsForVolume(ctx, c.cachedClient, volumeName, azureutils.ReplicaOnly)
-	if err != nil {
-		w.Logger().V(5).Errorf(err, "failed to get AzVolumeAttachments for volume %s.", volumeName)
-		return nil, err
-	}
-
-	nodes := []string{}
-	for _, azVolumeAttachment := range azVolumeAttachments {
-		nodes = append(nodes, azVolumeAttachment.Spec.NodeName)
-	}
-	w.Logger().V(5).Infof("Nodes with AzVolumeAttachments for volume %s are: %v, Len: %d", volumeName, nodes, len(nodes))
-	return nodes, nil
-}
-
-func (c *SharedState) createReplicaAzVolumeAttachment(ctx context.Context, volumeID, node string, volumeContext map[string]string) error {
-	var err error
-	ctx, w := workflow.New(ctx, workflow.WithDetails(consts.NodeNameLabel, node))
-	defer func() { w.Finish(err) }()
-
-	var diskName string
-	diskName, err = azureutils.GetDiskName(volumeID)
-	if err != nil {
-		err = status.Errorf(codes.Internal, "failed to extract volume name from volumeID (%s)", volumeID)
-		return err
-	}
-	w.AddDetailToLogger(consts.VolumeNameLabel, diskName)
-
-	w.Logger().V(5).Info("Creating replica AzVolumeAttachments")
-	if volumeContext == nil {
-		volumeContext = make(map[string]string)
-	}
-	// creating azvolumeattachment
-	volumeName := strings.ToLower(diskName)
-	replicaName := azureutils.GetAzVolumeAttachmentName(volumeName, node)
-	azVolumeAttachment := azdiskv1beta2.AzVolumeAttachment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      replicaName,
-			Namespace: c.objectNamespace,
-			Labels: map[string]string{
-				consts.NodeNameLabel:   node,
-				consts.VolumeNameLabel: volumeName,
-				consts.RoleLabel:       string(azdiskv1beta2.ReplicaRole),
-			},
-			Annotations: map[string]string{consts.VolumeAttachRequestAnnotation: "controller"},
-			Finalizers:  []string{consts.AzVolumeAttachmentFinalizer},
-		},
-		Spec: azdiskv1beta2.AzVolumeAttachmentSpec{
-			NodeName:      node,
-			VolumeID:      volumeID,
-			VolumeName:    volumeName,
-			RequestedRole: azdiskv1beta2.ReplicaRole,
-			VolumeContext: volumeContext,
-		},
-	}
-	w.AnnotateObject(&azVolumeAttachment)
-	_, err = c.azClient.DiskV1beta2().AzVolumeAttachments(c.objectNamespace).Create(ctx, &azVolumeAttachment, metav1.CreateOptions{})
-	if err != nil {
-		err = status.Errorf(codes.Internal, "failed to create replica AzVolumeAttachment %s.", replicaName)
-		return err
-	}
-	return nil
-}
-
-func (c *SharedState) cleanUpAzVolumeAttachmentByVolume(ctx context.Context, azVolumeName string, caller operationRequester, role azureutils.AttachmentRoleMode, deleteMode cleanUpMode) ([]azdiskv1beta2.AzVolumeAttachment, error) {
-	var err error
-	ctx, w := workflow.New(ctx, workflow.WithDetails(consts.VolumeNameLabel, azVolumeName))
-	defer func() { w.Finish(err) }()
-
-	w.Logger().Infof("AzVolumeAttachment clean up requested by %s for AzVolume (%s)", caller, azVolumeName)
-
-	var attachments []azdiskv1beta2.AzVolumeAttachment
-	attachments, err = azureutils.GetAzVolumeAttachmentsForVolume(ctx, c.cachedClient, azVolumeName, role)
-	if err != nil {
-		if apiErrors.IsNotFound(err) {
-			err = nil
-			return nil, nil
-		}
-		err = status.Errorf(codes.Aborted, "failed to get AzVolumeAttachments: %v", err)
-		return nil, err
-	}
-
-	if err = c.cleanUpAzVolumeAttachments(ctx, attachments, deleteMode, caller); err != nil {
-		return attachments, err
-	}
-	c.unmarkVolumeVisited(azVolumeName)
-	return attachments, nil
-}
-
-func (c *SharedState) cleanUpAzVolumeAttachmentByNode(ctx context.Context, azDriverNodeName string, caller operationRequester, role azureutils.AttachmentRoleMode, deleteMode cleanUpMode) ([]azdiskv1beta2.AzVolumeAttachment, error) {
-	var err error
-	ctx, w := workflow.New(ctx, workflow.WithDetails(consts.NodeNameLabel, azDriverNodeName))
-	defer func() { w.Finish(err) }()
-	w.Logger().Infof("AzVolumeAttachment clean up requested by %s for AzDriverNode (%s)", caller, azDriverNodeName)
-
-	var nodeRequirement *labels.Requirement
-	nodeRequirement, err = azureutils.CreateLabelRequirements(consts.NodeNameLabel, selection.Equals, azDriverNodeName)
-	if err != nil {
-		return nil, err
-	}
-	labelSelector := labels.NewSelector().Add(*nodeRequirement)
-
-	var attachments *azdiskv1beta2.AzVolumeAttachmentList
-	attachments, err = c.azClient.DiskV1beta2().AzVolumeAttachments(c.objectNamespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector.String()})
-	if err != nil {
-		if apiErrors.IsNotFound(err) {
-			err = nil
-			return nil, nil
-		}
-		err = status.Errorf(codes.Aborted, "failed to get AzVolumeAttachments: %v", err)
-		return nil, err
-	}
-
-	cleanUpMap := map[string][]azdiskv1beta2.AzVolumeAttachment{}
-	for _, attachment := range attachments.Items {
-		if shouldCleanUp(attachment, role) {
-			cleanUpMap[attachment.Spec.VolumeName] = append(cleanUpMap[attachment.Spec.VolumeName], attachment)
-		}
-	}
-
-	for volumeName, cleanUps := range cleanUpMap {
-		volumeName := volumeName
-		defer w.Finish(nil)
-		c.addToOperationQueue(ctx,
-			volumeName,
-			caller,
-			func(ctx context.Context) error {
-				return c.cleanUpAzVolumeAttachments(ctx, cleanUps, deleteMode, caller)
-			},
-			false)
-	}
-	return attachments.Items, nil
-}
-
-func (c *SharedState) cleanUpAzVolumeAttachments(ctx context.Context, attachments []azdiskv1beta2.AzVolumeAttachment, cleanUp cleanUpMode, caller operationRequester) error {
-	var err error
-	w, _ := workflow.GetWorkflowFromContext(ctx)
-
-	for _, attachment := range attachments {
-		var patchRequired bool
-		patched := attachment.DeepCopy()
-
-		// if caller is azdrivernode, don't append cleanup annotation
-		if (caller != azdrivernode && !metav1.HasAnnotation(patched.ObjectMeta, consts.CleanUpAnnotation)) ||
-			// replica attachments should always be detached regardless of the cleanup mode
-			((cleanUp == detachAndDeleteCRI || patched.Spec.RequestedRole == azdiskv1beta2.ReplicaRole) && !metav1.HasAnnotation(patched.ObjectMeta, consts.VolumeDetachRequestAnnotation)) {
-			patchRequired = true
-			if caller != azdrivernode {
-				patched.Status.Annotations = azureutils.AddToMap(patched.Status.Annotations, consts.CleanUpAnnotation, string(caller))
-			}
-			if cleanUp == detachAndDeleteCRI || patched.Spec.RequestedRole == azdiskv1beta2.ReplicaRole {
-				patched.Status.Annotations = azureutils.AddToMap(patched.Status.Annotations, consts.VolumeDetachRequestAnnotation, string(caller))
-			}
-		}
-
-		if patchRequired {
-			if err = c.cachedClient.Status().Patch(ctx, patched, client.MergeFrom(&attachment)); err != nil && apiErrors.IsNotFound(err) {
-				err = status.Errorf(codes.Internal, "failed to patch AzVolumeAttachment (%s)", attachment.Name)
-				return err
-			}
-		}
-		if !objectDeletionRequested(patched) {
-			if err := c.cachedClient.Delete(ctx, patched); err != nil && apiErrors.IsNotFound(err) {
-				err = status.Errorf(codes.Internal, "failed to delete AzVolumeAttachment (%s)", attachment.Name)
-				return err
-			}
-			w.Logger().V(5).Infof("Set deletion timestamp for AzVolumeAttachment (%s)", attachment.Name)
-		}
-	}
-	return nil
 }
 
 func shouldCleanUp(attachment azdiskv1beta2.AzVolumeAttachment, mode azureutils.AttachmentRoleMode) bool {
@@ -1932,17 +969,6 @@ type VolumeReplicaRequestsPriorityQueue struct {
 	size  int32
 }
 
-func (c *SharedState) createReplicaRequestsQueue() {
-	c.priorityReplicaRequestsQueue = &VolumeReplicaRequestsPriorityQueue{}
-	c.priorityReplicaRequestsQueue.queue = cache.NewHeap(
-		func(obj interface{}) (string, error) {
-			return obj.(*ReplicaRequest).VolumeName, nil
-		},
-		func(left, right interface{}) bool {
-			return left.(*ReplicaRequest).Priority > right.(*ReplicaRequest).Priority
-		})
-}
-
 func (vq *VolumeReplicaRequestsPriorityQueue) Push(ctx context.Context, replicaRequest *ReplicaRequest) {
 	w, _ := workflow.GetWorkflowFromContext(ctx)
 	err := vq.queue.Add(replicaRequest)
@@ -1963,205 +989,6 @@ func (vq *VolumeReplicaRequestsPriorityQueue) DrainQueue() []*ReplicaRequest {
 		listRequests = append(listRequests, vq.Pop())
 	}
 	return listRequests
-}
-
-// Removes replica requests from the priority queue and adds to operation queue.
-func (c *SharedState) tryCreateFailedReplicas(ctx context.Context, requestor operationRequester) {
-	if atomic.SwapInt32(&c.processingReplicaRequestQueue, 1) == 0 {
-		ctx, w := workflow.New(ctx)
-		defer w.Finish(nil)
-		requests := c.priorityReplicaRequestsQueue.DrainQueue()
-		for i := 0; i < len(requests); i++ {
-			replicaRequest := requests[i]
-			c.addToOperationQueue(ctx,
-				replicaRequest.VolumeName,
-				requestor,
-				func(ctx context.Context) error {
-					return c.manageReplicas(ctx, replicaRequest.VolumeName)
-				},
-				false,
-			)
-		}
-		atomic.StoreInt32(&c.processingReplicaRequestQueue, 0)
-	}
-}
-
-func (c *SharedState) garbageCollectReplicas(ctx context.Context, volumeName string, requester operationRequester) {
-	c.addToOperationQueue(
-		ctx,
-		volumeName,
-		replica,
-		func(ctx context.Context) error {
-			if _, err := c.cleanUpAzVolumeAttachmentByVolume(ctx, volumeName, requester, azureutils.ReplicaOnly, detachAndDeleteCRI); err != nil {
-				return err
-			}
-			c.addToGcExclusionList(volumeName, replica)
-			c.removeGarbageCollection(volumeName)
-			c.unmarkVolumeVisited(volumeName)
-			return nil
-		},
-		true,
-	)
-}
-
-func (c *SharedState) removeGarbageCollection(volumeName string) {
-	v, ok := c.cleanUpMap.LoadAndDelete(volumeName)
-	if ok {
-		cancelFunc := v.(context.CancelFunc)
-		cancelFunc()
-	}
-	// if there is any garbage collection enqueued in operation queue, remove it
-	c.dequeueGarbageCollection(volumeName)
-}
-
-func (c *SharedState) manageReplicas(ctx context.Context, volumeName string) error {
-	var err error
-	ctx, w := workflow.New(ctx)
-	defer func() { w.Finish(err) }()
-
-	var azVolume *azdiskv1beta2.AzVolume
-	azVolume, err = azureutils.GetAzVolume(ctx, c.cachedClient, c.azClient, volumeName, c.objectNamespace, true)
-	if apiErrors.IsNotFound(err) {
-		w.Logger().Info("Volume no longer exists. Aborting manage replica operation")
-		return nil
-	} else if err != nil {
-		w.Logger().Error(err, "failed to get AzVolume")
-		return err
-	}
-
-	// replica management should not be executed or retried if AzVolume is scheduled for a deletion or not created.
-	if !isCreated(azVolume) || objectDeletionRequested(azVolume) {
-		w.Logger().Errorf(err, "azVolume is scheduled for deletion or has no underlying volume object")
-		return nil
-	}
-
-	azVolumeAttachments, err := azureutils.GetAzVolumeAttachmentsForVolume(ctx, c.cachedClient, volumeName, azureutils.ReplicaOnly)
-	if err != nil {
-		w.Logger().Errorf(err, "failed to list replica AzVolumeAttachments")
-		return err
-	}
-
-	desiredReplicaCount, currentReplicaCount := azVolume.Spec.MaxMountReplicaCount, len(azVolumeAttachments)
-	w.Logger().Infof("Control number of replicas for volume (%s): desired=%d,\tcurrent:%d", azVolume.Spec.VolumeName, desiredReplicaCount, currentReplicaCount)
-
-	if desiredReplicaCount > currentReplicaCount {
-		w.Logger().Infof("Need %d more replicas for volume (%s)", desiredReplicaCount-currentReplicaCount, azVolume.Spec.VolumeName)
-		if azVolume.Status.Detail == nil || azVolume.Status.State == azdiskv1beta2.VolumeDeleting || azVolume.Status.State == azdiskv1beta2.VolumeDeleted {
-			// underlying volume does not exist, so volume attachment cannot be made
-			return nil
-		}
-		if err = c.createReplicas(ctx, desiredReplicaCount-currentReplicaCount, azVolume.Name, azVolume.Status.Detail.VolumeID, azVolume.Spec.Parameters); err != nil {
-			w.Logger().Errorf(err, "failed to create %d replicas for volume (%s): %v", desiredReplicaCount-currentReplicaCount, azVolume.Spec.VolumeName, err)
-			return err
-		}
-	}
-	return nil
-}
-func (c *SharedState) createReplicas(ctx context.Context, remainingReplicas int, volumeName, volumeID string, volumeContext map[string]string) error {
-	var err error
-	ctx, w := workflow.New(ctx)
-	defer func() { w.Finish(err) }()
-
-	// if volume is scheduled for clean up, skip replica creation
-	if _, cleanUpScheduled := c.cleanUpMap.Load(volumeName); cleanUpScheduled {
-		return nil
-	}
-
-	// get pods linked to the volume
-	var pods []v1.Pod
-	pods, err = c.getPodsFromVolume(ctx, c.cachedClient, volumeName)
-	if err != nil {
-		return err
-	}
-
-	// acquire per-pod lock to be released upon creation of replica AzVolumeAttachment CRIs
-	for _, pod := range pods {
-		podKey := getQualifiedName(pod.Namespace, pod.Name)
-		v, _ := c.podLocks.LoadOrStore(podKey, &sync.Mutex{})
-		podLock := v.(*sync.Mutex)
-		podLock.Lock()
-		defer podLock.Unlock()
-	}
-
-	var nodes []string
-	nodes, err = c.getNodesForReplica(ctx, volumeName, pods, remainingReplicas)
-	if err != nil {
-		w.Logger().Errorf(err, "failed to get a list of nodes for replica attachment")
-		return err
-	}
-
-	requiredReplicas := remainingReplicas
-	for _, node := range nodes {
-		if err = c.createReplicaAzVolumeAttachment(ctx, volumeID, node, volumeContext); err != nil {
-			w.Logger().Errorf(err, "failed to create replica AzVolumeAttachment for volume %s", volumeName)
-			//Push to queue the failed replica number
-			request := ReplicaRequest{VolumeName: volumeName, Priority: remainingReplicas}
-			c.priorityReplicaRequestsQueue.Push(ctx, &request)
-			return err
-		}
-		remainingReplicas--
-	}
-
-	if remainingReplicas > 0 {
-		//no failed replica attachments, but there are still more replicas to reach MaxShares
-		request := ReplicaRequest{VolumeName: volumeName, Priority: remainingReplicas}
-		c.priorityReplicaRequestsQueue.Push(ctx, &request)
-		for _, pod := range pods {
-			c.eventRecorder.Eventf(pod.DeepCopyObject(), v1.EventTypeWarning, consts.ReplicaAttachmentFailedEvent, "Not enough suitable nodes to attach %d of %d replica mount(s) for volume %s", remainingReplicas, requiredReplicas, volumeName)
-		}
-	}
-	return nil
-}
-
-func (c *SharedState) getNodesForReplica(ctx context.Context, volumeName string, pods []v1.Pod, numReplica int) ([]string, error) {
-	var err error
-	ctx, w := workflow.New(ctx)
-	defer func() { w.Finish(err) }()
-
-	if len(pods) == 0 {
-		pods, err = c.getPodsFromVolume(ctx, c.cachedClient, volumeName)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	var volumes []string
-	volumes, err = c.getVolumesForPodObjs(ctx, pods)
-	if err != nil {
-		return nil, err
-	}
-
-	var nodes []string
-	nodes, err = c.getRankedNodesForReplicaAttachments(ctx, volumes, pods)
-	if err != nil {
-		return nil, err
-	}
-
-	var replicaNodes []string
-	replicaNodes, err = c.getNodesWithReplica(ctx, volumeName)
-	if err != nil {
-		return nil, err
-	}
-
-	skipSet := map[string]bool{}
-	for _, replicaNode := range replicaNodes {
-		skipSet[replicaNode] = true
-	}
-
-	filtered := []string{}
-	numFiltered := 0
-	for _, node := range nodes {
-		if numFiltered >= numReplica {
-			break
-		}
-		if skipSet[node] {
-			continue
-		}
-		filtered = append(filtered, node)
-		numFiltered++
-	}
-
-	return filtered, nil
 }
 
 func verifyObjectDeleted(obj interface{}, objectDeleted bool) (bool, error) {

--- a/pkg/controller/common.go
+++ b/pkg/controller/common.go
@@ -236,21 +236,21 @@ func shouldRequeueReplicaOperation(isReplicaGarbageCollection bool, err error) b
 
 type filterPlugin interface {
 	name() string
-	setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, state *sharedState)
+	setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, state *SharedState)
 	filter(ctx context.Context, nodes []v1.Node) ([]v1.Node, error)
 }
 
 // interPodAffinityFilter selects nodes that either meets inter-pod affinity rules or has replica mounts of volumes of pods with matching labels
 type interPodAffinityFilter struct {
 	pods  []v1.Pod
-	state *sharedState
+	state *SharedState
 }
 
 func (p *interPodAffinityFilter) name() string {
 	return "inter-pod affinity filter"
 }
 
-func (p *interPodAffinityFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, state *sharedState) {
+func (p *interPodAffinityFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, state *SharedState) {
 	p.pods = pods
 	p.state = state
 }
@@ -396,14 +396,14 @@ func (p *interPodAffinityFilter) filter(ctx context.Context, nodes []v1.Node) ([
 
 type interPodAntiAffinityFilter struct {
 	pods  []v1.Pod
-	state *sharedState
+	state *SharedState
 }
 
 func (p *interPodAntiAffinityFilter) name() string {
 	return "inter-pod anti-affinity filter"
 }
 
-func (p *interPodAntiAffinityFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, state *sharedState) {
+func (p *interPodAntiAffinityFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, state *SharedState) {
 	p.pods = pods
 	p.state = state
 }
@@ -519,7 +519,7 @@ func (p *podTolerationFilter) name() string {
 	return "pod toleration filter"
 }
 
-func (p *podTolerationFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, state *sharedState) {
+func (p *podTolerationFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, state *SharedState) {
 	p.pods = pods
 }
 
@@ -590,7 +590,7 @@ func (p *podNodeAffinityFilter) name() string {
 	return "pod node-affinity filter"
 }
 
-func (p *podNodeAffinityFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, state *sharedState) {
+func (p *podNodeAffinityFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, state *SharedState) {
 	p.pods = pods
 }
 
@@ -630,14 +630,14 @@ func (p *podNodeAffinityFilter) filter(ctx context.Context, nodes []v1.Node) ([]
 
 type podNodeSelectorFilter struct {
 	pods  []v1.Pod
-	state *sharedState
+	state *SharedState
 }
 
 func (p *podNodeSelectorFilter) name() string {
 	return "pod node-selector filter"
 }
 
-func (p *podNodeSelectorFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, state *sharedState) {
+func (p *podNodeSelectorFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, state *SharedState) {
 	p.pods = pods
 	p.state = state
 }
@@ -681,7 +681,7 @@ func (v *volumeNodeSelectorFilter) name() string {
 	return "volume node-selector filter"
 }
 
-func (v *volumeNodeSelectorFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, state *sharedState) {
+func (v *volumeNodeSelectorFilter) setup(pods []v1.Pod, persistentVolumes []*v1.PersistentVolume, state *SharedState) {
 	v.persistentVolumes = persistentVolumes
 }
 
@@ -728,20 +728,20 @@ func (v *volumeNodeSelectorFilter) filter(ctx context.Context, nodes []v1.Node) 
 
 type nodeScorerPlugin interface {
 	name() string
-	setup(pods []v1.Pod, volumes []string, state *sharedState)
+	setup(pods []v1.Pod, volumes []string, state *SharedState)
 	score(ctx context.Context, nodeScores map[string]int) (map[string]int, error)
 }
 
 type scoreByNodeCapacity struct {
 	volumes []string
-	state   *sharedState
+	state   *SharedState
 }
 
 func (s *scoreByNodeCapacity) name() string {
 	return "score by node capacity"
 }
 
-func (s *scoreByNodeCapacity) setup(pods []v1.Pod, volumes []string, state *sharedState) {
+func (s *scoreByNodeCapacity) setup(pods []v1.Pod, volumes []string, state *SharedState) {
 	s.volumes = volumes
 	s.state = state
 }
@@ -771,14 +771,14 @@ func (s *scoreByNodeCapacity) score(ctx context.Context, nodeScores map[string]i
 
 type scoreByReplicaCount struct {
 	volumes []string
-	state   *sharedState
+	state   *SharedState
 }
 
 func (s *scoreByReplicaCount) name() string {
 	return "score by replica count"
 }
 
-func (s *scoreByReplicaCount) setup(pods []v1.Pod, volumes []string, state *sharedState) {
+func (s *scoreByReplicaCount) setup(pods []v1.Pod, volumes []string, state *SharedState) {
 	s.volumes = volumes
 	s.state = state
 }

--- a/pkg/controller/common_test.go
+++ b/pkg/controller/common_test.go
@@ -342,7 +342,7 @@ func createPod(podNamespace, podName string, pvcs []string) v1.Pod {
 	return testPod
 }
 
-func initState(client client.Client, azClient azdisk.Interface, kubeClient kubernetes.Interface, objs ...runtime.Object) (c *SharedState) {
+func initState(client client.Client, azClient azdisk.Interface, kubeClient kubernetes.Interface, objs ...runtime.Object) (c *sharedState) {
 	c = NewSharedState(consts.DefaultDriverName, consts.DefaultAzureDiskCrdNamespace, consts.WellKnownTopologyKey, &record.FakeRecorder{}, client, azClient, kubeClient, nil)
 	c.MarkRecoveryComplete()
 

--- a/pkg/controller/common_test.go
+++ b/pkg/controller/common_test.go
@@ -342,7 +342,7 @@ func createPod(podNamespace, podName string, pvcs []string) v1.Pod {
 	return testPod
 }
 
-func initState(client client.Client, azClient azdisk.Interface, kubeClient kubernetes.Interface, objs ...runtime.Object) (c *sharedState) {
+func initState(client client.Client, azClient azdisk.Interface, kubeClient kubernetes.Interface, objs ...runtime.Object) (c *SharedState) {
 	c = NewSharedState(consts.DefaultDriverName, consts.DefaultAzureDiskCrdNamespace, consts.WellKnownTopologyKey, &record.FakeRecorder{}, client, azClient, kubeClient, nil)
 	c.MarkRecoveryComplete()
 

--- a/pkg/controller/node_availability.go
+++ b/pkg/controller/node_availability.go
@@ -33,8 +33,8 @@ import (
 )
 
 type ReconcileNodeAvailability struct {
+	*SharedState
 	logger logr.Logger
-	*sharedState
 }
 
 var _ reconcile.Reconciler = &ReconcileNodeAvailability{}
@@ -64,10 +64,10 @@ func (r *ReconcileNodeAvailability) Reconcile(ctx context.Context, request recon
 	return reconcile.Result{Requeue: false}, err
 }
 
-func NewNodeAvailabilityController(mgr manager.Manager, controllerSharedState *sharedState) (*ReconcileNodeAvailability, error) {
+func NewNodeAvailabilityController(mgr manager.Manager, controllerSharedState *SharedState) (*ReconcileNodeAvailability, error) {
 	logger := mgr.GetLogger().WithValues("controller", "nodeavailability")
 	reconciler := ReconcileNodeAvailability{
-		sharedState: controllerSharedState,
+		SharedState: controllerSharedState,
 		logger:      logger,
 	}
 

--- a/pkg/controller/node_availability_test.go
+++ b/pkg/controller/node_availability_test.go
@@ -43,7 +43,7 @@ func NewTestNodeAvailabilityController(controller *gomock.Controller, namespace 
 	controllerSharedState := initState(mockclient.NewMockClient(controller), azdiskfakes.NewSimpleClientset(diskv1alpha1Objs...), fakev1.NewSimpleClientset(kubeObjs...), objects...)
 
 	return &ReconcileNodeAvailability{
-		sharedState: controllerSharedState,
+		SharedState: controllerSharedState,
 		logger:      klogr.New(),
 	}
 }

--- a/pkg/controller/node_availability_test.go
+++ b/pkg/controller/node_availability_test.go
@@ -43,8 +43,8 @@ func NewTestNodeAvailabilityController(controller *gomock.Controller, namespace 
 	controllerSharedState := initState(mockclient.NewMockClient(controller), azdiskfakes.NewSimpleClientset(diskv1alpha1Objs...), fakev1.NewSimpleClientset(kubeObjs...), objects...)
 
 	return &ReconcileNodeAvailability{
-		controllerSharedState: controllerSharedState,
-		logger:                klogr.New(),
+		sharedState: controllerSharedState,
+		logger:      klogr.New(),
 	}
 }
 
@@ -81,8 +81,8 @@ func TestNodeAvailabilityController(t *testing.T) {
 					newPod,
 				)
 
-				mockClients(controller.controllerSharedState.cachedClient.(*mockclient.MockClient), controller.controllerSharedState.azClient, controller.controllerSharedState.kubeClient)
-				controller.controllerSharedState.priorityReplicaRequestsQueue.Push(context.TODO(), &ReplicaRequest{VolumeName: testPersistentVolume0Name, Priority: 1})
+				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
+				controller.priorityReplicaRequestsQueue.Push(context.TODO(), &ReplicaRequest{VolumeName: testPersistentVolume0Name, Priority: 1})
 
 				return controller
 			},
@@ -94,7 +94,7 @@ func TestNodeAvailabilityController(t *testing.T) {
 				labelSelector := labels.NewSelector().Add(*roleReq)
 
 				conditionFunc := func() (bool, error) {
-					replicas, localError := controller.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(testPrimaryAzVolumeAttachment0.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector.String()})
+					replicas, localError := controller.azClient.DiskV1beta2().AzVolumeAttachments(testPrimaryAzVolumeAttachment0.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector.String()})
 					require.NoError(t, localError)
 					require.NotNil(t, replicas)
 					return len(replicas.Items) == 1, nil

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -42,16 +42,16 @@ import (
 
 // Struct for the reconciler
 type ReconcilePod struct {
-	logger                logr.Logger
-	namespace             string
-	controllerSharedState *SharedState
+	logger    logr.Logger
+	namespace string
+	*sharedState
 }
 
 // Implement reconcile.Reconciler so the controller can reconcile objects
 var _ reconcile.Reconciler = &ReconcilePod{}
 
 func (r *ReconcilePod) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	if !r.controllerSharedState.isRecoveryComplete() {
+	if !r.isRecoveryComplete() {
 		return reconcile.Result{Requeue: true}, nil
 	}
 
@@ -59,11 +59,11 @@ func (r *ReconcilePod) Reconcile(ctx context.Context, request reconcile.Request)
 	podKey := getQualifiedName(request.Namespace, request.Name)
 	logger := r.logger.WithValues(consts.PodNameKey, request.Name)
 
-	if err := r.controllerSharedState.cachedClient.Get(ctx, request.NamespacedName, &pod); err != nil {
+	if err := r.cachedClient.Get(ctx, request.NamespacedName, &pod); err != nil {
 		// if the pod has been deleted, remove entry from podToClaimsMap and claimToPodMap
 		if errors.IsNotFound(err) {
 			logger.V(5).Info("No need to reconcile. Pod was deleted.")
-			if err := r.controllerSharedState.deletePod(ctx, podKey); err != nil {
+			if err := r.deletePod(ctx, podKey); err != nil {
 				return reconcile.Result{Requeue: true}, err
 			}
 			return reconcile.Result{}, nil
@@ -71,7 +71,7 @@ func (r *ReconcilePod) Reconcile(ctx context.Context, request reconcile.Request)
 		r.logger.Error(err, fmt.Sprintf("failed to get pod (%s)", podKey))
 		return reconcile.Result{Requeue: true}, err
 	}
-	if err := r.controllerSharedState.addPod(ctx, &pod, acquireLock); err != nil {
+	if err := r.addPod(ctx, &pod, acquireLock); err != nil {
 		return reconcile.Result{Requeue: true}, err
 	}
 
@@ -91,7 +91,7 @@ func (r *ReconcilePod) createReplicas(ctx context.Context, podKey string) error 
 	w.Logger().V(5).Infof("Creating replicas for pod %s.", podKey)
 
 	var volumes []string
-	volumes, err = r.controllerSharedState.getVolumesFromPod(ctx, podKey)
+	volumes, err = r.getVolumesFromPod(ctx, podKey)
 	if err != nil {
 		w.Logger().V(5).Errorf(err, "failed to get volumes for pod %s", podKey)
 		return err
@@ -101,7 +101,7 @@ func (r *ReconcilePod) createReplicas(ctx context.Context, podKey string) error 
 	// creating replica attachments for each volume
 	for _, volume := range volumes {
 		volume := volume
-		r.controllerSharedState.addToOperationQueue(
+		r.addToOperationQueue(
 			ctx,
 			volume,
 			pod,
@@ -109,7 +109,7 @@ func (r *ReconcilePod) createReplicas(ctx context.Context, podKey string) error 
 				var err error
 				var azVolume *azdiskv1beta2.AzVolume
 				w, _ := workflow.GetWorkflowFromContext(ctx)
-				azVolume, err = azureutils.GetAzVolume(ctx, r.controllerSharedState.cachedClient, r.controllerSharedState.azClient, volume, r.controllerSharedState.objectNamespace, true)
+				azVolume, err = azureutils.GetAzVolume(ctx, r.cachedClient, r.azClient, volume, r.objectNamespace, true)
 				if err != nil {
 					w.Logger().V(5).Errorf(err, "failed to get AzVolumes for pod %s", podKey)
 					return err
@@ -121,21 +121,21 @@ func (r *ReconcilePod) createReplicas(ctx context.Context, podKey string) error 
 				}
 
 				// get all replica attachments for the given volume
-				if r.controllerSharedState.isVolumeVisited(volume) {
+				if r.isVolumeVisited(volume) {
 					w.Logger().V(5).Infof("No need to create replica attachment for volume (%s). Replica controller is responsible for it", volume)
 					return nil
 				}
 
-				err = r.controllerSharedState.manageReplicas(ctx, azVolume.Spec.VolumeName)
+				err = r.manageReplicas(ctx, azVolume.Spec.VolumeName)
 				if err != nil {
 					err = status.Errorf(codes.Internal, "failed to create replica AzVolumeAttachment for pod %s and volume %s: %v", podKey, volume, err)
 					return err
 				}
 
 				// once replica attachment batch is created by pod controller, future replica reconciliation needs to be handled by replica controller
-				r.controllerSharedState.markVolumeVisited(volume)
+				r.markVolumeVisited(volume)
 				// remove replica controller from the blacklist
-				r.controllerSharedState.removeFromExclusionList(volume, replica)
+				r.removeFromExclusionList(volume, replica)
 				return nil
 			},
 			false,
@@ -152,7 +152,7 @@ func (r *ReconcilePod) Recover(ctx context.Context) error {
 	w.Logger().V(5).Info("Recover pod state.")
 	// recover replica AzVolumeAttachments
 	var pods corev1.PodList
-	if err = r.controllerSharedState.cachedClient.List(ctx, &pods, &client.ListOptions{}); err != nil {
+	if err = r.cachedClient.List(ctx, &pods, &client.ListOptions{}); err != nil {
 		err = status.Errorf(codes.Internal, "failed to list pods: %v", err)
 		return err
 	}
@@ -160,7 +160,7 @@ func (r *ReconcilePod) Recover(ctx context.Context) error {
 	for _, pod := range pods.Items {
 		// update the shared map
 		podKey := getQualifiedName(pod.Namespace, pod.Name)
-		if err := r.controllerSharedState.addPod(ctx, &pod, skipLock); err != nil {
+		if err := r.addPod(ctx, &pod, skipLock); err != nil {
 			w.Logger().V(5).Infof("failed to add necessary components for pod (%s)", podKey)
 			continue
 		}
@@ -172,11 +172,11 @@ func (r *ReconcilePod) Recover(ctx context.Context) error {
 	return nil
 }
 
-func NewPodController(mgr manager.Manager, controllerSharedState *SharedState) (*ReconcilePod, error) {
+func NewPodController(mgr manager.Manager, controllerSharedState *sharedState) (*ReconcilePod, error) {
 	logger := mgr.GetLogger().WithValues("controller", "pod")
 	reconciler := ReconcilePod{
-		controllerSharedState: controllerSharedState,
-		logger:                logger,
+		sharedState: controllerSharedState,
+		logger:      logger,
 	}
 	c, err := controller.New("pod-controller", mgr, controller.Options{
 		MaxConcurrentReconciles: 10,

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -42,9 +42,9 @@ import (
 
 // Struct for the reconciler
 type ReconcilePod struct {
+	*SharedState
 	logger    logr.Logger
 	namespace string
-	*sharedState
 }
 
 // Implement reconcile.Reconciler so the controller can reconcile objects
@@ -172,10 +172,10 @@ func (r *ReconcilePod) Recover(ctx context.Context) error {
 	return nil
 }
 
-func NewPodController(mgr manager.Manager, controllerSharedState *sharedState) (*ReconcilePod, error) {
+func NewPodController(mgr manager.Manager, controllerSharedState *SharedState) (*ReconcilePod, error) {
 	logger := mgr.GetLogger().WithValues("controller", "pod")
 	reconciler := ReconcilePod{
-		sharedState: controllerSharedState,
+		SharedState: controllerSharedState,
 		logger:      logger,
 	}
 	c, err := controller.New("pod-controller", mgr, controller.Options{

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -44,7 +44,7 @@ func NewTestPodController(controller *gomock.Controller, namespace string, objec
 
 	return &ReconcilePod{
 		namespace:   namespace,
-		sharedState: controllerSharedState,
+		SharedState: controllerSharedState,
 		logger:      klogr.New(),
 	}
 }

--- a/pkg/controller/pv.go
+++ b/pkg/controller/pv.go
@@ -45,10 +45,10 @@ import (
 
 // Struct for the reconciler
 type ReconcilePV struct {
+	*SharedState
 	logger logr.Logger
 	// retryMap allows volumeAttachment controller to retry Get operation for AzVolume in case the CRI has not been created yet
 	controllerRetryInfo *retryInfo
-	*sharedState
 }
 
 // Implement reconcile.Reconciler so the controller can reconcile objects
@@ -249,11 +249,11 @@ func (r *ReconcilePV) Recover(ctx context.Context) error {
 	return nil
 }
 
-func NewPVController(mgr manager.Manager, controllerSharedState *sharedState) (*ReconcilePV, error) {
+func NewPVController(mgr manager.Manager, controllerSharedState *SharedState) (*ReconcilePV, error) {
 	logger := mgr.GetLogger().WithValues("controller", "pv")
 	reconciler := ReconcilePV{
 		controllerRetryInfo: newRetryInfo(),
-		sharedState:         controllerSharedState,
+		SharedState:         controllerSharedState,
 		logger:              logger,
 	}
 

--- a/pkg/controller/pv_test.go
+++ b/pkg/controller/pv_test.go
@@ -39,7 +39,7 @@ func newTestPVController(controller *gomock.Controller, namespace string, object
 
 	return &ReconcilePV{
 		controllerRetryInfo: newRetryInfo(),
-		sharedState:         controllerSharedState,
+		SharedState:         controllerSharedState,
 		logger:              klogr.New(),
 	}
 }

--- a/pkg/controller/pv_test.go
+++ b/pkg/controller/pv_test.go
@@ -38,9 +38,9 @@ func newTestPVController(controller *gomock.Controller, namespace string, object
 	controllerSharedState := initState(mockclient.NewMockClient(controller), azdiskfakes.NewSimpleClientset(azDiskObjs...), fakev1.NewSimpleClientset(kubeObjs...), objects...)
 
 	return &ReconcilePV{
-		controllerRetryInfo:   newRetryInfo(),
-		controllerSharedState: controllerSharedState,
-		logger:                klogr.New(),
+		controllerRetryInfo: newRetryInfo(),
+		sharedState:         controllerSharedState,
+		logger:              klogr.New(),
 	}
 }
 
@@ -67,7 +67,7 @@ func TestPVControllerReconcile(t *testing.T) {
 					&testReplicaAzVolumeAttachment,
 					pv)
 
-				mockClients(controller.controllerSharedState.cachedClient.(*mockclient.MockClient), controller.controllerSharedState.azClient, controller.controllerSharedState.kubeClient)
+				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 
 				return controller
 			},
@@ -75,7 +75,7 @@ func TestPVControllerReconcile(t *testing.T) {
 				require.NoError(t, err)
 				require.False(t, result.Requeue)
 				waitErr := wait.PollImmediate(verifyCRIInterval, verifyCRITimeout, func() (bool, error) {
-					azVolumeAttachments, err := controller.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).List(context.TODO(), metav1.ListOptions{})
+					azVolumeAttachments, err := controller.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).List(context.TODO(), metav1.ListOptions{})
 					return len(azVolumeAttachments.Items) == 0, err
 				})
 				require.NoError(t, waitErr)

--- a/pkg/controller/replica.go
+++ b/pkg/controller/replica.go
@@ -45,8 +45,8 @@ import (
 )
 
 type ReconcileReplica struct {
-	logger logr.Logger
-	*sharedState
+	*SharedState
+	logger                     logr.Logger
 	timeUntilGarbageCollection time.Duration
 }
 
@@ -227,10 +227,10 @@ func (r *ReconcileReplica) triggerCreateFailedReplicas(ctx context.Context, volu
 	r.tryCreateFailedReplicas(ctx, "replicaController")
 }
 
-func NewReplicaController(mgr manager.Manager, controllerSharedState *sharedState) (*ReconcileReplica, error) {
+func NewReplicaController(mgr manager.Manager, controllerSharedState *SharedState) (*ReconcileReplica, error) {
 	logger := mgr.GetLogger().WithValues("controller", "replica")
 	reconciler := ReconcileReplica{
-		sharedState:                controllerSharedState,
+		SharedState:                controllerSharedState,
 		timeUntilGarbageCollection: DefaultTimeUntilGarbageCollection,
 		logger:                     logger,
 	}

--- a/pkg/controller/replica_test.go
+++ b/pkg/controller/replica_test.go
@@ -50,7 +50,7 @@ func NewTestReplicaController(controller *gomock.Controller, namespace string, o
 	controllerSharedState := initState(mockclient.NewMockClient(controller), azdiskfakes.NewSimpleClientset(azDiskObjs...), fakev1.NewSimpleClientset(kubeObjs...), objects...)
 
 	return &ReconcileReplica{
-		sharedState:                controllerSharedState,
+		SharedState:                controllerSharedState,
 		timeUntilGarbageCollection: testTimeUntilGarbageCollection,
 		logger:                     klogr.New(),
 	}

--- a/pkg/controller/replica_test.go
+++ b/pkg/controller/replica_test.go
@@ -50,7 +50,7 @@ func NewTestReplicaController(controller *gomock.Controller, namespace string, o
 	controllerSharedState := initState(mockclient.NewMockClient(controller), azdiskfakes.NewSimpleClientset(azDiskObjs...), fakev1.NewSimpleClientset(kubeObjs...), objects...)
 
 	return &ReconcileReplica{
-		controllerSharedState:      controllerSharedState,
+		sharedState:                controllerSharedState,
 		timeUntilGarbageCollection: testTimeUntilGarbageCollection,
 		logger:                     klogr.New(),
 	}
@@ -87,7 +87,7 @@ func TestReplicaReconcile(t *testing.T) {
 					&testPod0,
 					&replicaAttachment)
 
-				mockClients(controller.controllerSharedState.cachedClient.(*mockclient.MockClient), controller.controllerSharedState.azClient, controller.controllerSharedState.kubeClient)
+				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 				return controller
 			},
 			verifyFunc: func(t *testing.T, controller *ReconcileReplica, result reconcile.Result, err error) {
@@ -95,9 +95,9 @@ func TestReplicaReconcile(t *testing.T) {
 				require.False(t, result.Requeue)
 
 				// delete the original replica attachment so that manageReplica can kick in
-				err = controller.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).Delete(context.TODO(), testReplicaAzVolumeAttachmentName, metav1.DeleteOptions{})
+				err = controller.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).Delete(context.TODO(), testReplicaAzVolumeAttachmentName, metav1.DeleteOptions{})
 				require.NoError(t, err)
-				_, err = controller.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).Get(context.TODO(), testReplicaAzVolumeAttachmentName, metav1.GetOptions{})
+				_, err = controller.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).Get(context.TODO(), testReplicaAzVolumeAttachmentName, metav1.GetOptions{})
 				require.True(t, errors.IsNotFound(err))
 
 				result, err = controller.Reconcile(context.TODO(), testReplicaAzVolumeAttachmentRequest)
@@ -107,7 +107,7 @@ func TestReplicaReconcile(t *testing.T) {
 				conditionFunc := func() (bool, error) {
 					roleReq, _ := azureutils.CreateLabelRequirements(consts.RoleLabel, selection.Equals, string(azdiskv1beta2.ReplicaRole))
 					labelSelector := labels.NewSelector().Add(*roleReq)
-					replicas, localError := controller.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector.String()})
+					replicas, localError := controller.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector.String()})
 					require.NoError(t, localError)
 					require.NotNil(t, replicas)
 					return len(replicas.Items) == 1, nil
@@ -147,7 +147,7 @@ func TestReplicaReconcile(t *testing.T) {
 					&testPod0,
 					replicaAttachment)
 
-				mockClients(controller.controllerSharedState.cachedClient.(*mockclient.MockClient), controller.controllerSharedState.azClient, controller.controllerSharedState.kubeClient)
+				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 				return controller
 			},
 			verifyFunc: func(t *testing.T, controller *ReconcileReplica, result reconcile.Result, err error) {
@@ -156,7 +156,7 @@ func TestReplicaReconcile(t *testing.T) {
 				conditionFunc := func() (bool, error) {
 					roleReq, _ := azureutils.CreateLabelRequirements(consts.RoleLabel, selection.Equals, string(azdiskv1beta2.ReplicaRole))
 					labelSelector := labels.NewSelector().Add(*roleReq)
-					replicas, localError := controller.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector.String()})
+					replicas, localError := controller.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector.String()})
 					require.NoError(t, localError)
 					require.NotNil(t, replicas)
 					return len(replicas.Items) == 1, nil
@@ -189,7 +189,7 @@ func TestReplicaReconcile(t *testing.T) {
 					&testNode1,
 					&testReplicaAzVolumeAttachment)
 
-				mockClients(controller.controllerSharedState.cachedClient.(*mockclient.MockClient), controller.controllerSharedState.azClient, controller.controllerSharedState.kubeClient)
+				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 				return controller
 			},
 			verifyFunc: func(t *testing.T, controller *ReconcileReplica, result reconcile.Result, err error) {
@@ -200,7 +200,7 @@ func TestReplicaReconcile(t *testing.T) {
 				time.Sleep(controller.timeUntilGarbageCollection + time.Minute)
 				roleReq, _ := azureutils.CreateLabelRequirements(consts.RoleLabel, selection.Equals, string(azdiskv1beta2.ReplicaRole))
 				labelSelector := labels.NewSelector().Add(*roleReq)
-				replicas, localError := controller.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector.String()})
+				replicas, localError := controller.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector.String()})
 				require.NoError(t, localError)
 				require.NotNil(t, replicas)
 				require.Len(t, replicas.Items, 0)
@@ -238,7 +238,7 @@ func TestReplicaReconcile(t *testing.T) {
 					&testPod0,
 					replicaAttachment)
 
-				mockClients(controller.controllerSharedState.cachedClient.(*mockclient.MockClient), controller.controllerSharedState.azClient, controller.controllerSharedState.kubeClient)
+				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 
 				// start garbage collection
 				result, err := controller.Reconcile(context.TODO(), testPrimaryAzVolumeAttachment0Request)
@@ -246,14 +246,14 @@ func TestReplicaReconcile(t *testing.T) {
 				require.False(t, result.Requeue)
 
 				// fully delete primary
-				err = controller.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(primaryAttachment.Namespace).Delete(context.TODO(), primaryAttachment.Name, metav1.DeleteOptions{})
+				err = controller.azClient.DiskV1beta2().AzVolumeAttachments(primaryAttachment.Namespace).Delete(context.TODO(), primaryAttachment.Name, metav1.DeleteOptions{})
 				require.NoError(t, err)
 
 				// promote replica to primary
 				replicaAttachment.Spec.RequestedRole = azdiskv1beta2.PrimaryRole
 				replicaAttachment = updateRole(replicaAttachment.DeepCopy(), azdiskv1beta2.PrimaryRole)
 
-				err = controller.controllerSharedState.cachedClient.Update(context.TODO(), replicaAttachment)
+				err = controller.cachedClient.Update(context.TODO(), replicaAttachment)
 				require.NoError(t, err)
 
 				return controller
@@ -265,7 +265,7 @@ func TestReplicaReconcile(t *testing.T) {
 				time.Sleep(controller.timeUntilGarbageCollection + time.Minute)
 				roleReq, _ := azureutils.CreateLabelRequirements(consts.RoleLabel, selection.Equals, string(azdiskv1beta2.ReplicaRole))
 				labelSelector := labels.NewSelector().Add(*roleReq)
-				replicas, localError := controller.controllerSharedState.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector.String()})
+				replicas, localError := controller.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector.String()})
 				require.NoError(t, localError)
 				require.NotNil(t, replicas)
 				// clean up should not have happened
@@ -321,7 +321,7 @@ func TestGetNodesForReplica(t *testing.T) {
 					&testPod0,
 				)
 
-				mockClients(controller.controllerSharedState.cachedClient.(*mockclient.MockClient), controller.controllerSharedState.azClient, controller.controllerSharedState.kubeClient)
+				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 				return controller
 			},
 			verifyFunc: func(t *testing.T, nodes []string, err error) {
@@ -370,7 +370,7 @@ func TestGetNodesForReplica(t *testing.T) {
 					&testPod0,
 				)
 
-				mockClients(controller.controllerSharedState.cachedClient.(*mockclient.MockClient), controller.controllerSharedState.azClient, controller.controllerSharedState.kubeClient)
+				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 				return controller
 			},
 			verifyFunc: func(t *testing.T, nodes []string, err error) {
@@ -386,7 +386,7 @@ func TestGetNodesForReplica(t *testing.T) {
 			mockCtl := gomock.NewController(t)
 			defer mockCtl.Finish()
 			controller := tt.setupFunc(t, mockCtl)
-			nodes, err := controller.controllerSharedState.getRankedNodesForReplicaAttachments(context.TODO(), tt.volumes, tt.pods)
+			nodes, err := controller.getRankedNodesForReplicaAttachments(context.TODO(), tt.volumes, tt.pods)
 			tt.verifyFunc(t, nodes, err)
 		})
 	}

--- a/pkg/controller/shared_state.go
+++ b/pkg/controller/shared_state.go
@@ -1,0 +1,1213 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"container/list"
+	"context"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	v1 "k8s.io/api/core/v1"
+	crdClientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/kubernetes"
+	cache "k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/kubernetes/pkg/features"
+	azdiskv1beta2 "sigs.k8s.io/azuredisk-csi-driver/pkg/apis/azuredisk/v1beta2"
+	azdisk "sigs.k8s.io/azuredisk-csi-driver/pkg/apis/client/clientset/versioned"
+	azdiskinformers "sigs.k8s.io/azuredisk-csi-driver/pkg/apis/client/informers/externalversions"
+	consts "sigs.k8s.io/azuredisk-csi-driver/pkg/azureconstants"
+	"sigs.k8s.io/azuredisk-csi-driver/pkg/azureutils"
+	"sigs.k8s.io/azuredisk-csi-driver/pkg/watcher"
+	"sigs.k8s.io/azuredisk-csi-driver/pkg/workflow"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type sharedState struct {
+	recoveryComplete              uint32
+	driverName                    string
+	objectNamespace               string
+	topologyKey                   string
+	podToClaimsMap                sync.Map
+	podToInlineMap                sync.Map
+	claimToPodsMap                sync.Map
+	volumeToClaimMap              sync.Map
+	claimToVolumeMap              sync.Map
+	azVolumeAttachmentToVaMap     sync.Map
+	pvToVolumeMap                 sync.Map
+	podLocks                      sync.Map
+	visitedVolumes                sync.Map
+	volumeOperationQueues         sync.Map
+	cleanUpMap                    sync.Map
+	priorityReplicaRequestsQueue  *VolumeReplicaRequestsPriorityQueue
+	processingReplicaRequestQueue int32
+	eventRecorder                 record.EventRecorder
+	cachedClient                  client.Client
+	azClient                      azdisk.Interface
+	kubeClient                    kubernetes.Interface
+	crdClient                     crdClientset.Interface
+	conditionWatcher              *watcher.ConditionWatcher
+}
+
+func NewSharedState(driverName, objectNamespace, topologyKey string, eventRecorder record.EventRecorder, cachedClient client.Client, azClient azdisk.Interface, kubeClient kubernetes.Interface, crdClient crdClientset.Interface) *sharedState {
+	newSharedState := &sharedState{driverName: driverName, objectNamespace: objectNamespace, topologyKey: topologyKey, eventRecorder: eventRecorder, cachedClient: cachedClient, azClient: azClient, kubeClient: kubeClient, crdClient: crdClient, conditionWatcher: watcher.New(context.Background(), azClient, azdiskinformers.NewSharedInformerFactory(azClient, consts.DefaultInformerResync), objectNamespace)}
+	newSharedState.createReplicaRequestsQueue()
+	return newSharedState
+}
+
+func (c *sharedState) isRecoveryComplete() bool {
+	return atomic.LoadUint32(&c.recoveryComplete) == 1
+}
+
+func (c *sharedState) MarkRecoveryComplete() {
+	atomic.StoreUint32(&c.recoveryComplete, 1)
+}
+
+func (c *sharedState) DeleteAPIVersion(ctx context.Context, deleteVersion string) error {
+	w, _ := workflow.GetWorkflowFromContext(ctx)
+	crdNames := []string{consts.AzDriverNodeCRDName, consts.AzVolumeCRDName, consts.AzVolumeAttachmentCRDName}
+	for _, crdName := range crdNames {
+		err := retry.RetryOnConflict(retry.DefaultBackoff,
+			func() error {
+				crd, err := c.crdClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crdName, metav1.GetOptions{})
+				if err != nil {
+					if apiErrors.IsNotFound(err) {
+						return err
+					}
+					return nil
+				}
+
+				updated := crd.DeepCopy()
+				var storedVersions []string
+				// remove version from status stored versions
+				for _, version := range updated.Status.StoredVersions {
+					if version == deleteVersion {
+						continue
+					}
+					storedVersions = append(storedVersions, version)
+				}
+				updated.Status.StoredVersions = storedVersions
+				crd, err = c.crdClient.ApiextensionsV1().CustomResourceDefinitions().UpdateStatus(ctx, updated, metav1.UpdateOptions{})
+				if err != nil {
+					// log the error and continue
+					return err
+				}
+				return nil
+			})
+
+		if err != nil {
+			w.Logger().Errorf(err, "failed to delete %s api version from CRD (%s)", deleteVersion, crdName)
+		}
+
+		// Uncomment when the all deployments have rolled over to v1beta1.
+		// updated = crd.DeepCopy()
+		// // remove version from spec versions
+		// var specVersions []crdv1.CustomResourceDefinitionVersion
+		// for _, version := range updated.Spec.Versions {
+		// 	if version.Name == deleteVersion {
+		// 		continue
+		// 	}
+		// 	specVersions = append(specVersions, version)
+		// }
+		// updated.Spec.Versions = specVersions
+
+		// // update the crd
+		// crd, err = c.crdClient.ApiextensionsV1().CustomResourceDefinitions().Update(ctx, updated, metav1.UpdateOptions{})
+		// if err != nil {
+		// 	// log the error and continue
+		// 	w.Logger().Errorf(err, "failed to remove %s spec version from CRD (%s)", deleteVersion, crd.Name)
+		// 	continue
+		// }
+	}
+	return nil
+}
+
+func (c *sharedState) createOperationQueue(volumeName string) {
+	_, _ = c.volumeOperationQueues.LoadOrStore(volumeName, newLockableEntry(newOperationQueue()))
+}
+
+func (c *sharedState) addToOperationQueue(ctx context.Context, volumeName string, requester operationRequester, operationFunc func(context.Context) error, isReplicaGarbageCollection bool) {
+	// It is expected for caller to provide parent workflow via context.
+	// The child workflow will be created below and be fed to the queued operation for necessary workflow information.
+	ctx, w := workflow.New(ctx, workflow.WithDetails(consts.VolumeNameLabel, volumeName))
+
+	v, ok := c.volumeOperationQueues.Load(volumeName)
+	if !ok {
+		return
+	}
+	lockable := v.(*lockableEntry)
+	lockable.Lock()
+
+	isFirst := lockable.entry.(*operationQueue).Len() <= 0
+	_ = lockable.entry.(*operationQueue).PushBack(&replicaOperation{
+		ctx:       ctx,
+		requester: requester,
+		operationFunc: func(ctx context.Context) (err error) {
+			defer func() {
+				if !shouldRequeueReplicaOperation(isReplicaGarbageCollection, err) {
+					w.Finish(err)
+				}
+			}()
+			err = operationFunc(ctx)
+			return
+		},
+		isReplicaGarbageCollection: isReplicaGarbageCollection,
+	})
+	lockable.Unlock()
+
+	// if first operation, start goroutine
+	if isFirst {
+		go func() {
+			lockable.Lock()
+			for {
+				operationQueue := lockable.entry.(*operationQueue)
+				// pop the first operation
+				front := operationQueue.Front()
+				operation := front.Value.(*replicaOperation)
+				lockable.Unlock()
+
+				// only run the operation if the operation requester is not enlisted in blacklist
+				if !operationQueue.gcExclusionList.has(operation.requester) {
+					if err := operation.operationFunc(operation.ctx); err != nil {
+						if shouldRequeueReplicaOperation(operation.isReplicaGarbageCollection, err) {
+							// if failed, push it to the end of the queue
+							lockable.Lock()
+							if operationQueue.isActive {
+								operationQueue.PushBack(operation)
+							}
+							lockable.Unlock()
+						}
+					}
+				}
+
+				lockable.Lock()
+				operationQueue.remove(front)
+				// there is no entry remaining, exit the loop
+				if operationQueue.Front() == nil {
+					break
+				}
+			}
+			lockable.Unlock()
+		}()
+	}
+}
+
+func (c *sharedState) deleteOperationQueue(volumeName string) {
+	v, ok := c.volumeOperationQueues.LoadAndDelete(volumeName)
+	// if operation queue has already been deleted, return
+	if !ok {
+		return
+	}
+	// clear the queue in case, there still is an entry in queue
+	lockable := v.(*lockableEntry)
+	lockable.Lock()
+	lockable.entry.(*operationQueue).Init()
+	lockable.Unlock()
+}
+
+func (c *sharedState) closeOperationQueue(volumeName string) func() {
+	v, ok := c.volumeOperationQueues.Load(volumeName)
+	if !ok {
+		return nil
+	}
+	lockable := v.(*lockableEntry)
+
+	lockable.Lock()
+	lockable.entry.(*operationQueue).isActive = false
+	lockable.entry.(*operationQueue).Init()
+	return lockable.Unlock
+}
+
+func (c *sharedState) addToGcExclusionList(volumeName string, target operationRequester) {
+	v, ok := c.volumeOperationQueues.Load(volumeName)
+	if !ok {
+		return
+	}
+	lockable := v.(*lockableEntry)
+	lockable.Lock()
+	lockable.entry.(*operationQueue).gcExclusionList.add(target)
+	lockable.Unlock()
+}
+
+func (c *sharedState) removeFromExclusionList(volumeName string, target operationRequester) {
+	v, ok := c.volumeOperationQueues.Load(volumeName)
+	if !ok {
+		return
+	}
+	lockable := v.(*lockableEntry)
+	lockable.Lock()
+	delete(lockable.entry.(*operationQueue).gcExclusionList, target)
+	lockable.Unlock()
+}
+
+func (c *sharedState) dequeueGarbageCollection(volumeName string) {
+	v, ok := c.volumeOperationQueues.Load(volumeName)
+	if !ok {
+		return
+	}
+	lockable := v.(*lockableEntry)
+	lockable.Lock()
+	queue := lockable.entry.(*operationQueue)
+	// look for garbage collection operation in the queue and remove from queue
+	var next *list.Element
+	for cur := queue.Front(); cur != nil; cur = next {
+		next = cur.Next()
+		if cur.Value.(*replicaOperation).isReplicaGarbageCollection {
+			queue.remove(cur)
+		}
+	}
+	lockable.Unlock()
+}
+
+func (c *sharedState) getVolumesFromPod(ctx context.Context, podName string) ([]string, error) {
+	w, _ := workflow.GetWorkflowFromContext(ctx)
+
+	var claims []string
+	w.Logger().V(5).Infof("Getting requested volumes for pod (%s).", podName)
+	value, ok := c.podToClaimsMap.Load(podName)
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "unable to find an entry for pod (%s) in podToClaims map", podName)
+	}
+	claims, ok = value.([]string)
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "wrong output type: expected []string")
+	}
+
+	volumes := []string{}
+	for _, claim := range claims {
+		value, ok := c.claimToVolumeMap.Load(claim)
+		if !ok {
+			// the pvc entry is not an azure resource
+			w.Logger().V(5).Infof("Requested volume %s for pod %s is not an azure resource", value, podName)
+			continue
+		}
+		volume, ok := value.(string)
+		if !ok {
+			return nil, status.Errorf(codes.Internal, "wrong output type: expected string")
+		}
+		volumes = append(volumes, volume)
+		w.Logger().V(5).Infof("Requested volumes for pod %s are now the following: Volumes: %v, Len: %d", podName, volumes, len(volumes))
+	}
+	return volumes, nil
+}
+
+func (c *sharedState) getPodsFromVolume(ctx context.Context, client client.Client, volumeName string) ([]v1.Pod, error) {
+	w, _ := workflow.GetWorkflowFromContext(ctx)
+	pods, err := c.getPodNamesFromVolume(volumeName)
+	if err != nil {
+		return nil, err
+	}
+	podObjs := []v1.Pod{}
+	for _, pod := range pods {
+		namespace, name, err := parseQualifiedName(pod)
+		if err != nil {
+			w.Logger().Errorf(err, "cannot get podObj for pod (%s)", pod)
+			continue
+		}
+		var podObj v1.Pod
+		if err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &podObj); err != nil {
+			return nil, err
+		}
+		podObjs = append(podObjs, podObj)
+	}
+	return podObjs, nil
+}
+
+func (c *sharedState) getPodNamesFromVolume(volumeName string) ([]string, error) {
+	v, ok := c.volumeToClaimMap.Load(volumeName)
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "no bound persistent volume claim was found for AzVolume (%s)", volumeName)
+	}
+	claimName, ok := v.(string)
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "volumeToClaimMap should should hold string")
+	}
+
+	value, ok := c.claimToPodsMap.Load(claimName)
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "no pods found for PVC (%s)", claimName)
+	}
+	lockable, ok := value.(*lockableEntry)
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "claimToPodsMap should hold lockable entry")
+	}
+
+	lockable.RLock()
+	defer lockable.RUnlock()
+
+	podMap, ok := lockable.entry.(set)
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "claimToPodsMap entry should hold a set")
+	}
+
+	pods := make([]string, len(podMap))
+	i := 0
+	for v := range podMap {
+		pod := v.(string)
+		pods[i] = pod
+		i++
+	}
+
+	return pods, nil
+}
+
+func (c *sharedState) getVolumesForPodObjs(ctx context.Context, pods []v1.Pod) ([]string, error) {
+	volumes := []string{}
+	for _, pod := range pods {
+		podVolumes, err := c.getVolumesFromPod(ctx, getQualifiedName(pod.Namespace, pod.Name))
+		if err != nil {
+			return nil, err
+		}
+		volumes = append(volumes, podVolumes...)
+	}
+	return volumes, nil
+}
+
+func (c *sharedState) addPod(ctx context.Context, pod *v1.Pod, updateOption updateWithLock) error {
+	w, _ := workflow.GetWorkflowFromContext(ctx)
+	podKey := getQualifiedName(pod.Namespace, pod.Name)
+	v, _ := c.podLocks.LoadOrStore(podKey, &sync.Mutex{})
+
+	w.Logger().V(5).Infof("Adding pod %s to shared map with keyName %s.", pod.Name, podKey)
+	podLock := v.(*sync.Mutex)
+	if updateOption == acquireLock {
+		podLock.Lock()
+		defer podLock.Unlock()
+	}
+	w.Logger().V(5).Infof("Pod spec of pod %s is: %+v. With volumes: %+v", pod.Name, pod.Spec, pod.Spec.Volumes)
+
+	// If the claims already exist for the podKey, add them to a set
+	value, _ := c.podToClaimsMap.LoadOrStore(podKey, []string{})
+	claims := value.([]string)
+	claimSet := set{}
+	for _, claim := range claims {
+		claimSet.add(claim)
+	}
+
+	for _, volume := range pod.Spec.Volumes {
+		// TODO: investigate if we need special support for CSI ephemeral volume or generic ephemeral volume
+		// if csiMigration is enabled and there is an inline volume, create AzVolume CRI for the inline volume.
+		if utilfeature.DefaultFeatureGate.Enabled(features.CSIMigration) &&
+			utilfeature.DefaultFeatureGate.Enabled(features.CSIMigrationAzureDisk) &&
+			volume.AzureDisk != nil {
+			// inline volume: create AzVolume resource
+			w.Logger().V(5).Infof("Creating AzVolume instance for inline volume %s.", volume.AzureDisk.DiskName)
+			if err := c.createAzVolumeFromInline(ctx, volume.AzureDisk); err != nil {
+				return err
+			}
+			v, exists := c.podToInlineMap.Load(podKey)
+			var inlines []string
+			if exists {
+				inlines = v.([]string)
+			}
+			inlines = append(inlines, volume.AzureDisk.DiskName)
+			c.podToInlineMap.Store(podKey, inlines)
+		}
+		if volume.PersistentVolumeClaim == nil {
+			w.Logger().V(5).Infof("Pod %s: Skipping Volume %s. No persistent volume exists.", pod.Name, volume)
+			continue
+		}
+		namespacedClaimName := getQualifiedName(pod.Namespace, volume.PersistentVolumeClaim.ClaimName)
+		if _, ok := c.claimToVolumeMap.Load(namespacedClaimName); !ok {
+			w.Logger().V(5).Infof("Skipping Pod %s. Volume %s not csi. Driver: %+v", pod.Name, volume.Name, volume.CSI)
+			continue
+		}
+		w.Logger().V(5).Infof("Pod %s. Volume %v is csi.", pod.Name, volume)
+		claimSet.add(namespacedClaimName)
+		v, _ := c.claimToPodsMap.LoadOrStore(namespacedClaimName, newLockableEntry(set{}))
+
+		lockable := v.(*lockableEntry)
+		lockable.Lock()
+		pods := lockable.entry.(set)
+		if !pods.has(podKey) {
+			pods.add(podKey)
+		}
+		// No need to restore the amended set to claimToPodsMap because set is a reference type
+		lockable.Unlock()
+
+		w.Logger().V(5).Infof("Storing pod %s and claim %s to claimToPodsMap map.", pod.Name, namespacedClaimName)
+	}
+	w.Logger().V(5).Infof("Storing pod %s and claim %s to podToClaimsMap map.", pod.Name, claims)
+
+	allClaims := []string{}
+	for key := range claimSet {
+		allClaims = append(allClaims, key.(string))
+	}
+	c.podToClaimsMap.Store(podKey, allClaims)
+	return nil
+}
+
+func (c *sharedState) deletePod(ctx context.Context, podKey string) error {
+	w, _ := workflow.GetWorkflowFromContext(ctx)
+	value, exists := c.podLocks.LoadAndDelete(podKey)
+	if !exists {
+		return nil
+	}
+	podLock := value.(*sync.Mutex)
+	podLock.Lock()
+	defer podLock.Unlock()
+
+	value, exists = c.podToInlineMap.LoadAndDelete(podKey)
+	if exists {
+		inlines := value.([]string)
+
+		for _, inline := range inlines {
+			if err := c.azClient.DiskV1beta2().AzVolumes(c.objectNamespace).Delete(ctx, inline, metav1.DeleteOptions{}); err != nil && !apiErrors.IsNotFound(err) {
+				w.Logger().Errorf(err, "failed to delete AzVolume (%s) for inline (%s): %v", inline, inline, err)
+				return err
+			}
+		}
+	}
+
+	value, exists = c.podToClaimsMap.LoadAndDelete(podKey)
+	if !exists {
+		return nil
+	}
+	claims := value.([]string)
+
+	for _, claim := range claims {
+		value, ok := c.claimToPodsMap.Load(claim)
+		if !ok {
+			w.Logger().Errorf(nil, "No pods found for PVC (%s)", claim)
+		}
+
+		// Scope the duration that we hold the lockable lock using a function.
+		func() {
+			lockable, ok := value.(*lockableEntry)
+			if !ok {
+				w.Logger().Error(nil, "claimToPodsMap should hold lockable entry")
+				return
+			}
+
+			lockable.Lock()
+			defer lockable.Unlock()
+
+			podSet, ok := lockable.entry.(set)
+			if !ok {
+				w.Logger().Error(nil, "claimToPodsMap entry should hold a set")
+			}
+
+			podSet.remove(podKey)
+			if len(podSet) == 0 {
+				c.claimToPodsMap.Delete(claim)
+			}
+		}()
+	}
+	return nil
+}
+
+func (c *sharedState) addVolumeAndClaim(azVolumeName, pvName, pvClaimName string) {
+	c.pvToVolumeMap.Store(pvName, azVolumeName)
+	c.volumeToClaimMap.Store(azVolumeName, pvClaimName)
+	c.claimToVolumeMap.Store(pvClaimName, azVolumeName)
+}
+
+func (c *sharedState) deletePV(pvName string) {
+	c.pvToVolumeMap.Delete(pvName)
+}
+
+func (c *sharedState) deleteVolumeAndClaim(azVolumeName string) {
+	v, ok := c.volumeToClaimMap.LoadAndDelete(azVolumeName)
+	if ok {
+		pvClaimName := v.(string)
+		c.claimToVolumeMap.Delete(pvClaimName)
+	}
+}
+
+func (c *sharedState) markVolumeVisited(azVolumeName string) {
+	c.visitedVolumes.Store(azVolumeName, struct{}{})
+}
+
+func (c *sharedState) unmarkVolumeVisited(azVolumeName string) {
+	c.visitedVolumes.Delete(azVolumeName)
+}
+
+func (c *sharedState) isVolumeVisited(azVolumeName string) bool {
+	_, visited := c.visitedVolumes.Load(azVolumeName)
+	return visited
+}
+
+func (c *sharedState) getRankedNodesForReplicaAttachments(ctx context.Context, volumes []string, podObjs []v1.Pod) ([]string, error) {
+	var err error
+	ctx, w := workflow.New(ctx)
+	defer func() { w.Finish(err) }()
+
+	w.Logger().V(5).Info("Getting ranked list of nodes for creating AzVolumeAttachments")
+
+	nodeList := &v1.NodeList{}
+	if err := c.cachedClient.List(ctx, nodeList); err != nil {
+		return nil, err
+	}
+
+	var selectedNodeObjs []v1.Node
+	selectedNodeObjs, err = c.selectNodesPerTopology(ctx, nodeList.Items, podObjs, volumes)
+	if err != nil {
+		w.Logger().Errorf(err, "failed to select nodes for volumes (%+v)", volumes)
+		return nil, err
+	}
+
+	selectedNodes := make([]string, len(selectedNodeObjs))
+	for i, selectedNodeObj := range selectedNodeObjs {
+		selectedNodes[i] = selectedNodeObj.Name
+	}
+
+	w.Logger().V(5).Infof("Selected nodes (%+v) for replica AzVolumeAttachments for volumes (%+v)", selectedNodes, volumes)
+	return selectedNodes, nil
+}
+
+func (c *sharedState) filterNodes(ctx context.Context, nodes []v1.Node, pods []v1.Pod, volumes []string) ([]v1.Node, error) {
+	var err error
+	ctx, w := workflow.New(ctx)
+	defer func() { w.Finish(err) }()
+
+	pvs := make([]*v1.PersistentVolume, len(volumes))
+	for i, volume := range volumes {
+		var azVolume *azdiskv1beta2.AzVolume
+		azVolume, err = azureutils.GetAzVolume(ctx, c.cachedClient, c.azClient, volume, c.objectNamespace, true)
+		if err != nil {
+			w.Logger().V(5).Errorf(err, "AzVolume for volume %s is not found.", volume)
+			return nil, err
+		}
+
+		var pv v1.PersistentVolume
+		if err = c.cachedClient.Get(ctx, types.NamespacedName{Name: azVolume.Spec.PersistentVolume}, &pv); err != nil {
+			return nil, err
+		}
+		pvs[i] = &pv
+	}
+
+	var filterPlugins = []filterPlugin{
+		&interPodAffinityFilter{},
+		&interPodAntiAffinityFilter{},
+		&podTolerationFilter{},
+		&podNodeAffinityFilter{},
+		&podNodeSelectorFilter{},
+		&volumeNodeSelectorFilter{},
+	}
+
+	filteredNodes := nodes
+	for _, filterPlugin := range filterPlugins {
+		filterPlugin.setup(pods, pvs, c)
+		if updatedFilteredNodes, err := filterPlugin.filter(ctx, filteredNodes); err != nil {
+			w.Logger().Errorf(err, "failed to filter node with filter plugin (%s). Ignoring filtered results.", filterPlugin.name())
+		} else {
+			filteredNodes = updatedFilteredNodes
+			nodeStrs := make([]string, len(filteredNodes))
+			for i, filteredNode := range filteredNodes {
+				nodeStrs[i] = filteredNode.Name
+			}
+			w.Logger().V(2).Infof("Filtered node list from filter plugin (%s): %+v", filterPlugin.name(), nodeStrs)
+		}
+	}
+
+	return filteredNodes, nil
+}
+
+func (c *sharedState) prioritizeNodes(ctx context.Context, pods []v1.Pod, volumes []string, nodes []v1.Node) []v1.Node {
+	ctx, w := workflow.New(ctx)
+	defer w.Finish(nil)
+
+	nodeScores := map[string]int{}
+	for _, node := range nodes {
+		nodeScores[node.Name] = 0
+	}
+
+	var nodeScorerPlugins = []nodeScorerPlugin{
+		&scoreByNodeCapacity{},
+		&scoreByReplicaCount{},
+	}
+
+	for _, nodeScorerPlugin := range nodeScorerPlugins {
+		nodeScorerPlugin.setup(pods, volumes, c)
+		if updatedNodeScores, err := nodeScorerPlugin.score(ctx, nodeScores); err != nil {
+			w.Logger().Errorf(err, "failed to score nodes by node scorer (%s)", nodeScorerPlugin.name())
+		} else {
+			// update node scores if scorer plugin returned success
+			nodeScores = updatedNodeScores
+		}
+	}
+
+	// normalize score
+	numFiltered := 0
+	for _, node := range nodes {
+		if _, exists := nodeScores[node.Name]; !exists {
+			nodeScores[node.Name] = -1
+			numFiltered++
+		}
+	}
+
+	sort.Slice(nodes[:], func(i, j int) bool {
+		return nodeScores[nodes[i].Name] > nodeScores[nodes[j].Name]
+	})
+
+	return nodes[:len(nodes)-numFiltered]
+}
+
+func (c *sharedState) filterAndSortNodes(ctx context.Context, nodes []v1.Node, pods []v1.Pod, volumes []string) ([]v1.Node, error) {
+	var err error
+	ctx, w := workflow.New(ctx)
+	defer func() { w.Finish(err) }()
+
+	var filteredNodes []v1.Node
+	filteredNodes, err = c.filterNodes(ctx, nodes, pods, volumes)
+	if err != nil {
+		w.Logger().Errorf(err, "failed to filter nodes for volumes (%+v): %v", volumes, err)
+		return nil, err
+	}
+	sortedNodes := c.prioritizeNodes(ctx, pods, volumes, filteredNodes)
+	return sortedNodes, nil
+}
+
+func (c *sharedState) selectNodesPerTopology(ctx context.Context, nodes []v1.Node, pods []v1.Pod, volumes []string) ([]v1.Node, error) {
+	var err error
+	ctx, w := workflow.New(ctx)
+	defer func() { w.Finish(err) }()
+
+	selectedNodes := []v1.Node{}
+	numReplicas := 0
+
+	// disperse node topology if possible
+	compatibleZonesSet := set{}
+	var primaryNode string
+	for i, volume := range volumes {
+		var azVolume *azdiskv1beta2.AzVolume
+		azVolume, err = azureutils.GetAzVolume(ctx, c.cachedClient, c.azClient, volume, c.objectNamespace, true)
+		if err != nil {
+			err = status.Errorf(codes.Aborted, "failed to get AzVolume CRI (%s)", volume)
+			return nil, err
+		}
+
+		numReplicas = max(numReplicas, azVolume.Spec.MaxMountReplicaCount)
+		w.Logger().V(5).Infof("Number of requested replicas for Azvolume (%s) is: %d. Max replica count is: %d.",
+			volume, numReplicas, azVolume.Spec.MaxMountReplicaCount)
+
+		var pv v1.PersistentVolume
+		if err = c.cachedClient.Get(ctx, types.NamespacedName{Name: azVolume.Spec.PersistentVolume}, &pv); err != nil {
+			return nil, err
+		}
+
+		if pv.Spec.NodeAffinity == nil || pv.Spec.NodeAffinity.Required == nil {
+			continue
+		}
+
+		// Find the intersection of the zones for all the volumes
+		topologyKey := c.topologyKey
+		if i == 0 {
+			compatibleZonesSet = getSupportedZones(pv.Spec.NodeAffinity.Required.NodeSelectorTerms, topologyKey)
+		} else {
+			listOfZones := getSupportedZones(pv.Spec.NodeAffinity.Required.NodeSelectorTerms, topologyKey)
+			for key := range compatibleZonesSet {
+				if !listOfZones.has(key) {
+					compatibleZonesSet.remove(key)
+				}
+			}
+		}
+
+		// find primary node if not already found
+		if primaryNode == "" {
+			if primaryAttachment, err := azureutils.GetAzVolumeAttachmentsForVolume(ctx, c.cachedClient, volume, azureutils.PrimaryOnly); err != nil || len(primaryAttachment) == 0 {
+				continue
+			} else {
+				primaryNode = primaryAttachment[0].Spec.NodeName
+			}
+		}
+	}
+
+	var compatibleZones []string
+	if len(compatibleZonesSet) > 0 {
+		for key := range compatibleZonesSet {
+			compatibleZones = append(compatibleZones, key.(string))
+		}
+	}
+
+	if len(compatibleZones) == 0 {
+		selectedNodes, err = c.filterAndSortNodes(ctx, nodes, pods, volumes)
+		if err != nil {
+			err = status.Errorf(codes.Aborted, "failed to select nodes for volumes (%+v): %v", volumes, err)
+			return nil, err
+		}
+	} else {
+		w.Logger().V(5).Infof("The list of zones to select nodes from is: %s", strings.Join(compatibleZones, ","))
+
+		var primaryNodeZone string
+		if primaryNode != "" {
+			nodeObj := &v1.Node{}
+			err = c.cachedClient.Get(ctx, types.NamespacedName{Name: primaryNode}, nodeObj)
+			if err != nil {
+				w.Logger().Errorf(err, "failed to retrieve the primary node")
+			}
+
+			var ok bool
+			if primaryNodeZone, ok = nodeObj.Labels[consts.WellKnownTopologyKey]; ok {
+				w.Logger().V(5).Infof("failed to find zone annotations for primary node")
+			}
+		}
+
+		nodeSelector := labels.NewSelector()
+		zoneRequirement, _ := labels.NewRequirement(consts.WellKnownTopologyKey, selection.In, compatibleZones)
+		nodeSelector = nodeSelector.Add(*zoneRequirement)
+
+		compatibleNodes := &v1.NodeList{}
+		if err = c.cachedClient.List(ctx, compatibleNodes, &client.ListOptions{LabelSelector: nodeSelector}); err != nil {
+			err = status.Errorf(codes.Aborted, "failed to retrieve node list: %v", err)
+			return nodes, err
+		}
+
+		// Create a zone to node map
+		zoneToNodeMap := map[string][]v1.Node{}
+		for _, node := range compatibleNodes.Items {
+			zoneName := node.Labels[consts.WellKnownTopologyKey]
+			zoneToNodeMap[zoneName] = append(zoneToNodeMap[zoneName], node)
+		}
+
+		// Get prioritized nodes per zone
+		nodesPerZone := [][]v1.Node{}
+		primaryZoneNodes := []v1.Node{}
+		totalCount := 0
+		for zone, nodeList := range zoneToNodeMap {
+			var sortedNodes []v1.Node
+			sortedNodes, err = c.filterAndSortNodes(ctx, nodeList, pods, volumes)
+			if err != nil {
+				err = status.Errorf(codes.Aborted, "failed to select nodes for volumes (%+v): %v", volumes, err)
+				return nil, err
+			}
+
+			totalCount += len(sortedNodes)
+			if zone == primaryNodeZone {
+				primaryZoneNodes = sortedNodes
+				continue
+			}
+			nodesPerZone = append(nodesPerZone, sortedNodes)
+		}
+		// Append the nodes from the zone of the primary node at last
+		if len(primaryZoneNodes) > 0 {
+			nodesPerZone = append(nodesPerZone, primaryZoneNodes)
+		}
+		// Select the nodes from each of the zones one by one and append to the list
+		i, j, countSoFar := 0, 0, 0
+		for len(selectedNodes) < numReplicas && countSoFar < totalCount {
+			if len(nodesPerZone[i]) > j {
+				selectedNodes = append(selectedNodes, nodesPerZone[i][j])
+				countSoFar++
+			}
+			if i < len(nodesPerZone)-1 {
+				i++
+			} else {
+				i = 0
+				j++
+			}
+		}
+	}
+
+	return selectedNodes[:min(len(selectedNodes), numReplicas)], nil
+}
+
+func (c *sharedState) getNodesWithReplica(ctx context.Context, volumeName string) ([]string, error) {
+	w, _ := workflow.GetWorkflowFromContext(ctx)
+	w.Logger().V(5).Infof("Getting nodes with replica AzVolumeAttachments for volume %s.", volumeName)
+	azVolumeAttachments, err := azureutils.GetAzVolumeAttachmentsForVolume(ctx, c.cachedClient, volumeName, azureutils.ReplicaOnly)
+	if err != nil {
+		w.Logger().V(5).Errorf(err, "failed to get AzVolumeAttachments for volume %s.", volumeName)
+		return nil, err
+	}
+
+	nodes := []string{}
+	for _, azVolumeAttachment := range azVolumeAttachments {
+		nodes = append(nodes, azVolumeAttachment.Spec.NodeName)
+	}
+	w.Logger().V(5).Infof("Nodes with AzVolumeAttachments for volume %s are: %v, Len: %d", volumeName, nodes, len(nodes))
+	return nodes, nil
+}
+
+func (c *sharedState) createReplicaAzVolumeAttachment(ctx context.Context, volumeID, node string, volumeContext map[string]string) error {
+	var err error
+	ctx, w := workflow.New(ctx, workflow.WithDetails(consts.NodeNameLabel, node))
+	defer func() { w.Finish(err) }()
+
+	var diskName string
+	diskName, err = azureutils.GetDiskName(volumeID)
+	if err != nil {
+		err = status.Errorf(codes.Internal, "failed to extract volume name from volumeID (%s)", volumeID)
+		return err
+	}
+	w.AddDetailToLogger(consts.VolumeNameLabel, diskName)
+
+	w.Logger().V(5).Info("Creating replica AzVolumeAttachments")
+	if volumeContext == nil {
+		volumeContext = make(map[string]string)
+	}
+	// creating azvolumeattachment
+	volumeName := strings.ToLower(diskName)
+	replicaName := azureutils.GetAzVolumeAttachmentName(volumeName, node)
+	azVolumeAttachment := azdiskv1beta2.AzVolumeAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      replicaName,
+			Namespace: c.objectNamespace,
+			Labels: map[string]string{
+				consts.NodeNameLabel:   node,
+				consts.VolumeNameLabel: volumeName,
+				consts.RoleLabel:       string(azdiskv1beta2.ReplicaRole),
+			},
+			Annotations: map[string]string{consts.VolumeAttachRequestAnnotation: "controller"},
+			Finalizers:  []string{consts.AzVolumeAttachmentFinalizer},
+		},
+		Spec: azdiskv1beta2.AzVolumeAttachmentSpec{
+			NodeName:      node,
+			VolumeID:      volumeID,
+			VolumeName:    volumeName,
+			RequestedRole: azdiskv1beta2.ReplicaRole,
+			VolumeContext: volumeContext,
+		},
+	}
+	w.AnnotateObject(&azVolumeAttachment)
+	_, err = c.azClient.DiskV1beta2().AzVolumeAttachments(c.objectNamespace).Create(ctx, &azVolumeAttachment, metav1.CreateOptions{})
+	if err != nil {
+		err = status.Errorf(codes.Internal, "failed to create replica AzVolumeAttachment %s.", replicaName)
+		return err
+	}
+	return nil
+}
+
+func (c *sharedState) cleanUpAzVolumeAttachmentByVolume(ctx context.Context, azVolumeName string, caller operationRequester, role azureutils.AttachmentRoleMode, deleteMode cleanUpMode) ([]azdiskv1beta2.AzVolumeAttachment, error) {
+	var err error
+	ctx, w := workflow.New(ctx, workflow.WithDetails(consts.VolumeNameLabel, azVolumeName))
+	defer func() { w.Finish(err) }()
+
+	w.Logger().Infof("AzVolumeAttachment clean up requested by %s for AzVolume (%s)", caller, azVolumeName)
+
+	var attachments []azdiskv1beta2.AzVolumeAttachment
+	attachments, err = azureutils.GetAzVolumeAttachmentsForVolume(ctx, c.cachedClient, azVolumeName, role)
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			err = nil
+			return nil, nil
+		}
+		err = status.Errorf(codes.Aborted, "failed to get AzVolumeAttachments: %v", err)
+		return nil, err
+	}
+
+	if err = c.cleanUpAzVolumeAttachments(ctx, attachments, deleteMode, caller); err != nil {
+		return attachments, err
+	}
+	c.unmarkVolumeVisited(azVolumeName)
+	return attachments, nil
+}
+
+func (c *sharedState) cleanUpAzVolumeAttachmentByNode(ctx context.Context, azDriverNodeName string, caller operationRequester, role azureutils.AttachmentRoleMode, deleteMode cleanUpMode) ([]azdiskv1beta2.AzVolumeAttachment, error) {
+	var err error
+	ctx, w := workflow.New(ctx, workflow.WithDetails(consts.NodeNameLabel, azDriverNodeName))
+	defer func() { w.Finish(err) }()
+	w.Logger().Infof("AzVolumeAttachment clean up requested by %s for AzDriverNode (%s)", caller, azDriverNodeName)
+
+	var nodeRequirement *labels.Requirement
+	nodeRequirement, err = azureutils.CreateLabelRequirements(consts.NodeNameLabel, selection.Equals, azDriverNodeName)
+	if err != nil {
+		return nil, err
+	}
+	labelSelector := labels.NewSelector().Add(*nodeRequirement)
+
+	var attachments *azdiskv1beta2.AzVolumeAttachmentList
+	attachments, err = c.azClient.DiskV1beta2().AzVolumeAttachments(c.objectNamespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector.String()})
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			err = nil
+			return nil, nil
+		}
+		err = status.Errorf(codes.Aborted, "failed to get AzVolumeAttachments: %v", err)
+		return nil, err
+	}
+
+	cleanUpMap := map[string][]azdiskv1beta2.AzVolumeAttachment{}
+	for _, attachment := range attachments.Items {
+		if shouldCleanUp(attachment, role) {
+			cleanUpMap[attachment.Spec.VolumeName] = append(cleanUpMap[attachment.Spec.VolumeName], attachment)
+		}
+	}
+
+	for volumeName, cleanUps := range cleanUpMap {
+		volumeName := volumeName
+		defer w.Finish(nil)
+		c.addToOperationQueue(ctx,
+			volumeName,
+			caller,
+			func(ctx context.Context) error {
+				return c.cleanUpAzVolumeAttachments(ctx, cleanUps, deleteMode, caller)
+			},
+			false)
+	}
+	return attachments.Items, nil
+}
+
+func (c *sharedState) cleanUpAzVolumeAttachments(ctx context.Context, attachments []azdiskv1beta2.AzVolumeAttachment, cleanUp cleanUpMode, caller operationRequester) error {
+	var err error
+	w, _ := workflow.GetWorkflowFromContext(ctx)
+
+	for _, attachment := range attachments {
+		var patchRequired bool
+		patched := attachment.DeepCopy()
+
+		// if caller is azdrivernode, don't append cleanup annotation
+		if (caller != azdrivernode && !metav1.HasAnnotation(patched.ObjectMeta, consts.CleanUpAnnotation)) ||
+			// replica attachments should always be detached regardless of the cleanup mode
+			((cleanUp == detachAndDeleteCRI || patched.Spec.RequestedRole == azdiskv1beta2.ReplicaRole) && !metav1.HasAnnotation(patched.ObjectMeta, consts.VolumeDetachRequestAnnotation)) {
+			patchRequired = true
+			if caller != azdrivernode {
+				patched.Status.Annotations = azureutils.AddToMap(patched.Status.Annotations, consts.CleanUpAnnotation, string(caller))
+			}
+			if cleanUp == detachAndDeleteCRI || patched.Spec.RequestedRole == azdiskv1beta2.ReplicaRole {
+				patched.Status.Annotations = azureutils.AddToMap(patched.Status.Annotations, consts.VolumeDetachRequestAnnotation, string(caller))
+			}
+		}
+
+		if patchRequired {
+			if err = c.cachedClient.Status().Patch(ctx, patched, client.MergeFrom(&attachment)); err != nil && apiErrors.IsNotFound(err) {
+				err = status.Errorf(codes.Internal, "failed to patch AzVolumeAttachment (%s)", attachment.Name)
+				return err
+			}
+		}
+		if !objectDeletionRequested(patched) {
+			if err := c.cachedClient.Delete(ctx, patched); err != nil && apiErrors.IsNotFound(err) {
+				err = status.Errorf(codes.Internal, "failed to delete AzVolumeAttachment (%s)", attachment.Name)
+				return err
+			}
+			w.Logger().V(5).Infof("Set deletion timestamp for AzVolumeAttachment (%s)", attachment.Name)
+		}
+	}
+	return nil
+}
+
+func (c *sharedState) createReplicaRequestsQueue() {
+	c.priorityReplicaRequestsQueue = &VolumeReplicaRequestsPriorityQueue{}
+	c.priorityReplicaRequestsQueue.queue = cache.NewHeap(
+		func(obj interface{}) (string, error) {
+			return obj.(*ReplicaRequest).VolumeName, nil
+		},
+		func(left, right interface{}) bool {
+			return left.(*ReplicaRequest).Priority > right.(*ReplicaRequest).Priority
+		})
+}
+
+///Removes replica requests from the priority queue and adds to operation queue.
+func (c *sharedState) tryCreateFailedReplicas(ctx context.Context, requestor operationRequester) {
+	if atomic.SwapInt32(&c.processingReplicaRequestQueue, 1) == 0 {
+		ctx, w := workflow.New(ctx)
+		defer w.Finish(nil)
+		requests := c.priorityReplicaRequestsQueue.DrainQueue()
+		for i := 0; i < len(requests); i++ {
+			replicaRequest := requests[i]
+			c.addToOperationQueue(ctx,
+				replicaRequest.VolumeName,
+				requestor,
+				func(ctx context.Context) error {
+					return c.manageReplicas(ctx, replicaRequest.VolumeName)
+				},
+				false,
+			)
+		}
+		atomic.StoreInt32(&c.processingReplicaRequestQueue, 0)
+	}
+}
+
+func (c *sharedState) garbageCollectReplicas(ctx context.Context, volumeName string, requester operationRequester) {
+	c.addToOperationQueue(
+		ctx,
+		volumeName,
+		replica,
+		func(ctx context.Context) error {
+			if _, err := c.cleanUpAzVolumeAttachmentByVolume(ctx, volumeName, requester, azureutils.ReplicaOnly, detachAndDeleteCRI); err != nil {
+				return err
+			}
+			c.addToGcExclusionList(volumeName, replica)
+			c.removeGarbageCollection(volumeName)
+			c.unmarkVolumeVisited(volumeName)
+			return nil
+		},
+		true,
+	)
+}
+
+func (c *sharedState) removeGarbageCollection(volumeName string) {
+	v, ok := c.cleanUpMap.LoadAndDelete(volumeName)
+	if ok {
+		cancelFunc := v.(context.CancelFunc)
+		cancelFunc()
+	}
+	// if there is any garbage collection enqueued in operation queue, remove it
+	c.dequeueGarbageCollection(volumeName)
+}
+
+func (c *sharedState) manageReplicas(ctx context.Context, volumeName string) error {
+	var err error
+	ctx, w := workflow.New(ctx)
+	defer func() { w.Finish(err) }()
+
+	var azVolume *azdiskv1beta2.AzVolume
+	azVolume, err = azureutils.GetAzVolume(ctx, c.cachedClient, c.azClient, volumeName, c.objectNamespace, true)
+	if apiErrors.IsNotFound(err) {
+		w.Logger().Info("Volume no longer exists. Aborting manage replica operation")
+		return nil
+	} else if err != nil {
+		w.Logger().Error(err, "failed to get AzVolume")
+		return err
+	}
+
+	// replica management should not be executed or retried if AzVolume is scheduled for a deletion or not created.
+	if !isCreated(azVolume) || objectDeletionRequested(azVolume) {
+		w.Logger().Errorf(err, "azVolume is scheduled for deletion or has no underlying volume object")
+		return nil
+	}
+
+	azVolumeAttachments, err := azureutils.GetAzVolumeAttachmentsForVolume(ctx, c.cachedClient, volumeName, azureutils.ReplicaOnly)
+	if err != nil {
+		w.Logger().Errorf(err, "failed to list replica AzVolumeAttachments")
+		return err
+	}
+
+	desiredReplicaCount, currentReplicaCount := azVolume.Spec.MaxMountReplicaCount, len(azVolumeAttachments)
+	w.Logger().Infof("Control number of replicas for volume (%s): desired=%d,\tcurrent:%d", azVolume.Spec.VolumeName, desiredReplicaCount, currentReplicaCount)
+
+	if desiredReplicaCount > currentReplicaCount {
+		w.Logger().Infof("Need %d more replicas for volume (%s)", desiredReplicaCount-currentReplicaCount, azVolume.Spec.VolumeName)
+		if azVolume.Status.Detail == nil || azVolume.Status.State == azdiskv1beta2.VolumeDeleting || azVolume.Status.State == azdiskv1beta2.VolumeDeleted {
+			// underlying volume does not exist, so volume attachment cannot be made
+			return nil
+		}
+		if err = c.createReplicas(ctx, desiredReplicaCount-currentReplicaCount, azVolume.Name, azVolume.Status.Detail.VolumeID, azVolume.Spec.Parameters); err != nil {
+			w.Logger().Errorf(err, "failed to create %d replicas for volume (%s): %v", desiredReplicaCount-currentReplicaCount, azVolume.Spec.VolumeName, err)
+			return err
+		}
+	}
+	return nil
+}
+func (c *sharedState) createReplicas(ctx context.Context, remainingReplicas int, volumeName, volumeID string, volumeContext map[string]string) error {
+	var err error
+	ctx, w := workflow.New(ctx)
+	defer func() { w.Finish(err) }()
+
+	// if volume is scheduled for clean up, skip replica creation
+	if _, cleanUpScheduled := c.cleanUpMap.Load(volumeName); cleanUpScheduled {
+		return nil
+	}
+
+	// get pods linked to the volume
+	var pods []v1.Pod
+	pods, err = c.getPodsFromVolume(ctx, c.cachedClient, volumeName)
+	if err != nil {
+		return err
+	}
+
+	// acquire per-pod lock to be released upon creation of replica AzVolumeAttachment CRIs
+	for _, pod := range pods {
+		podKey := getQualifiedName(pod.Namespace, pod.Name)
+		v, _ := c.podLocks.LoadOrStore(podKey, &sync.Mutex{})
+		podLock := v.(*sync.Mutex)
+		podLock.Lock()
+		defer podLock.Unlock()
+	}
+
+	var nodes []string
+	nodes, err = c.getNodesForReplica(ctx, volumeName, pods, remainingReplicas)
+	if err != nil {
+		w.Logger().Errorf(err, "failed to get a list of nodes for replica attachment")
+		return err
+	}
+
+	requiredReplicas := remainingReplicas
+	for _, node := range nodes {
+		if err = c.createReplicaAzVolumeAttachment(ctx, volumeID, node, volumeContext); err != nil {
+			w.Logger().Errorf(err, "failed to create replica AzVolumeAttachment for volume %s", volumeName)
+			//Push to queue the failed replica number
+			request := ReplicaRequest{VolumeName: volumeName, Priority: remainingReplicas}
+			c.priorityReplicaRequestsQueue.Push(ctx, &request)
+			return err
+		}
+		remainingReplicas--
+	}
+
+	if remainingReplicas > 0 {
+		//no failed replica attachments, but there are still more replicas to reach MaxShares
+		request := ReplicaRequest{VolumeName: volumeName, Priority: remainingReplicas}
+		c.priorityReplicaRequestsQueue.Push(ctx, &request)
+		for _, pod := range pods {
+			c.eventRecorder.Eventf(pod.DeepCopyObject(), v1.EventTypeWarning, consts.ReplicaAttachmentFailedEvent, "Not enough suitable nodes to attach %d of %d replica mount(s) for volume %s", remainingReplicas, requiredReplicas, volumeName)
+		}
+	}
+	return nil
+}
+
+func (c *sharedState) getNodesForReplica(ctx context.Context, volumeName string, pods []v1.Pod, numReplica int) ([]string, error) {
+	var err error
+	ctx, w := workflow.New(ctx)
+	defer func() { w.Finish(err) }()
+
+	if len(pods) == 0 {
+		pods, err = c.getPodsFromVolume(ctx, c.cachedClient, volumeName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var volumes []string
+	volumes, err = c.getVolumesForPodObjs(ctx, pods)
+	if err != nil {
+		return nil, err
+	}
+
+	var nodes []string
+	nodes, err = c.getRankedNodesForReplicaAttachments(ctx, volumes, pods)
+	if err != nil {
+		return nil, err
+	}
+
+	var replicaNodes []string
+	replicaNodes, err = c.getNodesWithReplica(ctx, volumeName)
+	if err != nil {
+		return nil, err
+	}
+
+	skipSet := map[string]bool{}
+	for _, replicaNode := range replicaNodes {
+		skipSet[replicaNode] = true
+	}
+
+	filtered := []string{}
+	numFiltered := 0
+	for _, node := range nodes {
+		if numFiltered >= numReplica {
+			break
+		}
+		if skipSet[node] {
+			continue
+		}
+		filtered = append(filtered, node)
+		numFiltered++
+	}
+
+	return filtered, nil
+}

--- a/pkg/controller/shared_state.go
+++ b/pkg/controller/shared_state.go
@@ -1025,7 +1025,7 @@ func (c *SharedState) createReplicaRequestsQueue() {
 		})
 }
 
-///Removes replica requests from the priority queue and adds to operation queue.
+// Removes replica requests from the priority queue and adds to operation queue.
 func (c *SharedState) tryCreateFailedReplicas(ctx context.Context, requestor operationRequester) {
 	if atomic.SwapInt32(&c.processingReplicaRequestQueue, 1) == 0 {
 		ctx, w := workflow.New(ctx)

--- a/pkg/controller/volumeattachment.go
+++ b/pkg/controller/volumeattachment.go
@@ -39,9 +39,9 @@ import (
 
 // Struct for the reconciler
 type ReconcileVolumeAttachment struct {
+	*SharedState
 	logger              logr.Logger
 	controllerRetryInfo *retryInfo
-	*sharedState
 }
 
 // Implement reconcile.Reconciler so the controller can reconcile objects
@@ -88,11 +88,11 @@ func (r *ReconcileVolumeAttachment) Reconcile(ctx context.Context, request recon
 	return reconcile.Result{}, nil
 }
 
-func NewVolumeAttachmentController(mgr manager.Manager, controllerSharedState *sharedState) (*ReconcileVolumeAttachment, error) {
+func NewVolumeAttachmentController(mgr manager.Manager, controllerSharedState *SharedState) (*ReconcileVolumeAttachment, error) {
 	logger := mgr.GetLogger().WithValues("controller", "volumeattachment")
 	reconciler := ReconcileVolumeAttachment{
 		controllerRetryInfo: newRetryInfo(),
-		sharedState:         controllerSharedState,
+		SharedState:         controllerSharedState,
 		logger:              logger,
 	}
 

--- a/pkg/controller/volumeattachment_test.go
+++ b/pkg/controller/volumeattachment_test.go
@@ -36,7 +36,7 @@ func NewTestVolumeAttachmentController(controller *gomock.Controller, namespace 
 
 	return &ReconcileVolumeAttachment{
 		controllerRetryInfo: newRetryInfo(),
-		sharedState:         controllerSharedState,
+		SharedState:         controllerSharedState,
 		logger:              klogr.New(),
 	}
 }

--- a/pkg/controller/volumeattachment_test.go
+++ b/pkg/controller/volumeattachment_test.go
@@ -35,9 +35,9 @@ func NewTestVolumeAttachmentController(controller *gomock.Controller, namespace 
 	controllerSharedState := initState(mockclient.NewMockClient(controller), azdiskfakes.NewSimpleClientset(azDiskObjs...), fakev1.NewSimpleClientset(kubeObjs...), objects...)
 
 	return &ReconcileVolumeAttachment{
-		controllerRetryInfo:   newRetryInfo(),
-		controllerSharedState: controllerSharedState,
-		logger:                klogr.New(),
+		controllerRetryInfo: newRetryInfo(),
+		sharedState:         controllerSharedState,
+		logger:              klogr.New(),
 	}
 }
 
@@ -65,7 +65,7 @@ func TestVolumeAttachmentReconcile(t *testing.T) {
 					newVolumeAttachment,
 					newAzVolumeAttachment)
 
-				mockClients(controller.controllerSharedState.cachedClient.(*mockclient.MockClient), controller.controllerSharedState.azClient, controller.controllerSharedState.kubeClient)
+				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 
 				return controller
 			},
@@ -73,7 +73,7 @@ func TestVolumeAttachmentReconcile(t *testing.T) {
 				require.NoError(t, err)
 				require.False(t, result.Requeue)
 
-				val, ok := controller.controllerSharedState.azVolumeAttachmentToVaMap.Load(testPrimaryAzVolumeAttachment0Name)
+				val, ok := controller.azVolumeAttachmentToVaMap.Load(testPrimaryAzVolumeAttachment0Name)
 				require.True(t, ok)
 				vaName := val.(string)
 				require.Equal(t, vaName, testVolumeAttachmentName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Currently, the SharedState struct and its related functions are scattered through source files in the pkg/controller package. This makes maintaining them harder. This PR refactors the SharedState struct and moves it and its related method to a separate file, making it easier to maintain.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1412

**Requirements**:
- [X] Move the `SharedState` struct and its related functions into a single source file, `shared_state.go`
- [X] Make the `SharedState` struct package private, if possible.
- [X] Consider making `SharedState` and anonymous field in the controllers to avoid the need to explicitly access if by field name (currently, controllerSharedState which is redundant information and really long to type).

**Special notes for your reviewer**:
Adding SharedState specific unit tests will be taken care as part of a separate PR.

**Release note**:
```
none
```
