### PR TITLE
[V2] fix: prevent requesting replica attachment in a row for one volume

### DIFF
--- a/pkg/controller/common.go
+++ b/pkg/controller/common.go
@@ -246,8 +246,9 @@ func newLockableEntry(entry interface{}) *lockableEntry {
 	}
 }
 
+// Return true for all errors unless the operation is replica garbage collection that had been aborted due to context cancellation
 func shouldRequeueReplicaOperation(isReplicaGarbageCollection bool, err error) bool {
-	return !isReplicaGarbageCollection || !errors.Is(err, context.Canceled)
+	return err != nil && !(isReplicaGarbageCollection && errors.Is(err, context.Canceled))
 }
 
 type filterPlugin interface {

--- a/pkg/controller/shared_state.go
+++ b/pkg/controller/shared_state.go
@@ -220,12 +220,10 @@ func (c *SharedState) addToOperationQueue(ctx context.Context, volumeName string
 					lockable.Unlock()
 					err := operation.operationFunc(operation.ctx)
 					lockable.Lock()
-					if err != nil {
-						if shouldRequeueReplicaOperation(operation.isReplicaGarbageCollection, err) {
-							// if failed, push it to the end of the queue
-							if operationQueue.isActive {
-								operationQueue.PushBack(operation)
-							}
+					if shouldRequeueReplicaOperation(operation.isReplicaGarbageCollection, err) {
+						// if operation failed, push it to the end of the queue
+						if operationQueue.isActive {
+							operationQueue.PushBack(operation)
 						}
 					}
 				}
@@ -1121,7 +1119,6 @@ func (c *SharedState) cleanUpAzVolumeAttachmentByNode(ctx context.Context, azDri
 
 	for volumeName, cleanUps := range cleanUpMap {
 		volumeName := volumeName
-		defer w.Finish(nil)
 		c.addToOperationQueue(ctx,
 			volumeName,
 			caller,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
We saw [`manageReplicas`](https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/3f5114357ac4c342eef8fd174d1e0c706edb11d3/pkg/controller/shared_state.go#L1233) is called twice for one volume to create its replica attachment. The root causes are:

1. incorrect logic in [`shouldRequeueReplicaOperation`](https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/3f5114357ac4c342eef8fd174d1e0c706edb11d3/pkg/controller/common.go#L249) to return `true` so that the replica operation is added to queue again.
2. When the replica attachment failed with non-retriable error, the CRI will be deleted and open another [goroutine](https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/3f5114357ac4c342eef8fd174d1e0c706edb11d3/pkg/controller/replica.go#L117) to trigger replica management. The update of adding deletion timestamp to the CRI in main goroutine will trigger another reconciliation of replica controller. If the CRI with deletion timestamp still exists in the cache client, it will fall into the same case and trigger replica management the second time.

This PR also fixes a workflow issue that we call an additional `w.Finish()` and it causes [panic](https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/3f5114357ac4c342eef8fd174d1e0c706edb11d3/pkg/workflow/workflow.go#L142).

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
