### PR TITLE
[V2] [WIP] test: add e2e tests for conflicting UUIDs issue and supporting for se…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ ifdef TEST_WINDOWS
 		--set controller.logLevel=6 \
 		--set schedulerExtender.replicas=1 \
 		--set node.logLevel=6 \
+		--set snapshot.enabled=true \
 		--set cloud=$(CLOUD)
 else
 	helm $(HELM_COMMAND) azuredisk-csi-driver charts/${CHART_VERSION}/azuredisk-csi-driver --namespace kube-system --wait --timeout=15m -v=5 --debug \

--- a/test/utils/testutil/env_utils.go
+++ b/test/utils/testutil/env_utils.go
@@ -78,3 +78,10 @@ func SkipIfNotDynamicallyResizeSupported(location string) {
 		ginkgo.Skip("test case not supported no regions without dynamic resize support")
 	}
 }
+
+func GetFSType(IsWindowsCluster bool) string {
+	if IsWindowsCluster {
+		return "ntfs"
+	}
+	return "ext4"
+}

--- a/test/utils/testutil/test_ops_util.go
+++ b/test/utils/testutil/test_ops_util.go
@@ -95,6 +95,8 @@ func ConvertToPowershellorCmdCommandIfNecessary(command string) string {
 		return "echo 'hello world' | Out-File -FilePath C:\\mnt\\test-1\\data.txt; Get-Content C:\\mnt\\test-1\\data.txt | findstr 'hello world'; echo 'hello world' | Out-File -FilePath C:\\mnt\\test-2\\data.txt; Get-Content C:\\mnt\\test-2\\data.txt | findstr 'hello world'; echo 'hello world' | Out-File -FilePath C:\\mnt\\test-3\\data.txt; Get-Content C:\\mnt\\test-3\\data.txt | findstr 'hello world'"
 	case "while true; do sleep 5; done":
 		return "while ($true) { Start-Sleep 5 }"
+	case "grep 'hello world' /mnt/test-1/data":
+		return "Select-String -Path '/mnt/test-1/data' -Pattern 'hello world'"
 	}
 
 	return command


### PR DESCRIPTION
Add e2e tests for volume snapshot with conflicting UUID issue

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind test

**What this PR does / why we need it**:

When a disk is partitioned, each partition gets a unique identifier (UUID) and the OS uses this to uniquely identify the partition. Problems arise when two partitions with the same UUID are mounted on the same node. This isn’t likely with newly created managed disks. However, it can happen when you create a disk, take a snapshot of it and the create a new disk using the snapshot as its data source.
Recently, the Disk Resource Provider (DiskRP) team has made a change to managed disk creation from snapshot that ensures the copy gets a new partition UUID. It’s currently in limited flighting and out test subscription (Xstore Container Storage) has the feature enabled. This PR modifies the test implementation to allow testing of this scenario and others. Specifically, it supports an option to schedule the overwrite pod and the snapshot pot on the same or on different nodes. This PR won’t be able to check this in upstream until the feature has been made public. Will need another PR to clean up all the TODOs.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
