### PR TITLE
[V2] fix: changing scheduler name logic to install method

### DIFF
--- a/test/podFailover/workload/chart/templates/workload.yaml
+++ b/test/podFailover/workload/chart/templates/workload.yaml
@@ -97,7 +97,7 @@ spec:
         app: pod-failover
         failureType: {{ .Values.failureType }}
     spec:
-      {{- if and (ne .Values.clusterProvisioner "aks-cli") .Values.schedulerName }}
+      {{- if and (eq .Values.installMethod "helm") .Values.schedulerName }}
       schedulerName: {{ .Values.schedulerName }}
       {{- end}}
       {{- if eq .Values.failureType "same-node-failover"}}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
- using scheduler name based on install method, not cluster provisioner
