### PR TITLE
[V2] chore: reporting pod failover downtime async

### DIFF
--- a/test/podFailover/workload/cmd/main.go
+++ b/test/podFailover/workload/cmd/main.go
@@ -108,7 +108,7 @@ func main() {
 		}
 	} else {
 		downtime := calculateDowntime(podfailurecrd.Status.HeartBeat)
-		reportDowntime(ctx, clientset, downtime, podfailurecrd.Status.FailureType)
+		go reportDowntime(ctx, clientset, downtime, podfailurecrd.Status.FailureType)
 	}
 
 	if *storageProvisioner != "" {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
- making report pod failover downtime a goroutine
- hoping to increase the chance that pods will report timestamps everytime they come online
