### PR TITLE
test(e2e): change the storageclass configuration method in the test file

### DIFF
--- a/deploy/example/statefulset-nonroot.yaml
+++ b/deploy/example/statefulset-nonroot.yaml
@@ -38,9 +38,8 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: persistent-storage
-        annotations:
-          volume.beta.kubernetes.io/storage-class: managed-csi
       spec:
+        storageClassName: managed-csi
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:

--- a/deploy/example/statefulset-nozone.yaml
+++ b/deploy/example/statefulset-nozone.yaml
@@ -47,9 +47,8 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: persistent-storage
-        annotations:
-          volume.beta.kubernetes.io/storage-class: managed-csi
       spec:
+        storageClassName: managed-csi
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:

--- a/deploy/example/statefulset.yaml
+++ b/deploy/example/statefulset.yaml
@@ -34,9 +34,8 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: persistent-storage
-        annotations:
-          volume.beta.kubernetes.io/storage-class: managed-csi
       spec:
+        storageClassName: managed-csi
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:

--- a/deploy/example/windows/statefulset.yaml
+++ b/deploy/example/windows/statefulset.yaml
@@ -33,9 +33,8 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: persistent-storage
-        annotations:
-          volume.beta.kubernetes.io/storage-class: managed-csi
       spec:
+        storageClassName: managed-csi
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind test
-->

**What this PR does / why we need it**:

The volume.beta.kubernetes.io/storage-class annotation is deprecated since v1.9. 
Changed it to a new way to deal with some e2e issues.

