### PR TITLE
[V2] fix: add nodeDiskAvailabilityMap

### DIFF
--- a/pkg/controller/attach_detach_test.go
+++ b/pkg/controller/attach_detach_test.go
@@ -98,6 +98,7 @@ func TestAttachDetachReconcile(t *testing.T) {
 					newAttachment)
 
 				controller.azVolumeAttachmentToVaMap.Store(newAttachment.Name, newVolumeAttachment.Name)
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, newAttachment.Spec.NodeName, testNodeAvailableAttachmentCount)
 
 				mockClientsAndAttachmentProvisioner(controller)
 
@@ -137,6 +138,7 @@ func TestAttachDetachReconcile(t *testing.T) {
 					newVolumeAttachment,
 					newAttachment)
 
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, newAttachment.Spec.NodeName, testNodeAvailableAttachmentCount)
 				mockClientsAndAttachmentProvisioner(controller)
 
 				return controller
@@ -168,6 +170,7 @@ func TestAttachDetachReconcile(t *testing.T) {
 					&testAzVolume0,
 					newAttachment)
 
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, newAttachment.Spec.NodeName, testNodeAvailableAttachmentCount)
 				mockClientsAndAttachmentProvisioner(controller)
 
 				return controller

--- a/pkg/controller/common.go
+++ b/pkg/controller/common.go
@@ -1042,13 +1042,6 @@ func isOperationInProcess(obj interface{}) bool {
 	return false
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func max(a, b int) int {
 	if a > b {
 		return a

--- a/pkg/controller/common_test.go
+++ b/pkg/controller/common_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/golang/mock/gomock"
@@ -197,6 +198,9 @@ var (
 	}
 
 	testVolumeAttachmentName = "test-attachment"
+
+	testNodeAvailableAttachmentCount   = 8
+	testNodeNoAvailableAttachmentCount = 0
 
 	testVolumeAttachment = storagev1.VolumeAttachment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -750,4 +754,10 @@ func mockClients(mockClient *mockclient.MockClient, azVolumeClient azdisk.Interf
 			return nil
 		}).
 		AnyTimes()
+}
+
+func addTestNodeInAvailableAttachmentsMap(sharedState *SharedState, nodeName string, capacity int) {
+	var count atomic.Int32
+	count.Store(int32(capacity))
+	sharedState.availableAttachmentsMap.Store(nodeName, &count)
 }

--- a/pkg/controller/node_availability_test.go
+++ b/pkg/controller/node_availability_test.go
@@ -81,6 +81,7 @@ func TestNodeAvailabilityController(t *testing.T) {
 					newPod,
 				)
 
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testSchedulableNode1.Name, testNodeAvailableAttachmentCount)
 				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 				controller.priorityReplicaRequestsQueue.Push(context.TODO(), &ReplicaRequest{VolumeName: testPersistentVolume0Name, Priority: 1})
 

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -79,6 +79,8 @@ func TestPodReconcile(t *testing.T) {
 					&testNode0,
 				)
 
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode0.Name, testNodeAvailableAttachmentCount)
+
 				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 				return controller
 			},
@@ -122,6 +124,9 @@ func TestPodReconcile(t *testing.T) {
 					&testNode1,
 					&testPersistentVolume0,
 					newPod)
+
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode0.Name, testNodeAvailableAttachmentCount)
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode1.Name, testNodeAvailableAttachmentCount)
 
 				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 				return controller
@@ -177,6 +182,10 @@ func TestPodReconcile(t *testing.T) {
 					&testNode1,
 					&testNode2,
 					newPod)
+
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode0.Name, testNodeAvailableAttachmentCount)
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode1.Name, testNodeAvailableAttachmentCount)
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode2.Name, testNodeAvailableAttachmentCount)
 
 				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 				return controller
@@ -239,6 +248,10 @@ func TestPodReconcile(t *testing.T) {
 					&testNode2,
 					newPod0,
 					newPod1)
+
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode0.Name, testNodeAvailableAttachmentCount)
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode1.Name, testNodeAvailableAttachmentCount)
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode2.Name, testNodeAvailableAttachmentCount)
 
 				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 				result, err := controller.Reconcile(context.TODO(), testPod0Request)
@@ -374,6 +387,9 @@ func TestPodRecover(t *testing.T) {
 					newAttachment0,
 					newAttachment1,
 					newPod)
+
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode0.Name, testNodeAvailableAttachmentCount)
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode1.Name, testNodeAvailableAttachmentCount)
 
 				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 				return controller

--- a/pkg/controller/replica_test.go
+++ b/pkg/controller/replica_test.go
@@ -86,6 +86,9 @@ func TestReplicaReconcile(t *testing.T) {
 					&testPod0,
 					&replicaAttachment)
 
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode0.Name, testNodeAvailableAttachmentCount)
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode1.Name, testNodeAvailableAttachmentCount)
+
 				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 				return controller
 			},
@@ -138,6 +141,9 @@ func TestReplicaReconcile(t *testing.T) {
 					&testPod0,
 					&replicaAttachment)
 
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode0.Name, testNodeAvailableAttachmentCount)
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode1.Name, testNodeAvailableAttachmentCount)
+
 				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 				return controller
 			},
@@ -174,6 +180,9 @@ func TestReplicaReconcile(t *testing.T) {
 					&testNode0,
 					&testNode1,
 					&testReplicaAzVolumeAttachment)
+
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode0.Name, testNodeAvailableAttachmentCount)
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode1.Name, testNodeAvailableAttachmentCount)
 
 				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 				return controller
@@ -219,6 +228,9 @@ func TestReplicaReconcile(t *testing.T) {
 					&testNode1,
 					&testPod0,
 					replicaAttachment)
+
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode0.Name, testNodeAvailableAttachmentCount)
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode1.Name, testNodeAvailableAttachmentCount)
 
 				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 				return controller
@@ -277,6 +289,9 @@ func TestReplicaReconcile(t *testing.T) {
 					&testPod0,
 					replicaAttachment)
 
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode0.Name, testNodeAvailableAttachmentCount)
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode1.Name, testNodeAvailableAttachmentCount)
+
 				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 				return controller
 			},
@@ -318,6 +333,9 @@ func TestReplicaReconcile(t *testing.T) {
 					&testNode0,
 					&testNode1,
 					&testReplicaAzVolumeAttachment)
+
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode0.Name, testNodeAvailableAttachmentCount)
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode1.Name, testNodeAvailableAttachmentCount)
 
 				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 				return controller
@@ -374,6 +392,9 @@ func TestReplicaReconcile(t *testing.T) {
 					&testNode1,
 					&testPod0,
 					replicaAttachment)
+
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode0.Name, testNodeAvailableAttachmentCount)
+				addTestNodeInAvailableAttachmentsMap(controller.SharedState, testNode1.Name, testNodeAvailableAttachmentCount)
 
 				mockClients(controller.cachedClient.(*mockclient.MockClient), controller.azClient, controller.kubeClient)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Passed tests:**

(node's max attachment count is 8. disk MaxShares = 2)
2 nodes, 8 disks
3 nodes, 11 disks
20 nodes, 20 disks
30 nodes, 30 disks


**How I verified:**

$kubectl get azvolumeattachment -A | grep Replica and 
$kubectl get azvolumeattachment -A | grep Primary 
can print out correct azvolumeattachments

**Release note**:
```
none
```
