### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/pkg/azuredisk/azuredisk_test.go
+++ b/pkg/azuredisk/azuredisk_test.go
@@ -93,13 +93,7 @@ func TestRun(t *testing.T) {
 					}
 				}()
 
-				originalCredFile, ok := os.LookupEnv(consts.DefaultAzureCredentialFileEnv)
-				if ok {
-					defer os.Setenv(consts.DefaultAzureCredentialFileEnv, originalCredFile)
-				} else {
-					defer os.Unsetenv(consts.DefaultAzureCredentialFileEnv)
-				}
-				os.Setenv(consts.DefaultAzureCredentialFileEnv, fakeCredFile)
+				t.Setenv(consts.DefaultAzureCredentialFileEnv, fakeCredFile)
 
 				d, _ := NewFakeDriver(t)
 				d.Run("tcp://127.0.0.1:0", "", true, true)
@@ -118,13 +112,7 @@ func TestRun(t *testing.T) {
 					}
 				}()
 
-				originalCredFile, ok := os.LookupEnv(consts.DefaultAzureCredentialFileEnv)
-				if ok {
-					defer os.Setenv(consts.DefaultAzureCredentialFileEnv, originalCredFile)
-				} else {
-					defer os.Unsetenv(consts.DefaultAzureCredentialFileEnv)
-				}
-				os.Setenv(consts.DefaultAzureCredentialFileEnv, fakeCredFile)
+				t.Setenv(consts.DefaultAzureCredentialFileEnv, fakeCredFile)
 
 				d, _ := NewFakeDriver(t)
 				d.setCloud(&azure.Cloud{})
@@ -145,13 +133,7 @@ func TestRun(t *testing.T) {
 					}
 				}()
 
