### PR TITLE
fix: adding optional workload value to pod-failover

### DIFF
--- a/test/e2e/manifest/pod-failover.json
+++ b/test/e2e/manifest/pod-failover.json
@@ -30,13 +30,13 @@
         "masterProfile": {
             "count": 1,
             "dnsPrefix": "{dnsPrefix}",
-            "vmSize": "Standard_DS2_v2"
+            "vmSize": "Standard_D4s_v3"
         },
         "agentPoolProfiles": [
             {
                 "name": "agentpool1",
-                "count": 5,
-                "vmSize": "Standard_DS2_v2",
+                "count": 3,
+                "vmSize": "Standard_D4s_v3",
                 "availabilityProfile": "AvailabilitySet",
                 "distro": "aks-ubuntu-18.04"
             }

--- a/test/podFailover/workload/chart/templates/workload.yaml
+++ b/test/podFailover/workload/chart/templates/workload.yaml
@@ -122,7 +122,11 @@ spec:
             {{$runID := randNumeric 5}}
             - {{ printf "--run-id=%s" $runID}}
             {{- end}}
+            {{- if .Values.workloadType }}
+            - {{ printf "--workload-type=%s" $.Values.workloadType}}
+            {{- else }}
             - {{ printf "--workload-type=%dpod%dpvc" (int $.Values.podCount) (int $.Values.pvcCount)}}
+            {{- end}}
             {{- if .Values.storageClass }}
             - {{ printf "--storage-provisioner=%s" $.Values.storageClass.provisioner}}
             {{- end}}

--- a/test/podFailover/workload/scenarios/azDiskV2-Replicas.yaml
+++ b/test/podFailover/workload/scenarios/azDiskV2-Replicas.yaml
@@ -12,6 +12,8 @@ storageClass:
 
 namespace: azdiskv2-pod-failover-1pod1pvc
 
+workloadType: 1pod1pvc1replica
+
 podCount: 1
 
 pvcCount: 1

--- a/test/podFailover/workload/scenarios/azDiskV2-noReplicas.yaml
+++ b/test/podFailover/workload/scenarios/azDiskV2-noReplicas.yaml
@@ -12,6 +12,8 @@ storageClass:
 
 namespace: azdiskv2-pod-failover-1pod1pvc
 
+workloadType: 1pod1pvc0replica
+
 podCount: 1
 
 pvcCount: 1


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
adding ability to specify workload type to pod failover tests

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
