### PR TITLE
[V2] feat: fetch VMs to recover AzVolumeAttachment 

### DIFF
--- a/pkg/azureconstants/azure_constants.go
+++ b/pkg/azureconstants/azure_constants.go
@@ -131,7 +131,7 @@ const (
 	PodNameKey                         = "disk.csi/azure.com/pod-name"
 	PreProvisionedVolumeAnnotation     = "disk.csi.azure.com/pre-provisioned"
 	RequestIDKey                       = "disk.csi.azure.com/request-id"
-	RequestStartimeKey                 = "disk.csi.azure.com/request-starttime"
+	RequestStartTimeKey                = "disk.csi.azure.com/request-starttime"
 	RequestTimeFormat                  = time.RFC3339Nano
 	RequesterKey                       = "disk.csi.azure.com/requester-name"
 	WorkflowKey                        = "disk.csi.azure.com/requester-name"

--- a/pkg/azureutils/azure_disk_utils.go
+++ b/pkg/azureutils/azure_disk_utils.go
@@ -1219,7 +1219,7 @@ func UpdateCRIWithRetry(ctx context.Context, informerFactory azdiskinformers.Sha
 			curRetry++
 			return true
 		}
-		if isNetError(err) {
+		if IsNetError(err) {
 			defer func() { curNetRetry++ }()
 			return curNetRetry < maxNetRetry
 		}
@@ -1238,7 +1238,7 @@ func UpdateCRIWithRetry(ctx context.Context, informerFactory azdiskinformers.Sha
 	)
 
 	// if encountered net error from api server unavailability, exit process
-	if isNetError(err) {
+	if IsNetError(err) {
 		ExitOnNetError(err, maxNetRetry > 0 && curNetRetry >= maxNetRetry)
 	}
 	return updatedObj, err
@@ -1339,10 +1339,10 @@ func isFatalNetError(err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return false
 	}
-	return isNetError(err)
+	return IsNetError(err)
 }
 
-func isNetError(err error) bool {
+func IsNetError(err error) bool {
 	return net.IsConnectionRefused(err) || net.IsConnectionReset(err) || net.IsTimeout(err) || net.IsProbableEOF(err)
 }
 

--- a/pkg/controller/common.go
+++ b/pkg/controller/common.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
 	azdiskv1beta2 "sigs.k8s.io/azuredisk-csi-driver/pkg/apis/azuredisk/v1beta2"
@@ -134,6 +135,9 @@ type CloudProvisioner interface {
 	DeleteVolume(ctx context.Context, volumeID string, secrets map[string]string) error
 	PublishVolume(ctx context.Context, volumeID string, nodeID string, volumeContext map[string]string) provisioner.CloudAttachResult
 	UnpublishVolume(ctx context.Context, volumeID string, nodeID string) error
+	GetNodeNameByProviderID(providerID string) (types.NodeName, error)
+	GetNodeDataDisks(nodeName types.NodeName) ([]compute.DataDisk, *string, error)
+	GetDiskLun(diskName, diskURI string, nodeName types.NodeName) (int32, *string, error)
 	ExpandVolume(ctx context.Context, volumeID string, capacityRange *azdiskv1beta2.CapacityRange, secrets map[string]string) (*azdiskv1beta2.AzVolumeStatusDetail, error)
 	ListVolumes(ctx context.Context, maxEntries int32, startingToken string) (*azdiskv1beta2.ListVolumesResult, error)
 	CreateSnapshot(ctx context.Context, sourceVolumeID string, snapshotName string, secrets map[string]string, parameters map[string]string) (*azdiskv1beta2.Snapshot, error)

--- a/pkg/controller/common_test.go
+++ b/pkg/controller/common_test.go
@@ -166,6 +166,7 @@ var (
 
 	testPrimaryAzVolumeAttachment0Name = azureutils.GetAzVolumeAttachmentName(testPersistentVolume0Name, testNode0Name)
 	testPrimaryAzVolumeAttachment1Name = azureutils.GetAzVolumeAttachmentName(testPersistentVolume1Name, testNode0Name)
+	testPrimaryAzVolumeAttachment2Name = azureutils.GetAzVolumeAttachmentName(testPersistentVolume2Name, testNode2Name)
 
 	testPrimaryAzVolumeAttachment0 = createTestAzVolumeAttachment(testPersistentVolume0Name, testNode0Name, azdiskv1beta2.PrimaryRole)
 
@@ -174,6 +175,8 @@ var (
 	testPrimaryAzVolumeAttachment1 = createTestAzVolumeAttachment(testPersistentVolume1Name, testNode0Name, azdiskv1beta2.PrimaryRole)
 
 	testPrimaryAzVolumeAttachment1Request = createReconcileRequest(testNamespace, testPrimaryAzVolumeAttachment1Name)
+
+	testPrimaryAzVolumeAttachment2 = createTestAzVolumeAttachment(testPersistentVolume2Name, testNode2Name, azdiskv1beta2.PrimaryRole)
 
 	testReplicaAzVolumeAttachmentName = azureutils.GetAzVolumeAttachmentName(testPersistentVolume0Name, testNode1Name)
 

--- a/pkg/controller/mockattachmentprovisioner/interface.go
+++ b/pkg/controller/mockattachmentprovisioner/interface.go
@@ -22,7 +22,9 @@ package mockattachmentprovisioner
 
 import (
 	context "context"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	gomock "github.com/golang/mock/gomock"
+	"k8s.io/apimachinery/pkg/types"
 	reflect "reflect"
 	azureconstants "sigs.k8s.io/azuredisk-csi-driver/pkg/azureconstants"
 	provisioner "sigs.k8s.io/azuredisk-csi-driver/pkg/provisioner"
@@ -77,6 +79,68 @@ func (m *MockCloudDiskAttachDetacher) UnpublishVolume(ctx context.Context, volum
 func (mr *MockCloudDiskAttachDetacherMockRecorder) UnpublishVolume(ctx, volumeID, nodeID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnpublishVolume", reflect.TypeOf((*MockCloudDiskAttachDetacher)(nil).UnpublishVolume), ctx, volumeID, nodeID)
+}
+
+// GetNodeDataDisks mocks base method
+func (m *MockCloudDiskAttachDetacher) GetNodeDataDisks(nodeName types.NodeName) ([]compute.DataDisk, *string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodeDataDisks", nodeName)
+	ret0, _ := ret[0].([]compute.DataDisk)
+	ret1, _ := ret[1].(*string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetNodeDataDisks indicates an expected call of GetNodeDataDisks
+func (mr *MockCloudDiskAttachDetacherMockRecorder) GetNodeDataDisks(nodeName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeDataDisks", reflect.TypeOf((*MockCloudDiskAttachDetacher)(nil).GetNodeDataDisks), nodeName)
+}
+
+// GetDiskLun mocks base method
+func (m *MockCloudDiskAttachDetacher) GetDiskLun(diskName, diskURI string, nodeName types.NodeName) (int32, *string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDiskLun", diskName, diskURI, nodeName)
+	ret0, _ := ret[0].(int32)
+	ret1, _ := ret[1].(*string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetDiskLun indicates an expected call of GetDiskLun
+func (mr *MockCloudDiskAttachDetacherMockRecorder) GetDiskLun(diskName, diskURI, nodeName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDiskLun", reflect.TypeOf((*MockCloudDiskAttachDetacher)(nil).GetDiskLun), diskName, diskURI, nodeName)
+}
+
+// CheckDiskExists mocks base method
+func (m *MockCloudDiskAttachDetacher) CheckDiskExists(ctx context.Context, diskURI string) (*compute.Disk, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckDiskExists", ctx, diskURI)
+	ret0, _ := ret[0].(*compute.Disk)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckDiskExists indicates an expected call of CheckDiskExists
+func (mr *MockCloudDiskAttachDetacherMockRecorder) CheckDiskExists(ctx, diskURI interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDiskExists", reflect.TypeOf((*MockCloudDiskAttachDetacher)(nil).CheckDiskExists), ctx, diskURI)
+}
+
+// GetNodeNameByProviderID mocks base method
+func (m *MockCloudDiskAttachDetacher) GetNodeNameByProviderID(providerID string) (types.NodeName, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodeNameByProviderID", providerID)
+	ret0, _ := ret[0].(types.NodeName)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckDiskExists indicates an expected call of GetNodeNameByProviderID
+func (mr *MockCloudDiskAttachDetacherMockRecorder) GetNodeNameByProviderID(providerID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeNameByProviderID", reflect.TypeOf((*MockCloudDiskAttachDetacher)(nil).GetNodeNameByProviderID), providerID)
 }
 
 // MockCrdDetacher is a mock of CrdDetacher interface

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -164,6 +164,7 @@ func (r *ReconcilePod) Recover(ctx context.Context) error {
 			w.Logger().V(5).Infof("failed to add necessary components for pod (%s)", podKey)
 			continue
 		}
+		// For cases like: upgrading driver V1 to V2, createReplicas() is needed here since V1 doesn't have any replica attachment.
 		if err := r.createReplicas(ctx, podKey); err != nil {
 			w.Logger().V(5).Infof("failed to create replica AzVolumeAttachments for pod (%s)", podKey)
 		}

--- a/pkg/provisioner/cloudprovisioner.go
+++ b/pkg/provisioner/cloudprovisioner.go
@@ -400,7 +400,7 @@ func (c *CloudProvisioner) PublishVolume(
 
 	var lun int32
 	var vmState *string
-	lun, vmState, err = c.cloud.GetDiskLun(diskName, volumeID, nodeName)
+	lun, vmState, err = c.GetDiskLun(diskName, volumeID, nodeName)
 	if err == cloudprovider.InstanceNotFound {
 		err = status.Errorf(codes.NotFound, "failed to get azure instance id for node %q: %v", nodeName, err)
 		return
@@ -463,7 +463,7 @@ func (c *CloudProvisioner) PublishVolume(
 		}
 	}
 
-	publishContext := map[string]string{"LUN": strconv.Itoa(int(lun))}
+	publishContext := map[string]string{azureconstants.LUN: strconv.Itoa(int(lun))}
 	attachResult.SetPublishContext(publishContext)
 	return
 }
@@ -877,6 +877,18 @@ func (c *CloudProvisioner) GetSnapshotAndResourceNameFromSnapshotID(snapshotID s
 	}
 
 	return snapshotName, resourceGroup, err
+}
+
+func (c *CloudProvisioner) GetNodeNameByProviderID(providerID string) (types.NodeName, error) {
+	return c.cloud.VMSet.GetNodeNameByProviderID(providerID)
+}
+
+func (c *CloudProvisioner) GetNodeDataDisks(nodeName types.NodeName) ([]compute.DataDisk, *string, error) {
+	return c.cloud.GetNodeDataDisks(nodeName, azcache.CacheReadTypeDefault)
+}
+
+func (c *CloudProvisioner) GetDiskLun(diskName, diskURI string, nodeName types.NodeName) (int32, *string, error) {
+	return c.cloud.GetDiskLun(diskName, diskURI, nodeName)
 }
 
 func (c *CloudProvisioner) getSnapshotByID(ctx context.Context, resourceGroup string, snapshotName string, sourceVolumeID string) (*azdiskv1beta2.Snapshot, error) {

--- a/pkg/provisioner/crdprovisioner.go
+++ b/pkg/provisioner/crdprovisioner.go
@@ -289,7 +289,7 @@ func (c *CrdProvisioner) CreateVolume(
 				Name:        azVolumeName,
 				Finalizers:  []string{consts.AzVolumeFinalizer},
 				Labels:      map[string]string{consts.PvNameLabel: pv, consts.PvcNameLabel: pvc, consts.PvcNamespaceLabel: namespace},
-				Annotations: map[string]string{consts.RequestIDKey: w.RequestID(), consts.RequestStartimeKey: w.StartTime().Format(consts.RequestTimeFormat)},
+				Annotations: map[string]string{consts.RequestIDKey: w.RequestID(), consts.RequestStartTimeKey: w.StartTime().Format(consts.RequestTimeFormat)},
 			},
 			Spec: azdiskv1beta2.AzVolumeSpec{
 				MaxMountReplicaCount:      maxMountReplicaCount,
@@ -531,7 +531,7 @@ func (c *CrdProvisioner) PublishVolume(
 				Annotations: map[string]string{
 					consts.VolumeAttachRequestAnnotation: "crdProvisioner",
 					consts.RequestIDKey:                  w.RequestID(),
-					consts.RequestStartimeKey:            w.StartTime().Format(consts.RequestTimeFormat),
+					consts.RequestStartTimeKey:           w.StartTime().Format(consts.RequestTimeFormat),
 				},
 			},
 			Spec: azdiskv1beta2.AzVolumeAttachmentSpec{

--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -54,7 +54,7 @@ func GetWorkflowFromObj(ctx context.Context, obj k8sRuntime.Object, opts ...Opti
 	w := Workflow{}.applyDefault()
 
 	w.requestID = GetRequestID(obj)
-	startTimeStr := getAnnotationFromRuntimeObject(obj, consts.RequestStartimeKey)
+	startTimeStr := getAnnotationFromRuntimeObject(obj, consts.RequestStartTimeKey)
 	if startTimeStr != "" {
 		w.startTime, _ = time.Parse(consts.RequestTimeFormat, startTimeStr)
 	}
@@ -177,7 +177,7 @@ func (w Workflow) AnnotateObject(obj k8sRuntime.Object) {
 	}
 	annotations[consts.RequesterKey] = w.name
 	annotations[consts.RequestIDKey] = w.requestID
-	annotations[consts.RequestStartimeKey] = w.startTime.Format(consts.RequestTimeFormat)
+	annotations[consts.RequestStartTimeKey] = w.startTime.Format(consts.RequestTimeFormat)
 	meta.SetAnnotations(annotations)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**


/kind bug


**What this PR does / why we need it**:

Without this change, only Primary role can be recreated and the Status.State and Status.Detail are missing. This change ensures that both Primary and Replica role can be recreated and if they are attached their Status.state can be recovered to "Attached". And the Status.Detail can be recover.


This change will do 3 steps to Recover AzVolumeAttachment:

1, recreate AzVolumeAttachments with Primary role from VolumeAttachemnts

2, recreate AzVolumeAttachments with Replica role from VMs

3, recover the  AzVolumeAttachments.Status.State and AzVolumeAttachments.Status.Detail



**How to test it?**
1, install driver 
2, create AzVolumeAttachments with Primary role and Replica role
3, update cleanUpAzVolumeAttachments() so when uninstall driver the replica role won't be detached
4, uninstall driver
5, install driver
6, it can recover AzVolumeAttachments with Primary role and Replica role. And both of their States are "Attached". And both of them have Status.Detail.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1648

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [x] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