-				originalCredFile, ok := os.LookupEnv(consts.DefaultAzureCredentialFileEnv)
-				if ok {
-					defer os.Setenv(consts.DefaultAzureCredentialFileEnv, originalCredFile)
-				} else {
-					defer os.Unsetenv(consts.DefaultAzureCredentialFileEnv)
-				}
-				os.Setenv(consts.DefaultAzureCredentialFileEnv, fakeCredFile)
+				t.Setenv(consts.DefaultAzureCredentialFileEnv, fakeCredFile)
 
 				d := newDriverV1(&DriverOptions{
 					NodeID:                 "",

--- a/pkg/azureutils/azure_disk_utils_test.go
+++ b/pkg/azureutils/azure_disk_utils_test.go
@@ -363,13 +363,7 @@ users:
 				os.Remove(fakeCredFile)
 			}()
 
-			originalCredFile, ok := os.LookupEnv(consts.DefaultAzureCredentialFileEnv)
-			if ok {
-				defer os.Setenv(consts.DefaultAzureCredentialFileEnv, originalCredFile)
-			} else {
-				defer os.Unsetenv(consts.DefaultAzureCredentialFileEnv)
-			}
-			os.Setenv(consts.DefaultAzureCredentialFileEnv, fakeCredFile)
+			t.Setenv(consts.DefaultAzureCredentialFileEnv, fakeCredFile)
 		}
 		if test.createFakeKubeConfig {
 			if err := createTestFile(fakeKubeConfig); err != nil {

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -39,7 +39,7 @@ var useDriverV2 = flag.Bool("temp-use-driver-v2", false, "A temporary flag to en
 
 func TestIntegrationOnAzurePublicCloud(t *testing.T) {
 	// Test on AzurePublicCloud
-	os.Setenv("AZURE_VM_TYPE", "standard")
+	t.Setenv("AZURE_VM_TYPE", "standard")
 	creds, err := credentials.CreateAzureCredentialFile()
 	defer func() {
 		err := credentials.DeleteAzureCredentialFile()
@@ -49,8 +49,8 @@ func TestIntegrationOnAzurePublicCloud(t *testing.T) {
 	assert.NotNil(t, creds)
 
 	// Set necessary env vars for sanity test
-	os.Setenv("AZURE_CREDENTIAL_FILE", credentials.TempAzureCredentialFilePath)
-	os.Setenv("nodeid", nodeid)
+	t.Setenv("AZURE_CREDENTIAL_FILE", credentials.TempAzureCredentialFilePath)
+	t.Setenv("nodeid", nodeid)
 
 	azureClient, err := azure.GetAzureClient(creds.Cloud, creds.SubscriptionID, creds.AADClientID, creds.TenantID, creds.AADClientSecret)
 	assert.NoError(t, err)

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -40,7 +40,7 @@ var useDriverV2 = flag.Bool("temp-use-driver-v2", false, "A temporary flag to en
 
 func TestSanity(t *testing.T) {
 	// Set necessary env vars for creating azure credential file
-	os.Setenv("AZURE_VM_TYPE", vmType)
+	t.Setenv("AZURE_VM_TYPE", vmType)
 
 	creds, err := credentials.CreateAzureCredentialFile()
 	defer func() {
@@ -51,8 +51,8 @@ func TestSanity(t *testing.T) {
 	assert.NotNil(t, creds)
 
 	// Set necessary env vars for sanity test
-	os.Setenv("AZURE_CREDENTIAL_FILE", credentials.TempAzureCredentialFilePath)
-	os.Setenv("nodeid", nodeid)
+	t.Setenv("AZURE_CREDENTIAL_FILE", credentials.TempAzureCredentialFilePath)
+	t.Setenv("nodeid", nodeid)
 
 	azureClient, err := azure.GetAzureClient(creds.Cloud, creds.SubscriptionID, creds.AADClientID, creds.TenantID, creds.AADClientSecret)
 	assert.NoError(t, err)

--- a/test/utils/credentials/credentials_test.go
+++ b/test/utils/credentials/credentials_test.go
@@ -47,38 +47,38 @@ const (
 
 func TestCreateAzureCredentialFileOnAzurePublicCloud(t *testing.T) {
 	t.Run("WithAzureCredentials", func(t *testing.T) {
-		os.Setenv(tenantIDEnvVar, "")
-		os.Setenv(subscriptionIDEnvVar, "")
-		os.Setenv(aadClientIDEnvVar, "")
-		os.Setenv(aadClientSecretEnvVar, "")
-		os.Setenv(resourceGroupEnvVar, testResourceGroup)
-		os.Setenv(locationEnvVar, testLocation)
-		os.Setenv(vmTypeEnvVar, testVMType)
+		t.Setenv(tenantIDEnvVar, "")
+		t.Setenv(subscriptionIDEnvVar, "")
+		t.Setenv(aadClientIDEnvVar, "")
+		t.Setenv(aadClientSecretEnvVar, "")
+		t.Setenv(resourceGroupEnvVar, testResourceGroup)
+		t.Setenv(locationEnvVar, testLocation)
+		t.Setenv(vmTypeEnvVar, testVMType)
 		withAzureCredentials(t)
 	})
 
 	t.Run("WithEnvironmentVariables", func(t *testing.T) {
-		os.Setenv(tenantIDEnvVar, testTenantID)
-		os.Setenv(subscriptionIDEnvVar, testSubscriptionID)
-		os.Setenv(aadClientIDEnvVar, testAadClientID)
-		os.Setenv(aadClientSecretEnvVar, testAadClientSecret)
-		os.Setenv(resourceGroupEnvVar, testResourceGroup)
-		os.Setenv(locationEnvVar, testLocation)
-		os.Setenv(vmTypeEnvVar, testVMType)
+		t.Setenv(tenantIDEnvVar, testTenantID)
+		t.Setenv(subscriptionIDEnvVar, testSubscriptionID)
+		t.Setenv(aadClientIDEnvVar, testAadClientID)
+		t.Setenv(aadClientSecretEnvVar, testAadClientSecret)
+		t.Setenv(resourceGroupEnvVar, testResourceGroup)
+		t.Setenv(locationEnvVar, testLocation)
+		t.Setenv(vmTypeEnvVar, testVMType)
 		withEnvironmentVariables(t)
 	})
 }
 
 func TestCreateAzureCredentialFileOnAzureStackCloud(t *testing.T) {
 	t.Run("WithEnvironmentVariables", func(t *testing.T) {
-		os.Setenv(cloudNameEnvVar, "AzureStackCloud")
-		os.Setenv(tenantIDEnvVar, testTenantID)
-		os.Setenv(subscriptionIDEnvVar, testSubscriptionID)
-		os.Setenv(aadClientIDEnvVar, testAadClientID)
-		os.Setenv(aadClientSecretEnvVar, testAadClientSecret)
-		os.Setenv(resourceGroupEnvVar, testResourceGroup)
-		os.Setenv(locationEnvVar, testLocation)
-		os.Setenv(vmTypeEnvVar, testVMType)
+		t.Setenv(cloudNameEnvVar, "AzureStackCloud")
+		t.Setenv(tenantIDEnvVar, testTenantID)
+		t.Setenv(subscriptionIDEnvVar, testSubscriptionID)
+		t.Setenv(aadClientIDEnvVar, testAadClientID)
+		t.Setenv(aadClientSecretEnvVar, testAadClientSecret)
+		t.Setenv(resourceGroupEnvVar, testResourceGroup)
+		t.Setenv(locationEnvVar, testLocation)
+		t.Setenv(vmTypeEnvVar, testVMType)
 		withEnvironmentVariables(t)
 	})
 }
@@ -91,7 +91,7 @@ func withAzureCredentials(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	os.Setenv("AZURE_CREDENTIALS", tempFile.Name())
+	t.Setenv("AZURE_CREDENTIALS", tempFile.Name())
 
 	_, err = tempFile.Write([]byte(fakeAzureCredentials))
 	assert.NoError(t, err)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

A testing cleanup.

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

```go
func TestFoo(t *testing.T) {
	// before
	key := "ENV"
	originalEnv := os.Getenv(key)
	
	if err := os.Setenv(key, "new value"); err != nil {
		t.Fatal(err)
	}
	defer func() {
		if err := os.Setenv(key, originalEnv); err != nil {
			t.Logf("failed to set env %s back to original value: %v", key, err)
		}
	}()
	
	// after
	t.Setenv(key, "new value")
}
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
NONE
```
