### PR TITLE
[V2] fix: replica AzVolumeAttachment retries return inconsistent error type

### DIFF
--- a/pkg/controller/attach_detach.go
+++ b/pkg/controller/attach_detach.go
@@ -274,11 +274,12 @@ func (r *ReconcileAttachDetach) triggerAttach(ctx context.Context, azVolumeAttac
 
 			updateFunc := func(obj client.Object) error {
 				azva := obj.(*azdiskv1beta2.AzVolumeAttachment)
-				// add retriable annotation if the attach error is PartialUpdateError or timeout
-				if _, ok := attachErr.(*retry.PartialUpdateError); ok || errors.Is(err, context.DeadlineExceeded) {
-					azva.Status.Annotations = azureutils.AddToMap(azva.Status.Annotations, consts.ReplicaVolumeAttachRetryAnnotation, "true")
+				// add retriable annotation if the replica attach error is PartialUpdateError or timeout
+				if azva.Status.Detail.Role == azdiskv1beta2.ReplicaRole {
+					if _, ok := attachErr.(*retry.PartialUpdateError); ok || errors.Is(err, context.DeadlineExceeded) {
+						azva.Status.Annotations = azureutils.AddToMap(azva.Status.Annotations, consts.ReplicaVolumeAttachRetryAnnotation, "true")
+					}
 				}
-
 				_, uerr := reportError(azva, azdiskv1beta2.AttachmentFailed, attachErr)
 				return uerr
 			}

--- a/pkg/controller/replica.go
+++ b/pkg/controller/replica.go
@@ -114,7 +114,8 @@ func (r *ReconcileReplica) Reconcile(ctx context.Context, request reconcile.Requ
 				}
 			} else if azVolumeAttachment.Status.State == azdiskv1beta2.AttachmentFailed {
 				// if the failed attachment isn't retriable, delete the CRI so that replacing replica AzVolumeAttachment can be created
-				if !azureutils.MapContains(azVolumeAttachment.Status.Annotations, consts.ReplicaVolumeAttachRetryAnnotation) {
+				// once the attachment has ever been retriable, it should be retried until it succeeds or gets detached
+				if !azureutils.MapContains(azVolumeAttachment.Status.Annotations, consts.ReplicaVolumeAttachRetryAnnotation) && !azureutils.MapContains(azVolumeAttachment.Status.Annotations, consts.ReplicaVolumeAttachRetryCount) {
 					if err := r.cachedClient.Delete(ctx, azVolumeAttachment); err != nil {
 						return reconcile.Result{Requeue: true}, err
 					}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
When running the scale test with replicas, we saw that cloudprovisioner could return retriable error at the first attempt to create a replica AzVolumeAttachment, and then return not retriable error due to throttling. Under this scenario, the driver will delete the CRI without detach, so we lose the track of that disk attachment that would cause exhausting MaxShares or not being able to delete disks that are still attached to VMs. This PR is to handle inconsistent error types returned during retries.

This PR also fixes that we only add `ReplicaVolumeAttachRetryAnnotation` to replica AzVolumeAttachment.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
