### PR TITLE
[V2]feat: adding mount replica managed resource

### DIFF
--- a/charts/latest-v2/azuredisk-csi-driver/templates/csi-azuredisk-scheduler-extender.yaml
+++ b/charts/latest-v2/azuredisk-csi-driver/templates/csi-azuredisk-scheduler-extender.yaml
@@ -23,6 +23,9 @@ data:
     - urlPrefix: "http://localhost:{{ .Values.schedulerExtender.servicePort }}/azdiskschedulerextender"
       filterVerb: "filter"
       prioritizeVerb: "prioritize"
+      managedResources:
+      - name: disk.csi.azure.com/mount-replicas
+        ignoredByScheduler: true
       weight: 1
       nodeCacheCapable: true
       ignorable: true

--- a/deploy/example/azdiskschedulerextender/nginx-pod-with-azschedulerextender.yaml
+++ b/deploy/example/azdiskschedulerextender/nginx-pod-with-azschedulerextender.yaml
@@ -3,9 +3,13 @@ kind: Pod
 metadata:
   name: nginx-test-pod
 spec:
-  schedulerName: csi-azuredisk-scheduler-extender
   containers:
   - name: nginx
     image: nginx
     ports:
     - containerPort: 80
+    resources:
+        requests:
+          disk.csi.azure.com/mount-replicas: 1
+        limits:
+          disk.csi.azure.com/mount-replicas: 1

--- a/deploy/example/failover/README.md
+++ b/deploy/example/failover/README.md
@@ -130,8 +130,6 @@ spec:
       labels:
         app: mysql
     spec:
-      # Use the scheduler extender to ensure the pod is placed on a node with an attachment replica on failover.
-      schedulerName: csi-azuredisk-scheduler-extender
       initContainers:
       - name: init-mysql
         image: mysql:5.7
@@ -199,6 +197,9 @@ spec:
           requests:
             cpu: 500m
             memory: 1Gi
+            disk.csi.azure.com/mount-replicas: 1
+          limits:
+            disk.csi.azure.com/mount-replicas: 1
         livenessProbe:
           exec:
             command: ["mysqladmin", "ping"]
@@ -269,6 +270,9 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+            disk.csi.azure.com/mount-replicas: 1
+          limits:
+            disk.csi.azure.com/mount-replicas: 1
       volumes:
       - name: conf
         emptyDir: {}

--- a/hack/verify-helm-chart-files.sh
+++ b/hack/verify-helm-chart-files.sh
@@ -80,6 +80,6 @@ if [[ -z "$(command -v helm)" ]]; then
   install_helm
 fi
 
-helm repo add azuredisk-csi-driver https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/charts
+helm repo add azuredisk-csi-driver https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/charts --force-update
 helm search repo -l azuredisk-csi-driver
 echo "helm chart index verified."

--- a/test/resources/statefulset.go
+++ b/test/resources/statefulset.go
@@ -26,6 +26,7 @@ import (
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -108,6 +109,17 @@ func NewTestStatefulset(c clientset.Interface, ns *v1.Namespace, command string,
 		} else {
 			testStatefulset.Statefulset.Spec.Template.Spec.Containers[0].Command = []string{"powershell.exe"}
 			testStatefulset.Statefulset.Spec.Template.Spec.Containers[0].Args = []string{"-Command", command}
+		}
+	}
+
+	if testutils.IsUsingAzureDiskScheduler(schedulerName) {
+		testStatefulset.Statefulset.Spec.Template.Spec.Containers[0].Resources = v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				"disk.csi.azure.com/mount-replicas": resource.MustParse("1"),
+			},
+			Limits: v1.ResourceList{
+				"disk.csi.azure.com/mount-replicas": resource.MustParse("1"),
+			},
 		}
 	}
 

--- a/test/utils/testutil/env_utils.go
+++ b/test/utils/testutil/env_utils.go
@@ -55,6 +55,10 @@ func GetSchedulerForE2E() string {
 	return "csi-azuredisk-scheduler-extender"
 }
 
+func IsUsingAzureDiskScheduler(schedulerName string) bool {
+	return schedulerName == "csi-azuredisk-scheduler-extender"
+}
+
 func IsZRSSupported(location string) bool {
 	return location == "westus2" || location == "westeurope" || location == "northeurope" || location == "francecentral"
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
- adding disk.csi.azure.com/mount-replicas resource to scheduler extender
- changed all of the e2e tests to use new managed resource

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
