### PR TITLE
[V2] fix: clear status error and detail in AzVolumeAttachment recovery if in in Attaching state 🐞

### DIFF
--- a/pkg/controller/attach_detach.go
+++ b/pkg/controller/attach_detach.go
@@ -765,6 +765,16 @@ func (r *ReconcileAttachDetach) recoverAzVolumeAttachment(ctx context.Context, r
 			case azdiskv1beta2.Attaching:
 				// reset state to Pending so Attach operation can be redone
 				targetState = azdiskv1beta2.AttachmentPending
+				innerUpdateFunc := updateFunc
+				updateFunc = func(obj client.Object) error {
+					if err := innerUpdateFunc(obj); err != nil {
+						return err
+					}
+					azv := obj.(*azdiskv1beta2.AzVolumeAttachment)
+					azv.Status.Detail = nil
+					azv.Status.Error = nil
+					return nil
+				}
 			case azdiskv1beta2.Detaching:
 				// reset state to Attached so Detach operation can be redone
 				targetState = azdiskv1beta2.Attached

--- a/pkg/controller/attach_detach_test.go
+++ b/pkg/controller/attach_detach_test.go
@@ -394,6 +394,8 @@ func TestAttachDetachRecover(t *testing.T) {
 			setupFunc: func(t *testing.T, mockCtl *gomock.Controller) *ReconcileAttachDetach {
 				newAzVolumeAttachment0 := testPrimaryAzVolumeAttachment0.DeepCopy()
 				newAzVolumeAttachment0.Status.State = azdiskv1beta2.Attaching
+				newAzVolumeAttachment0.Status.Detail = &azdiskv1beta2.AzVolumeAttachmentStatusDetail{}
+				newAzVolumeAttachment0.Status.Error = &azdiskv1beta2.AzError{}
 
 				newAzVolumeAttachment1 := testPrimaryAzVolumeAttachment1.DeepCopy()
 				newAzVolumeAttachment1.Status.State = azdiskv1beta2.Detaching
@@ -414,6 +416,8 @@ func TestAttachDetachRecover(t *testing.T) {
 				azVolumeAttachment, localErr := controller.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).Get(context.TODO(), testPrimaryAzVolumeAttachment0Name, metav1.GetOptions{})
 				require.NoError(t, localErr)
 				require.Equal(t, azVolumeAttachment.Status.State, azdiskv1beta2.AttachmentPending)
+				require.Nil(t, azVolumeAttachment.Status.Detail)
+				require.Nil(t, azVolumeAttachment.Status.Error)
 				require.Contains(t, azVolumeAttachment.Status.Annotations, consts.RecoverAnnotation)
 
 				azVolumeAttachment, localErr = controller.azClient.DiskV1beta2().AzVolumeAttachments(testNamespace).Get(context.TODO(), testPrimaryAzVolumeAttachment1Name, metav1.GetOptions{})


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
This PR fixes an issue in 1AzVolumeAttachment1 recovery. If the 1AzVolumeAttachment1 is in the `Attaching` state when the driver crashes, we recover the state by setting the status to `AttachmentPending`, as we do not know where in the `Attaching` state the controller was in when it crashed.

However, the code is checking if `azVolumeAttachment.Status.Detail` is `nil` prior to calling `triggerAttach`. Setting the `Status.Detail` and `Status.Error` to `nil` will ensure that the driver completes the attachment upon recovery. 

This issue was exposed because we are seeing driver OOM issues.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
