### PR TITLE
fix: Ultra Disk DefaultDiskMBPSReadWrite calc issue

### DIFF
--- a/pkg/azuredisk/azuredisk.go
+++ b/pkg/azuredisk/azuredisk.go
@@ -40,6 +40,7 @@ import (
 	csicommon "sigs.k8s.io/azuredisk-csi-driver/pkg/csi-common"
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/mounter"
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/optimization"
+	"sigs.k8s.io/azuredisk-csi-driver/pkg/util"
 	volumehelper "sigs.k8s.io/azuredisk-csi-driver/pkg/util"
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	azurecloudconsts "sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -427,10 +428,10 @@ func getDefaultDiskMBPSReadWrite(requestGiB int) int {
 	bandwidth := azurecloudconsts.DefaultDiskMBpsReadWrite
 	iops := getDefaultDiskIOPSReadWrite(requestGiB)
 	if iops/256 > bandwidth {
-		bandwidth = iops / 256
+		bandwidth = int(util.RoundUpSize(int64(iops), 256))
 	}
 	if bandwidth > iops/4 {
-		bandwidth = iops / 4
+		bandwidth = int(util.RoundUpSize(int64(iops), 4))
 	}
 	if bandwidth > 4000 {
 		bandwidth = 4000

--- a/pkg/azuredisk/azuredisk_test.go
+++ b/pkg/azuredisk/azuredisk_test.go
@@ -251,6 +251,10 @@ func TestGetDefaultDiskMBPSReadWrite(t *testing.T) {
 			requestGiB: 512000000,
 			expected:   625,
 		},
+		{
+			requestGiB: 65535,
+			expected:   256,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -45,13 +45,13 @@ func IsLinuxOS() bool {
 // RoundUpBytes rounds up the volume size in bytes up to multiplications of GiB
 // in the unit of Bytes
 func RoundUpBytes(volumeSizeBytes int64) int64 {
-	return roundUpSize(volumeSizeBytes, GiB) * GiB
+	return RoundUpSize(volumeSizeBytes, GiB) * GiB
 }
 
 // RoundUpGiB rounds up the volume size in bytes up to multiplications of GiB
 // in the unit of GiB
 func RoundUpGiB(volumeSizeBytes int64) int64 {
-	return roundUpSize(volumeSizeBytes, GiB)
+	return RoundUpSize(volumeSizeBytes, GiB)
 }
 
 // BytesToGiB conversts Bytes to GiB
@@ -64,12 +64,12 @@ func GiBToBytes(volumeSizeGiB int64) int64 {
 	return volumeSizeGiB * GiB
 }
 
-// roundUpSize calculates how many allocation units are needed to accommodate
+// RoundUpSize calculates how many allocation units are needed to accommodate
 // a volume of given size. E.g. when user wants 1500MiB volume, while AWS EBS
 // allocates volumes in gibibyte-sized chunks,
 // RoundUpSize(1500 * 1024*1024, 1024*1024*1024) returns '2'
 // (2 GiB is the smallest allocatable volume that can hold 1500MiB)
-func roundUpSize(volumeSizeBytes int64, allocationUnitBytes int64) int64 {
+func RoundUpSize(volumeSizeBytes int64, allocationUnitBytes int64) int64 {
 	roundedUp := volumeSizeBytes / allocationUnitBytes
 	if volumeSizeBytes%allocationUnitBytes > 0 {
 		roundedUp++


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: Ultra Disk DefaultDiskMBPSReadWrite calc issue
This PR fixed a corner case with following Ultra Disk DefaultDiskMBPSReadWrite default value issue:

<details>

```
I0831 14:31:34.966292       1 utils.go:77] GRPC call: /csi.v1.Controller/CreateVolume
I0831 14:31:34.966314       1 utils.go:78] GRPC request: {"accessibility_requirements":{"preferred":[{"segments":{"topology.disk.csi.azure.com/zone":""}}],"requisite":[{"segments":{"topology.disk.csi.azure.com/zone":""}}]},"capacity_range":{"required_bytes":70367670435840},"name":"pvc-65ca543f-75f1-4ba8-9a2e-b7bb050f442d","parameters":{"cachingMode":"None","csi.storage.k8s.io/pv/name":"pvc-65ca543f-75f1-4ba8-9a2e-b7bb050f442d","csi.storage.k8s.io/pvc/name":"pvc-azuredisk-ultra","csi.storage.k8s.io/pvc/namespace":"default","fsType":"ext4","skuname":"UltraSSD_LRS"},"volume_capabilities":[{"AccessType":{"Mount":{"fs_type":"ext4"}},"access_mode":{"mode":7}}]}
I0831 14:31:34.966651       1 controllerserver.go:174] begin to create azure disk(pvc-65ca543f-75f1-4ba8-9a2e-b7bb050f442d) account type(UltraSSD_LRS) rg(mc_andy-aks1219_group_andy-aks1219_uksouth) location(uksouth) size(65535) diskZone() maxShares(0)
I0831 14:31:34.966676       1 controllerserver.go:218] set default DiskIOPSReadWrite as 65535, DiskMBPSReadWrite as 255 on disk(pvc-65ca543f-75f1-4ba8-9a2e-b7bb050f442d)
I0831 14:31:34.966690       1 azure_managedDiskController.go:92] azureDisk - creating new managed Name:pvc-65ca543f-75f1-4ba8-9a2e-b7bb050f442d StorageAccountType:UltraSSD_LRS Size:65535
I0831 14:31:36.025245       1 util.go:137] Send.sendRequest original response: {
  "error": {
    "code": "BadRequest",
    "message": "The value 255 of parameter disk.diskMBpsReadWrite is not valid. The supported range for a UltraSSD_LRS disk of size 65535 GB is between 256 and 4000."
  }
```

</details>

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: Ultra Disk DefaultDiskMBPSReadWrite calc issue
```
