### PR TITLE
feat: add copy snapshot in cross region directly

### DIFF
--- a/deploy/csi-azuredisk-controller.yaml
+++ b/deploy/csi-azuredisk-controller.yaml
@@ -86,6 +86,7 @@ spec:
             - "-leader-election"
             - "--leader-election-namespace=kube-system"
             - "--v=2"
+            - "--timeout=600s"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -43,6 +44,11 @@ import (
 	volumehelper "sigs.k8s.io/azuredisk-csi-driver/pkg/util"
 	"sigs.k8s.io/cloud-provider-azure/pkg/metrics"
 	azure "sigs.k8s.io/cloud-provider-azure/pkg/provider"
+)
+
+const (
+	waitForSnapshotCopyInterval = 5 * time.Second
+	waitForSnapshotCopyTimeout  = 10 * time.Minute
 )
 
 // listVolumeStatus explains the return status of `listVolumesByResourceGroup`
@@ -868,7 +874,7 @@ func (d *Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequ
 			},
 			Incremental: &incremental,
 		},
-		Location: &location,
+		Location: &d.cloud.Location,
 		Tags:     tags,
 	}
 
@@ -879,13 +885,28 @@ func (d *Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequ
 		snapshot.SnapshotProperties.DataAccessAuthMode = compute.DataAccessAuthMode(dataAccessAuthMode)
 	}
 
+	if acquired := d.volumeLocks.TryAcquire(snapshotName); !acquired {
+		return nil, status.Errorf(codes.Aborted, volumeOperationAlreadyExistsFmt, snapshotName)
+	}
+	defer d.volumeLocks.Release(snapshotName)
+
+	var crossRegionSnapshotName string
+	if location != "" && location != d.cloud.Location {
+		if incremental {
+			crossRegionSnapshotName = snapshotName
+			snapshotName = azureutils.CreateValidDiskName("local_" + snapshotName)
+		} else {
+			return nil, status.Errorf(codes.InvalidArgument, "could not create snapshot cross region with incremental is false")
+		}
+	}
+
 	mc := metrics.NewMetricContext(consts.AzureDiskCSIDriverName, "controller_create_snapshot", d.cloud.ResourceGroup, d.cloud.SubscriptionID, d.Name)
 	isOperationSucceeded := false
 	defer func() {
 		mc.ObserveOperationWithResult(isOperationSucceeded, consts.SourceResourceID, sourceVolumeID, consts.SnapshotName, snapshotName)
 	}()
 
