### PR TITLE
fix: volume metrics on Windows csi-proxy v1beta

### DIFF
--- a/pkg/mounter/safe_mounter_v1beta_windows.go
+++ b/pkg/mounter/safe_mounter_v1beta_windows.go
@@ -335,10 +335,12 @@ func (mounter *csiProxyMounterV1Beta) GetVolumeStats(ctx context.Context, path s
 	if err != nil || resp == nil {
 		return nil, fmt.Errorf("GetVolumeStats(%s) failed with error: %v, response: %v", volIDResp.VolumeId, err, resp)
 	}
+	// in v1beta interface, VolumeSize is actually availableSize
+	availableSize := resp.VolumeSize
 	volUsage := &csi.VolumeUsage{
 		Unit:      csi.VolumeUsage_BYTES,
-		Available: resp.VolumeSize - resp.VolumeUsedSize,
-		Total:     resp.VolumeSize,
+		Available: availableSize,
+		Total:     availableSize + resp.VolumeUsedSize,
 		Used:      resp.VolumeUsedSize,
 	}
 	return volUsage, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: volume metrics on Windows csi-proxy v1beta

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

 - correct `NodeGetVolumeStats` response
```
I1128 13:06:41.438471    6376 utils.go:77] GRPC call: /csi.v1.Node/NodeGetVolumeStats
I1128 13:06:41.438998    6376 utils.go:78] GRPC request: {"volume_id":"/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/kubetest-5zrwevie/providers/Microsoft.Compute/disks/pvc-b7977a80-d0b0-4b7a-bf70-10e16ae07123","volume_path":"c:\\var\\lib\\kubelet\\pods\\e94d925a-9045-4fe8-a834-d7403a5dade2\\volumes\\kubernetes.io~csi\\pvc-b7977a80-d0b0-4b7a-bf70-10e16ae07123\\mount"}
I1128 13:06:41.982617    6376 safe_mounter_v1beta_windows.go:333] GetVolumeStats(c:\var\lib\kubelet\pods\e94d925a-9045-4fe8-a834-d7403a5dade2\volumes\kubernetes.io~csi\pvc-b7977a80-d0b0-4b7a-bf70-10e16ae07123\mount) returned volumeID(\\?\Volume{2e73efca-0000-0000-0000-100000000000}\)
I1128 13:06:44.452604    6376 utils.go:84] GRPC response: {"usage":[{"available":10692947968,"total":10735316992,"unit":1,"used":42369024}]}
```

<details>

```
// https://github.com/kubernetes-csi/csi-proxy/blob/v0.2.2/internal/os/volume/api.go#L157-L180
// VolumeStats - retrieves the volume stats for a given volume
func (VolAPIImplementor) VolumeStats(volumeID string) (int64, int64, error) {
        // get the size and sizeRemaining for the volume
        cmd := fmt.Sprintf("(Get-Volume -UniqueId \"%s\" | Select SizeRemaining,Size) | ConvertTo-Json", volumeID)
        out, err := runExec(cmd)

        if err != nil {
                return -1, -1, fmt.Errorf("error getting capacity and used size of volume. cmd: %s, output: %s, error: %v", cmd, string(out), err)
        }

        var getVolume map[string]int64
        outString := string(out)
        err = json.Unmarshal([]byte(outString), &getVolume)
        if err != nil {
                return -1, -1, fmt.Errorf("out %v outstring %v err %v", out, outString, err)
        }
        var volumeSizeRemaining int64
        var volumeSize int64

        volumeSize = getVolume["Size"]
        volumeSizeRemaining = getVolume["SizeRemaining"]

        volumeUsedSize := volumeSize - volumeSizeRemaining
        return volumeSizeRemaining, volumeUsedSize, nil
}

// https://github.com/kubernetes-csi/csi-proxy/blob/v0.2.2/internal/server/volume/server.go#L195
func (s *Server) VolumeStats(context context.Context, request *internal.VolumeStatsRequest, version apiversion.Version) (*internal.VolumeStatsResponse, error) {
        klog.V(4).Infof("calling VolumeStats with request: %+v", request)
        minimumVersion := apiversion.NewVersionOrPanic("v1beta1")
        if version.Compare(minimumVersion) < 0 {
                return nil, fmt.Errorf("VolumeStats requires CSI-Proxy API version v1beta1 or greater")
        }

        volumeId := request.VolumeId
        if volumeId == "" {
                return nil, fmt.Errorf("volume id empty")
        }

        capacity, used, err := s.hostAPI.VolumeStats(request.VolumeId)

        if err != nil {
                klog.Errorf("failed VolumeStats %v", err)
                return nil, err
        }

        klog.V(5).Infof("VolumeStats: returned: Capacity %v Used %v", capacity, used)

        response := &internal.VolumeStatsResponse{
                VolumeSize:     capacity,
                VolumeUsedSize: used,
        }

        return response, nil
}

https://github.com/kubernetes-csi/csi-proxy/blob/v1.0.0/pkg/os/volume/api.go
// GetVolumeStats - retrieves the volume stats for a given volume
func (VolumeAPI) GetVolumeStats(volumeID string) (int64, int64, error) {
	// get the size and sizeRemaining for the volume
	cmd := fmt.Sprintf("(Get-Volume -UniqueId \"%s\" | Select SizeRemaining,Size) | ConvertTo-Json", volumeID)
	out, err := runExec(cmd)

	if err != nil {
		return -1, -1, fmt.Errorf("error getting capacity and used size of volume. cmd: %s, output: %s, error: %v", cmd, string(out), err)
	}

	var getVolume map[string]int64
	outString := string(out)
	err = json.Unmarshal([]byte(outString), &getVolume)
	if err != nil {
		return -1, -1, fmt.Errorf("out %v outstring %v err %v", out, outString, err)
	}
	var volumeSizeRemaining int64
	var volumeSize int64

	volumeSize = getVolume["Size"]
	volumeSizeRemaining = getVolume["SizeRemaining"]

	volumeUsedSize := volumeSize - volumeSizeRemaining
	return volumeSize, volumeUsedSize, nil
}

https://github.com/kubernetes-csi/csi-proxy/blob/v1.0.0/pkg/server/volume/server.go#L184-L187
func (s *Server) GetVolumeStats(context context.Context, request *internal.GetVolumeStatsRequest, version apiversion.Version) (*internal.GetVolumeStatsResponse, error) {
	klog.V(2).Infof("GetVolumeStats: Request: %+v", request)
	volumeID := request.VolumeId
	if volumeID == "" {
		return nil, fmt.Errorf("volume id empty")
	}

	totalBytes, usedBytes, err := s.hostAPI.GetVolumeStats(volumeID)
	if err != nil {
		klog.Errorf("failed GetVolumeStats %v", err)
		return nil, err
	}

	klog.V(2).Infof("VolumeStats: returned: Capacity %v Used %v", totalBytes, usedBytes)

	response := &internal.GetVolumeStatsResponse{
		TotalBytes: totalBytes,
		UsedBytes:  usedBytes,
	}

	return response, nil
}
```

</details>

**Release note**:
```
fix: volume metrics on Windows csi-proxy v1beta
```
