### PR TITLE
[V2] fix: only call handleReplicaDelete after deletion

### DIFF
--- a/pkg/controller/attach_detach.go
+++ b/pkg/controller/attach_detach.go
@@ -378,6 +378,9 @@ func (r *ReconcileAttachDetach) triggerDetach(ctx context.Context, azVolumeAttac
 			if derr := r.cachedClient.Delete(goCtx, azVolumeAttachment); derr != nil {
 				w.Logger().Error(derr, "failed to delete AzVolumeAttachment")
 			}
+			if azVolumeAttachment.Spec.RequestedRole == azdiskv1beta2.ReplicaRole && !isCleanupRequested(azVolumeAttachment) {
+				go r.handleReplicaDelete(context.Background(), azVolumeAttachment)
+			}
 		}
 	}()
 	<-waitCh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
When checking the controller logs, found that detaching the failed CRI failed many times due to client throttling, and after that, manageReplicas were called many times. 

I think it's because each time we update the state of DetachmentFailed [here](https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/4611c51946d9ae37d1582ca206ea60794ef03116/pkg/controller/replica.go#L113), a goroutine will be created for handleReplicaDelete. Once the detachment succeeds and CRI get deleted, multiple manageReplicas are called concurrently.

To fix this bug, we need to make sure `handleReplicaDelete` function is called only after the deletion timestamp is put.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
