### PR TITLE
[v2] fix: fixing pod failure status

### DIFF
--- a/test/podFailover/controller/chart/templates/podfailurecrd.yaml
+++ b/test/podFailover/controller/chart/templates/podfailurecrd.yaml
@@ -22,7 +22,6 @@ spec:
                   type: string
             status:
               type: object
-              required: ["failureType", "heartbeat"]
               properties:
                 failureType:
                   type: string


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
pod failure status listed failuretype and heartbeat as required
fields making the workload pods fail.
changing crd definition to make these fields optional

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
