### PR TITLE
[V2] fix: adding cluster provisioner variable

### DIFF
--- a/test/podFailover/workload/chart/templates/workload.yaml
+++ b/test/podFailover/workload/chart/templates/workload.yaml
@@ -34,6 +34,7 @@ roleRef:
   name: {{ .Values.namespace }}-workload-pod-sa-role
   apiGroup: rbac.authorization.k8s.io
 ---
+{{- if .Values.azureClientId }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -45,6 +46,7 @@ stringData:
   AZURE_CLIENT_SECRET: {{ .Values.azureClientSecret }}
   AZURE_TENANT_ID: {{ .Values.azureTenantId }}
 ---
+{{- end }}
 {{- if .Values.storageClass }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -95,7 +97,7 @@ spec:
         app: pod-failover
         failureType: {{ .Values.failureType }}
     spec:
-      {{- if .Values.schedulerName }}
+      {{- if and (ne .Values.clusterProvisioner "aks-cli") .Values.schedulerName }}
       schedulerName: {{ .Values.schedulerName }}
       {{- end}}
       {{- if eq .Values.failureType "same-node-failover"}}
@@ -175,4 +177,3 @@ spec:
             storage: 1Gi
     {{- end}}
   {{- end}}
-


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
- adding cluster provisioner variable so scheduler name is not set when using AKS CLI clusters


**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
