### PR TITLE
[V2] fix: adding scheduler to pod-failover workload pods

### DIFF
--- a/test/e2e/manifest/pod-failover.json
+++ b/test/e2e/manifest/pod-failover.json
@@ -30,13 +30,13 @@
         "masterProfile": {
             "count": 1,
             "dnsPrefix": "{dnsPrefix}",
-            "vmSize": "Standard_D4s_v3"
+            "vmSize": "Standard_D8s_v3"
         },
         "agentPoolProfiles": [
             {
                 "name": "agentpool1",
                 "count": 3,
-                "vmSize": "Standard_D4s_v3",
+                "vmSize": "Standard_D8s_v3",
                 "availabilityProfile": "AvailabilitySet",
                 "distro": "aks-ubuntu-18.04"
             }

--- a/test/podFailover/workload/chart/templates/workload.yaml
+++ b/test/podFailover/workload/chart/templates/workload.yaml
@@ -95,6 +95,20 @@ spec:
         app: pod-failover
         failureType: {{ .Values.failureType }}
     spec:
+      {{- if .Values.schedulerName }}
+      schedulerName: {{ .Values.schedulerName }}
+      {{- end}}
+      {{- if eq .Values.failureType "same-node-failover"}}
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  failureType: same-node-failover
+              topologyKey: kubernetes.io/hostname
+      {{- end}}
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: workload-pod-sa

--- a/test/podFailover/workload/scenarios/azDiskV2-Replicas.yaml
+++ b/test/podFailover/workload/scenarios/azDiskV2-Replicas.yaml
@@ -10,6 +10,9 @@ storageClass:
     allowVolumeExpansion: true
   provisioner: disk.csi.azure.com
 
+# use only with standalone installations of azdisk or it will break the pods
+schedulerName: csi-azuredisk-scheduler-extender
+
 namespace: azdiskv2-pod-failover-1pod1pvc
 
 workloadType: 1pod1pvc1replica

--- a/test/podFailover/workload/scenarios/sameNodeFailover.yaml
+++ b/test/podFailover/workload/scenarios/sameNodeFailover.yaml
@@ -14,7 +14,7 @@ namespace: samenode-pod-failover-1pod1pvc
 
 podCount: 3
 
-pvcCount: 3
+pvcCount: 1
 
 failureType: same-node-failover
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Adds scheduler extender to pod failover workload pods so v2 with replica works as intended
Fixes same node failovers
Changes SKU of pod failover template to make sure the max disks is enough

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