-	klog.V(2).Infof("begin to create snapshot(%s, incremental: %v) under rg(%s)", snapshotName, incremental, resourceGroup)
+	klog.V(2).Infof("begin to create snapshot(%s, incremental: %v) under rg(%s) region(%s)", snapshotName, incremental, resourceGroup, d.cloud.Location)
 	if rerr := d.cloud.SnapshotsClient.CreateOrUpdate(ctx, subsID, resourceGroup, snapshotName, snapshot); rerr != nil {
 		if strings.Contains(rerr.Error().Error(), "existing disk") {
 			return nil, status.Error(codes.AlreadyExists, fmt.Sprintf("request snapshot(%s) under rg(%s) already exists, but the SourceVolumeId is different, error details: %v", snapshotName, resourceGroup, rerr.Error()))
@@ -894,11 +915,52 @@ func (d *Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequ
 		azureutils.SleepIfThrottled(rerr.Error(), azureconstants.SnapshotOpThrottlingSleepSec)
 		return nil, status.Error(codes.Internal, fmt.Sprintf("create snapshot error: %v", rerr.Error()))
 	}
-	klog.V(2).Infof("create snapshot(%s) under rg(%s) successfully", snapshotName, resourceGroup)
+	klog.V(2).Infof("create snapshot(%s) under rg(%s) region(%s) successfully", snapshotName, resourceGroup, d.cloud.Location)
 
 	csiSnapshot, err := d.getSnapshotByID(ctx, subsID, resourceGroup, snapshotName, sourceVolumeID)
 	if err != nil {
 		return nil, err
+	}
+
+	if crossRegionSnapshotName != "" {
+		copySnapshot := snapshot
+		if copySnapshot.SnapshotProperties == nil {
+			copySnapshot.SnapshotProperties = &compute.SnapshotProperties{}
+		}
+		if copySnapshot.SnapshotProperties.CreationData == nil {
+			copySnapshot.SnapshotProperties.CreationData = &compute.CreationData{}
+		}
+		copySnapshot.SnapshotProperties.CreationData.SourceResourceID = &csiSnapshot.SnapshotId
+		copySnapshot.SnapshotProperties.CreationData.CreateOption = compute.CopyStart
+		copySnapshot.Location = &location
+
+		klog.V(2).Infof("begin to create snapshot(%s, incremental: %v) under rg(%s) region(%s)", crossRegionSnapshotName, incremental, resourceGroup, location)
+		if rerr := d.cloud.SnapshotsClient.CreateOrUpdate(ctx, subsID, resourceGroup, crossRegionSnapshotName, copySnapshot); rerr != nil {
+			if strings.Contains(rerr.Error().Error(), "existing disk") {
+				return nil, status.Error(codes.AlreadyExists, fmt.Sprintf("request snapshot(%s) under rg(%s) already exists, but the SourceVolumeId is different, error details: %v", crossRegionSnapshotName, resourceGroup, rerr.Error()))
+			}
+
+			azureutils.SleepIfThrottled(rerr.Error(), consts.SnapshotOpThrottlingSleepSec)
+			return nil, status.Error(codes.Internal, fmt.Sprintf("create snapshot error: %v", rerr.Error()))
+		}
+		klog.V(2).Infof("create snapshot(%s) under rg(%s) region(%s) successfully", crossRegionSnapshotName, resourceGroup, location)
+
+		if err := d.waitForSnapshotCopy(ctx, subsID, resourceGroup, crossRegionSnapshotName, waitForSnapshotCopyInterval, waitForSnapshotCopyTimeout); err != nil {
+			return nil, status.Error(codes.Internal, fmt.Sprintf("failed to wait for snapshot copy cross region: %v", err.Error()))
+		}
+
+		klog.V(2).Infof("begin to delete snapshot(%s) under rg(%s) region(%s)", snapshotName, resourceGroup, d.cloud.Location)
+		if rerr := d.cloud.SnapshotsClient.Delete(ctx, subsID, resourceGroup, snapshotName); rerr != nil {
+			azureutils.SleepIfThrottled(rerr.Error(), consts.SnapshotOpThrottlingSleepSec)
+			klog.Errorf("delete snapshot error: %v", rerr.Error())
+		} else {
+			klog.V(2).Infof("delete snapshot(%s) under rg(%s) region(%s) successfully", snapshotName, resourceGroup, d.cloud.Location)
+		}
+
+		csiSnapshot, err = d.getSnapshotByID(ctx, subsID, resourceGroup, crossRegionSnapshotName, sourceVolumeID)
+		if err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
 	}
 
 	createResp := &csi.CreateSnapshotResponse{
@@ -1031,6 +1093,31 @@ func (d *Driver) getSnapshotInfo(snapshotID string) (snapshotName, resourceGroup
 		return "", "", "", fmt.Errorf("cannot get SubscriptionID from %s", snapshotID)
 	}
 	return snapshotName, resourceGroup, subsID, err
+}
+
+// waitForSnapshotCopy wait for copy incremental snapshot to a new region until completionPercent is 100.0
+func (d *Driver) waitForSnapshotCopy(ctx context.Context, subsID, resourceGroup, copySnapshotName string, intervel, timeout time.Duration) error {
+	timeAfter := time.After(timeout)
+	timeTick := time.Tick(intervel)
+
+	for {
+		select {
+		case <-timeTick:
+			copySnapshot, rerr := d.cloud.SnapshotsClient.Get(ctx, subsID, resourceGroup, copySnapshotName)
+			if rerr != nil {
+				return rerr.Error()
+			}
+
+			completionPercent := *copySnapshot.SnapshotProperties.CompletionPercent
+			klog.V(2).Infof("copy snapshot(%s) under rg(%s) region(%s) completionPercent: %f", copySnapshotName, resourceGroup, *copySnapshot.Location, completionPercent)
+			if completionPercent >= float64(100.0) {
+				klog.V(2).Infof("copy snapshot(%s) under rg(%s) region(%s) complete", copySnapshotName, resourceGroup, *copySnapshot.Location)
+				return nil
+			}
+		case <-timeAfter:
+			return fmt.Errorf("timeout waiting for copy snapshot(%s) under rg(%s)", copySnapshotName, resourceGroup)
+		}
+	}
 }
 
 func isAsyncAttachEnabled(defaultValue bool, volumeContext map[string]string) bool {

--- a/pkg/azuredisk/controllerserver_test.go
+++ b/pkg/azuredisk/controllerserver_test.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest/date"
@@ -2026,6 +2028,130 @@ func getFakeDriverWithKubeClient(t *testing.T) FakeDriver {
 	d.getCloud().KubeClient.(*mockkubeclient.MockInterface).EXPECT().CoreV1().Return(corev1).AnyTimes()
 	d.getCloud().KubeClient.CoreV1().(*mockcorev1.MockInterface).EXPECT().PersistentVolumes().Return(persistentvolume).AnyTimes()
 	return d
+}
+
+func TestWaitForSnapshotCopy(t *testing.T) {
+	testCases := []struct {
+		name     string
+		testFunc func(t *testing.T)
+	}{
+		{
+			name: "snapshotID not valid",
+			testFunc: func(t *testing.T) {
+				d, _ := NewFakeDriver(t)
+				subID := "subs"
+				resourceGroup := "rg"
+				intervel := 1 * time.Millisecond
+				timeout := 10 * time.Millisecond
+				snapshotID := "test"
+				snapshot := compute.Snapshot{
+					SnapshotProperties: &compute.SnapshotProperties{},
+					ID:                 &snapshotID}
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+				mockSnapshotClient := mocksnapshotclient.NewMockInterface(ctrl)
+				d.getCloud().SnapshotsClient = mockSnapshotClient
+				rerr := &retry.Error{
+					RawError: fmt.Errorf("invalid snapshotID"),
+				}
+				mockSnapshotClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(snapshot, rerr).AnyTimes()
+				err := d.waitForSnapshotCopy(context.Background(), subID, resourceGroup, snapshotID, intervel, timeout)
+
+				wantErr := true
+				subErrMsg := "invalid snapshotID"
+				if (err != nil) != wantErr {
+					t.Errorf("waitForSnapshotCopy() error = %v, wantErr %v", err, wantErr)
+				}
+				if err != nil && !strings.Contains(err.Error(), subErrMsg) {
+					t.Errorf("waitForSnapshotCopy() error = %v, wantErr %v", err, subErrMsg)
+				}
+			},
+		},
+		{
+			name: "timeout for waiting snapshot copy cross region",
+			testFunc: func(t *testing.T) {
+				d, _ := NewFakeDriver(t)
+				subID := "subs"
+				resourceGroup := "rg"
+				intervel := 1 * time.Millisecond
+				timeout := 10 * time.Millisecond
+				volumeID := "test"
+				DiskSize := int32(10)
+				snapshotID := "test"
+				location := "loc"
+				provisioningState := "succeeded"
+				snapshot := compute.Snapshot{
+					SnapshotProperties: &compute.SnapshotProperties{
+						TimeCreated:       &date.Time{},
+						ProvisioningState: &provisioningState,
+						DiskSizeGB:        &DiskSize,
+						CreationData:      &compute.CreationData{SourceResourceID: &volumeID},
+						CompletionPercent: pointer.Float64(0.0),
+					},
+					Location: &location,
+					ID:       &snapshotID}
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+				mockSnapshotClient := mocksnapshotclient.NewMockInterface(ctrl)
+				d.getCloud().SnapshotsClient = mockSnapshotClient
+				mockSnapshotClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(snapshot, nil).AnyTimes()
+				err := d.waitForSnapshotCopy(context.Background(), subID, resourceGroup, snapshotID, intervel, timeout)
+
+				wantErr := true
+				subErrMsg := "timeout"
+				if (err != nil) != wantErr {
+					t.Errorf("waitForSnapshotCopy() error = %v, wantErr %v", err, wantErr)
+				}
+				if err != nil && !strings.Contains(err.Error(), subErrMsg) {
+					t.Errorf("waitForSnapshotCopy() error = %v, wantErr %v", err, subErrMsg)
+				}
+			},
+		},
+		{
+			name: "succeed for waiting snapshot copy cross region",
+			testFunc: func(t *testing.T) {
+				d, _ := NewFakeDriver(t)
+				subID := "subs"
+				resourceGroup := "rg"
+				intervel := 1 * time.Millisecond
+				timeout := 10 * time.Millisecond
+				volumeID := "test"
+				DiskSize := int32(10)
+				snapshotID := "test"
+				location := "loc"
+				provisioningState := "succeeded"
+				snapshot := compute.Snapshot{
+					SnapshotProperties: &compute.SnapshotProperties{
+						TimeCreated:       &date.Time{},
+						ProvisioningState: &provisioningState,
+						DiskSizeGB:        &DiskSize,
+						CreationData:      &compute.CreationData{SourceResourceID: &volumeID},
+						CompletionPercent: pointer.Float64(100.0),
+					},
+					Location: &location,
+					ID:       &snapshotID}
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+				mockSnapshotClient := mocksnapshotclient.NewMockInterface(ctrl)
+				d.getCloud().SnapshotsClient = mockSnapshotClient
+				mockSnapshotClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(snapshot, nil).AnyTimes()
+				err := d.waitForSnapshotCopy(context.Background(), subID, resourceGroup, snapshotID, intervel, timeout)
+
+				wantErr := false
+				subErrMsg := ""
+				if (err != nil) != wantErr {
+					t.Errorf("waitForSnapshotCopy() error = %v, wantErr %v", err, wantErr)
+				}
+				if err != nil && !strings.Contains(err.Error(), subErrMsg) {
+					t.Errorf("waitForSnapshotCopy() error = %v, wantErr %v", err, subErrMsg)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, tc.testFunc)
+	}
 }
 
 func TestIsAsyncAttachEnabled(t *testing.T) {

--- a/pkg/azuredisk/controllerserver_v2.go
+++ b/pkg/azuredisk/controllerserver_v2.go
@@ -26,6 +26,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -961,4 +962,29 @@ func (d *DriverV2) getSnapshotInfo(snapshotID string) (snapshotName, resourceGro
 		return "", "", "", fmt.Errorf("cannot get SubscriptionID from %s", snapshotID)
 	}
 	return snapshotName, resourceGroup, subsID, err
+}
+
+// waitForSnapshotCopy wait for copy incremental snapshot to a new region until completionPercent is 100.0
+func (d *DriverV2) waitForSnapshotCopy(ctx context.Context, subsID, resourceGroup, copySnapshotName string, intervel, timeout time.Duration) error {
+	timeAfter := time.After(timeout)
+	timeTick := time.Tick(intervel)
+
+	for {
+		select {
+		case <-timeTick:
+			copySnapshot, rerr := d.cloud.SnapshotsClient.Get(ctx, subsID, resourceGroup, copySnapshotName)
+			if rerr != nil {
+				return status.Error(codes.Internal, fmt.Sprintf("get snapshot error: %v", rerr.Error()))
+			}
+
+			completionPercent := *copySnapshot.SnapshotProperties.CompletionPercent
+			klog.V(2).Infof("copy snapshot(%s) under rg(%s) region(%s) completionPercent: %f", copySnapshotName, resourceGroup, *copySnapshot.Location, completionPercent)
+			if completionPercent == float64(100.0) {
+				klog.V(2).Infof("copy snapshot(%s) under rg(%s) region(%s) complete", copySnapshotName, resourceGroup, *copySnapshot.Location)
+				return nil
+			}
+		case <-timeAfter:
+			return fmt.Errorf("timeout waiting for copy snapshot(%s) under rg(%s)", copySnapshotName, resourceGroup)
+		}
+	}
 }

--- a/pkg/azuredisk/fake_azuredisk.go
+++ b/pkg/azuredisk/fake_azuredisk.go
@@ -88,6 +88,7 @@ type FakeDriver interface {
 	checkDiskCapacity(context.Context, string, string, string, int) (bool, error)
 	checkDiskExists(ctx context.Context, diskURI string) (*compute.Disk, error)
 	getSnapshotInfo(string) (string, string, string, error)
+	waitForSnapshotCopy(context.Context, string, string, string, time.Duration, time.Duration) error
 	getSnapshotByID(context.Context, string, string, string, string) (*csi.Snapshot, error)
 	ensureMountPoint(string) (bool, error)
 	ensureBlockTargetFile(string) error

--- a/test/e2e/testsuites/dynamically_provisioned_volume_snapshot_cross_region_tester.go
+++ b/test/e2e/testsuites/dynamically_provisioned_volume_snapshot_cross_region_tester.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testsuites
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/azuredisk-csi-driver/test/e2e/driver"
+	"sigs.k8s.io/azuredisk-csi-driver/test/utils/azure"
+	"sigs.k8s.io/azuredisk-csi-driver/test/utils/credentials"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/pborman/uuid"
+
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	restclientset "k8s.io/client-go/rest"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// DynamicallyProvisionedVolumeSnapshotCrossRegionTest will provision required StorageClass(es),VolumeSnapshotClass(es), PVC(s) and Pod(s)
+// Waiting for the PV provisioner to create a new PV
+// Testing if the Pod(s) can write and read to mounted volumes
+// Create a snapshot, validate the data is still on the disk, and then write and read to it again
+// And finally delete the snapshot
+// This test only supports a single volume
+type DynamicallyProvisionedVolumeSnapshotCrossRegionTest struct {
+	CSIDriver                      driver.PVTestDriver
+	Pod                            PodDetails
+	PodOverwrite                   PodDetails
+	PodWithSnapshot                PodDetails
+	StorageClassParameters         map[string]string
+	SnapshotStorageClassParameters map[string]string
+}
+
+func (t *DynamicallyProvisionedVolumeSnapshotCrossRegionTest) Run(client clientset.Interface, restclient restclientset.Interface, namespace *v1.Namespace) {
+	tpod := NewTestPod(client, namespace, t.Pod.Cmd, t.Pod.IsWindows, t.Pod.WinServerVer)
+	volume := t.Pod.Volumes[0]
+	tpvc, pvcCleanup := volume.SetupDynamicPersistentVolumeClaim(client, namespace, t.CSIDriver, t.StorageClassParameters)
+	for i := range pvcCleanup {
+		defer pvcCleanup[i]()
+	}
+	tpod.SetupVolume(tpvc.persistentVolumeClaim, volume.VolumeMount.NameGenerate+"1", volume.VolumeMount.MountPathGenerate+"1", volume.VolumeMount.ReadOnly)
+	ginkgo.By("deploying the pod")
+	tpod.Create()
+	defer tpod.Cleanup()
+	ginkgo.By("checking that the pod's command exits with no error")
+	tpod.WaitForSuccess()
+
+	ginkgo.By("Checking Prow test resource group")
+	creds, err := credentials.CreateAzureCredentialFile()
+	framework.ExpectNoError(err, fmt.Sprintf("Error getting creds for AzurePublicCloud %v", err))
+	defer func() {
+		err := credentials.DeleteAzureCredentialFile()
+		framework.ExpectNoError(err)
+	}()
+
+	ginkgo.By("Prow test resource group: " + creds.ResourceGroup)
+
+	azureClient, err := azure.GetAzureClient(creds.Cloud, creds.SubscriptionID, creds.AADClientID, creds.TenantID, creds.AADClientSecret)
+	framework.ExpectNoError(err)
+
+	//create external resource group
+	externalRG := credentials.ResourceGroupPrefix + uuid.NewUUID().String()
+	ginkgo.By("Creating external resource group: " + externalRG)
+	ctx := context.Background()
+	_, err = azureClient.EnsureResourceGroup(ctx, externalRG, creds.Location, nil)
+	framework.ExpectNoError(err)
+	defer func() {
+		// Only delete resource group the test created
+		if strings.HasPrefix(externalRG, credentials.ResourceGroupPrefix) {
+			framework.Logf("Deleting resource group %s", externalRG)
+			err := azureClient.DeleteResourceGroup(ctx, externalRG)
+			framework.ExpectNoError(err)
+		}
+	}()
+
+	ginkgo.By("creating volume snapshot class with external rg " + externalRG)
+	tvsc, cleanup := CreateVolumeSnapshotClass(restclient, namespace, t.SnapshotStorageClassParameters, t.CSIDriver)
+	if tvsc.volumeSnapshotClass.Parameters == nil {
+		tvsc.volumeSnapshotClass.Parameters = map[string]string{}
+	}
+	tvsc.volumeSnapshotClass.Parameters["resourceGroup"] = externalRG
+	tvsc.Create()
+	defer cleanup()
+
+	ginkgo.By("taking snapshots")
+	snapshot := tvsc.CreateSnapshot(tpvc.persistentVolumeClaim)
+
+	defer tvsc.DeleteSnapshot(snapshot)
+	tvsc.ReadyToUse(snapshot)
+
+	snapshotVolume := volume
+	snapshotVolume.DataSource = &DataSource{
+		Kind: VolumeSnapshotKind,
+		Name: snapshot.Name,
+	}
+	t.PodWithSnapshot.Volumes = []VolumeDetails{snapshotVolume}
+
+	ginkgo.By("Set cross region storageclass and snapshot restored pvc")
+	restoredStorageClassParameters := t.StorageClassParameters
+	restoredStorageClassParameters["location"] = t.SnapshotStorageClassParameters["location"]
+	volumeBindingMode := storagev1.VolumeBindingWaitForFirstConsumer
+	snapshotVolume.VolumeBindingMode = &volumeBindingMode
+	trpvc, rpvcCleanup := snapshotVolume.SetupDynamicPersistentVolumeClaim(client, namespace, t.CSIDriver, restoredStorageClassParameters)
+	for i := range rpvcCleanup {
+		defer rpvcCleanup[i]()
+	}
+
+	tPodWithSnapshotCrossRegion := NewTestPod(client, namespace, t.Pod.Cmd, t.Pod.IsWindows, t.Pod.WinServerVer)
+	tPodWithSnapshotCrossRegion.SetupVolume(trpvc.persistentVolumeClaim, snapshotVolume.VolumeMount.NameGenerate+"2", snapshotVolume.VolumeMount.MountPathGenerate+"2", snapshotVolume.VolumeMount.ReadOnly)
+	ginkgo.By("deploying a pod with a volume restored from the snapshot cross region")
+	tPodWithSnapshotCrossRegion.Create()
+	defer tPodWithSnapshotCrossRegion.Cleanup()
+	ginkgo.By("checking that different region disk is restored")
+	trpvc.WaitForBound()
+
+}

--- a/test/e2e/testsuites/testsuites.go
+++ b/test/e2e/testsuites/testsuites.go
@@ -166,7 +166,7 @@ func (t *TestVolumeSnapshotClass) CreateSnapshot(pvc *v1.PersistentVolumeClaim) 
 
 func (t *TestVolumeSnapshotClass) ReadyToUse(snapshot *snapshotv1.VolumeSnapshot) {
 	ginkgo.By("waiting for VolumeSnapshot to be ready to use - " + snapshot.Name)
-	err := wait.Poll(15*time.Second, 5*time.Minute, func() (bool, error) {
+	err := wait.Poll(15*time.Second, 30*time.Minute, func() (bool, error) {
 		vs, err := snapshotclientset.New(t.client).SnapshotV1().VolumeSnapshots(t.namespace.Name).Get(context.TODO(), snapshot.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Errorf("did not see ReadyToUse: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

**What this PR does / why we need it**:

feat: add copy snapshot in cross region directly

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1694

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
test log
```
I0327 11:35:05.765036       1 controllerserver.go:893] begin to create snapshot(local_snapshot-4d074b39-8a9b-493a-a101-dc110548227b, incremental: true) under rg(mc_aks-yxytest_group_aks-yxytest_eastus) region(eastus)
I0327 11:35:08.224270       1 controllerserver.go:902] create snapshot(local_snapshot-4d074b39-8a9b-493a-a101-dc110548227b) under rg(mc_aks-yxytest_group_aks-yxytest_eastus) region(eastus) successfully
I0327 11:35:08.273543       1 util.go:124] Send.sendRequest got response with ContentLength -1, StatusCode 200 and responseBody length 1295
I0327 11:35:08.273723       1 controllerserver.go:909] create snapshot location(westus) is different from disk location(eastus)
I0327 11:35:08.273745       1 controllerserver.go:911] begin to copy an incremental snapshot from region(eastus) to new region(westus)
I0327 11:35:08.273755       1 controllerserver.go:917] begin to create snapshot(snapshot-4d074b39-8a9b-493a-a101-dc110548227b, incremental: true) under rg(mc_aks-yxytest_group_aks-yxytest_eastus) region(westus)
I0327 11:35:12.444469       1 controllerserver.go:926] create snapshot(snapshot-4d074b39-8a9b-493a-a101-dc110548227b) under rg(mc_aks-yxytest_group_aks-yxytest_eastus) region(westus) successfully
I0327 11:35:12.444498       1 controllerserver.go:928] begin to delete snapshot(local_snapshot-4d074b39-8a9b-493a-a101-dc110548227b) under rg(mc_aks-yxytest_group_aks-yxytest_eastus) region(westus)
I0327 11:35:17.695038       1 controllerserver.go:933] delete snapshot(local_snapshot-4d074b39-8a9b-493a-a101-dc110548227b) under rg(mc_aks-yxytest_group_aks-yxytest_eastus) region(westus) successfully
I0327 11:35:17.791222       1 util.go:124] Send.sendRequest got response with ContentLength -1, StatusCode 200 and responseBody length 1334
I0327 11:35:17.791401       1 azure_metrics.go:115] "Observed Request Latency" latency_seconds=12.026353477 request="azuredisk_csi_driver_controller_create_snapshot" resource_group="mc_aks-yxytest_group_aks-yxytest_eastus" subscription_id="8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8" source="disk.csi.azure.com" source_resource_id="/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/mc_aks-yxytest_group_aks-yxytest_eastus/providers/Microsoft.Compute/disks/pvc-8deda4a0-f6c8-4e82-9f9d-10e7f40bcc2c" snapshot_name="snapshot-4d074b39-8a9b-493a-a101-dc110548227b" result_code="succeeded"
I0327 11:35:17.791421       1 utils.go:84] GRPC response: {"snapshot":{"creation_time":{"nanos":47815400,"seconds":1679916910},"ready_to_use":true,"size_bytes":10737418240,"snapshot_id":"/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/mc_aks-yxytest_group_aks-yxytest_eastus/providers/Microsoft.Compute/snapshots/snapshot-4d074b39-8a9b-493a-a101-dc110548227b","source_volume_id":"/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/mc_aks-yxytest_group_aks-yxytest_eastus/providers/Microsoft.Compute/disks/pvc-8deda4a0-f6c8-4e82-9f9d-10e7f40bcc2c"}}
```
<img width="788" alt="image" src="https://user-images.githubusercontent.com/19743085/227951413-eb31f363-a7e2-4ac5-a0e3-ea7b3bc1d953.png">

**Release note**:
```
none
```
