### PR TITLE
fix: second expand volume failure on Ubuntu 22.04

### DIFF
--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -481,8 +481,10 @@ func (d *Driver) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolume
 		}
 	}
 
+	var retErr error
 	if err := resizeVolume(devicePath, volumePath, d.mounter); err != nil {
-		return nil, status.Errorf(codes.Internal, "could not resize volume %q (%q):  %v", volumeID, devicePath, err)
+		retErr = status.Errorf(codes.Internal, "could not resize volume %q (%q):  %v", volumeID, devicePath, err)
+		klog.Errorf("%v, will continue checking whether the volume has been resized", retErr)
 	}
 
 	gotBlockSizeBytes, err := getBlockSizeBytes(devicePath, d.mounter)
@@ -491,9 +493,13 @@ func (d *Driver) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolume
 	}
 	gotBlockGiB := volumehelper.RoundUpGiB(gotBlockSizeBytes)
 	if gotBlockGiB < requestGiB {
+		if retErr != nil {
+			return nil, retErr
+		}
 		// Because size was rounded up, getting more size than requested will be a success.
 		return nil, status.Errorf(codes.Internal, "resize requested for %v, but after resizing volume size was %v", requestGiB, gotBlockGiB)
 	}
+
 	klog.V(2).Infof("NodeExpandVolume succeeded on resizing volume %v to %v", volumeID, gotBlockSizeBytes)
 
 	return &csi.NodeExpandVolumeResponse{

--- a/pkg/azuredisk/nodeserver_test.go
+++ b/pkg/azuredisk/nodeserver_test.go
@@ -1140,7 +1140,7 @@ func TestNodeExpandVolume(t *testing.T) {
 			},
 			expectedErr:   resizeErr,
 			skipOnDarwin:  true, // ResizeFs not supported on Darwin
-			outputScripts: []testingexec.FakeAction{findmntAction, blkidAction, resize2fsFailedAction},
+			outputScripts: []testingexec.FakeAction{findmntAction, blkidAction, resize2fsFailedAction, blockdevSizeTooSmallAction},
 		},
 		{
 			desc: "Resize too small failure",

--- a/pkg/azuredisk/nodeserver_v2.go
+++ b/pkg/azuredisk/nodeserver_v2.go
@@ -466,8 +466,10 @@ func (d *DriverV2) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolu
 		}
 	}
 
+	var retErr error
 	if err := resizeVolume(devicePath, volumePath, d.mounter); err != nil {
-		return nil, status.Errorf(codes.Internal, "could not resize volume %q (%q):  %v", volumeID, devicePath, err)
+		retErr = status.Errorf(codes.Internal, "could not resize volume %q (%q):  %v", volumeID, devicePath, err)
+		klog.Errorf("%v, will continue checking whether the volume has been resized", retErr)
 	}
 
 	gotBlockSizeBytes, err := getBlockSizeBytes(devicePath, d.mounter)
@@ -476,6 +478,9 @@ func (d *DriverV2) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolu
 	}
 	gotBlockGiB := volumehelper.RoundUpGiB(gotBlockSizeBytes)
 	if gotBlockGiB < requestGiB {
+		if retErr != nil {
+			return nil, retErr
+		}
 		// Because size was rounded up, getting more size than requested will be a success.
 		return nil, status.Errorf(codes.Internal, "resize requested for %v, but after resizing volume size was %v", requestGiB, gotBlockGiB)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: second expand volume failure on Ubuntu 22.04
This is related to bug: https://bugzilla.redhat.com/show_bug.cgi?id=2128863 on Ubuntu 22.04, second `resize2fs` always failed with following error:
```
  Warning  FailedMount             0s (x5 over 8s)  kubelet                  MountVolume.Setup failed while expanding volume for volume "pvc-8e0170f3-c7f1-413d-909f-5f1c7487f098" : Expander.NodeExpand failed to expand the volume : rpc error: code = Internal desc = could not resize volume "/subscriptions/xxx/resourceGroups/mc_andy-aks125_andy-aks125_eastus2/providers/Microsoft.Compute/disks/pvc-8e0170f3-c7f1-413d-909f-5f1c7487f098" ("/dev/sdc"):  resize of device /dev/sdc failed: exit status 1. resize2fs output: resize2fs 1.46.4 (18-Aug-2021)
resize2fs: Superblock checksum does not match superblock while trying to open /dev/sdc
Couldn't find valid filesystem superblock.
```

When hit `resize2fs` error, this PR would continue check volume size, if it's expected resized size, then return success.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1631

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: second expand volume failure on Ubuntu 22.04
```
