### PR TITLE
[V2] fix: handle pre-provisioned volume deletion at the right time

### DIFF
--- a/pkg/azureutils/azure_disk_utils.go
+++ b/pkg/azureutils/azure_disk_utils.go
@@ -1129,7 +1129,9 @@ func UpdateCRIWithRetry(ctx context.Context, informerFactory azdiskinformers.Sha
 		}
 
 		if err != nil {
-			err = status.Errorf(codes.Internal, "failed to get object: %v", err)
+			if !k8serrors.IsNotFound(err) {
+				err = status.Errorf(codes.Internal, "failed to get object: %v", err)
+			}
 			return err
 		}
 

--- a/pkg/controller/common.go
+++ b/pkg/controller/common.go
@@ -1101,11 +1101,18 @@ func verifyObjectFailedOrDeleted(obj interface{}, objectDeleted bool) (bool, err
 		return true, nil
 	}
 
-	// otherwise, the volume detachment has either failed with error or pending
-	azVolumeAttachmentInstance := obj.(*azdiskv1beta2.AzVolumeAttachment)
-	if azVolumeAttachmentInstance.Status.Error != nil {
-		return false, util.ErrorFromAzError(azVolumeAttachmentInstance.Status.Error)
+	switch target := obj.(type) {
+	case azdiskv1beta2.AzVolumeAttachment:
+		if target.Status.Error != nil {
+			return false, util.ErrorFromAzError(target.Status.Error)
+		}
+	case azdiskv1beta2.AzVolume:
+		// otherwise, the volume detachment has either failed with error or pending
+		if target.Status.Error != nil {
+			return false, util.ErrorFromAzError(target.Status.Error)
+		}
 	}
+
 	return false, nil
 }
 

--- a/pkg/controller/common.go
+++ b/pkg/controller/common.go
@@ -97,6 +97,13 @@ const (
 	cleanUpAttachment
 )
 
+type deleteMode int
+
+const (
+	deleteOnly deleteMode = iota
+	deleteAndWait
+)
+
 type updateMode int
 
 const (

--- a/pkg/controller/common_test.go
+++ b/pkg/controller/common_test.go
@@ -333,6 +333,7 @@ func createTestAzVolume(pvName string, maxMountReplicaCount int) azdiskv1beta2.A
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pvName,
 			Namespace: testNamespace,
+			Labels:    map[string]string{consts.PvNameLabel: pvName},
 		},
 		Spec: azdiskv1beta2.AzVolumeSpec{
 			VolumeName: pvName,
@@ -744,6 +745,13 @@ func mockClients(mockClient *mockclient.MockClient, azVolumeClient azdisk.Interf
 				}
 
 				azVolumeAttachments.DeepCopyInto(target)
+			case *azdiskv1beta2.AzVolumeList:
+				azVolumes, err := azVolumeClient.DiskV1beta2().AzVolumes(testNamespace).List(ctx, *options.AsListOptions())
+				if err != nil {
+					return err
+				}
+
+				azVolumes.DeepCopyInto(target)
 			case *azdiskv1beta2.AzDriverNodeList:
 				azDriverNodes, err := azVolumeClient.DiskV1beta2().AzDriverNodes(testNamespace).List(ctx, *options.AsListOptions())
 				if err != nil {

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -71,7 +71,7 @@ func (r *ReconcileNode) Reconcile(ctx context.Context, request reconcile.Request
 		r.deleteNodeFromAvailableAttachmentsMap(ctx, request.Name)
 
 		// Delete all volumeAttachments attached to this node, if failed, requeue
-		if _, err = r.cleanUpAzVolumeAttachmentByNode(ctx, request.Name, azdrivernode, azureutils.AllRoles, cleanUpAttachment); err != nil {
+		if _, err = r.cleanUpAzVolumeAttachmentByNode(ctx, request.Name, azdrivernode, azureutils.AllRoles, cleanUpAttachment, deleteOnly); err != nil {
 			return reconcile.Result{Requeue: true}, err
 		}
 		return reconcile.Result{}, nil

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -93,8 +93,8 @@ func TestPodReconcile(t *testing.T) {
 				require.NotNil(t, azVolume)
 
 				// check the azVolume's pv and pvc labels are not added
-				require.NotContains(t, azVolume.Labels, consts.PvNameKey)
-				require.NotContains(t, azVolume.Labels, consts.PvcNameKey)
+				require.NotContains(t, azVolume.Labels, consts.PvNameLabel)
+				require.NotContains(t, azVolume.Labels, consts.PvcNameLabel)
 
 				// check the azVolume is annotated with inlineVolumeAnnotation
 				require.Contains(t, azVolume.Status.Annotations, consts.InlineVolumeAnnotation)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
* Current PV controller issues a delete request for `AzVolume` CRI upon seeing a deletionTimestamp for `PV` but this can be problematic when user issues `ControllerUnpublishVolume` after marking the preprovisioned PV with a deletion timestamp, as 
`AzVolume` may no longer be able to be found in cluster when trying to unpublish the volume, ultimately resulting in detach failures.
* Also, when deleting `AzVolume` for pre-provisioned volume, `PV controller` needs to be able to retrigger a failed deletion.
* The PR addresses these issue.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
