### PR TITLE
[V2] bug: Fixing date race caused by read/write to package global vars

### DIFF
--- a/pkg/csi-common/utils_test.go
+++ b/pkg/csi-common/utils_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"flag"
+	"os"
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -28,6 +29,25 @@ import (
 
 	"github.com/stretchr/testify/assert"
 )
+
+func init() {
+	klog.InitFlags(nil)
+}
+
+func TestMain(m *testing.M) {
+	if e := flag.Set("logtostderr", "false"); e != nil {
+		klog.Error(e)
+	}
+	if e := flag.Set("alsologtostderr", "false"); e != nil {
+		klog.Error(e)
+	}
+	if e := flag.Set("v", "100"); e != nil {
+		klog.Error(e)
+	}
+	flag.Parse()
+	exitVal := m.Run()
+	os.Exit(exitVal)
+}
 
 func TestParseEndpoint(t *testing.T) {
 
@@ -84,17 +104,6 @@ func TestParseEndpoint(t *testing.T) {
 
 func TestLogGRPC(t *testing.T) {
 	// SET UP
-	klog.InitFlags(nil)
-	if e := flag.Set("logtostderr", "false"); e != nil {
-		t.Error(e)
-	}
-	if e := flag.Set("alsologtostderr", "false"); e != nil {
-		t.Error(e)
-	}
-	if e := flag.Set("v", "100"); e != nil {
-		t.Error(e)
-	}
-	flag.Parse()
 
 	buf := new(bytes.Buffer)
 	klog.SetOutput(buf)


### PR DESCRIPTION
…lel test.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
The package tests in csi-common were causing a data race due to reading/writing to `addDirHeader` global variable in `klog` package. `TestLogGRPC` was calling `InitFlags` which was initializing global variables including `addDirHeader` which would cause any other parallel call to `klog.Info` to result in data race as the fucntion is relying on the value of  `addDirHeader`. 



<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
