### PR TITLE
[V2] fix: retry annotation not being added for replica volume attachment CRI when context.DeadlineExceeded occurs on attach 🐞

### DIFF
--- a/pkg/azurediskplugin/main.go
+++ b/pkg/azurediskplugin/main.go
@@ -142,7 +142,7 @@ func getDriverConfig() *azdiskv1beta2.AzDiskDriverConfiguration {
 		}
 
 		// Convert yaml to a driveConfig object
-		err = yaml.Unmarshal(yamlFile, &driverConfig)
+		err = yaml.Unmarshal(yamlFile, driverConfig)
 		if err != nil {
 			klog.Fatalf("failed to unmarshal the driver config, error: %v", err)
 		}

--- a/pkg/controller/attach_detach.go
+++ b/pkg/controller/attach_detach.go
@@ -275,7 +275,7 @@ func (r *ReconcileAttachDetach) triggerAttach(ctx context.Context, azVolumeAttac
 				azva := obj.(*azdiskv1beta2.AzVolumeAttachment)
 				// add retriable annotation if the replica attach error is PartialUpdateError or timeout
 				if azva.Spec.RequestedRole == azdiskv1beta2.ReplicaRole {
-					if _, ok := attachErr.(*retry.PartialUpdateError); ok || errors.Is(err, context.DeadlineExceeded) {
+					if _, ok := attachErr.(*retry.PartialUpdateError); ok || errors.Is(attachErr, context.DeadlineExceeded) {
 						azva.Status.Annotations = azureutils.AddToMap(azva.Status.Annotations, consts.ReplicaVolumeAttachRetryAnnotation, "true")
 					}
 				}
@@ -316,7 +316,7 @@ func (r *ReconcileAttachDetach) triggerAttach(ctx context.Context, azVolumeAttac
 				_ = r.updateVolumeAttachmentWithResult(goCtx, azVolumeAttachment)
 			}
 
-			if updatedObj, err := azureutils.UpdateCRIWithRetry(goCtx, nil, r.cachedClient, r.azClient, azVolumeAttachment, updateFunc, consts.ForcedUpdateMaxNetRetry, azureutils.UpdateCRIStatus); err != nil {
+			if updatedObj, err := azureutils.UpdateCRIWithRetry(goCtx, nil, r.cachedClient, r.azClient, azVolumeAttachment, updateFunc, consts.ForcedUpdateMaxNetRetry, azureutils.UpdateCRIStatus); err == nil {
 				azVolumeAttachment = updatedObj.(*azdiskv1beta2.AzVolumeAttachment)
 			} else {
 				// There's nothing much we can do in this case, so just log the error and move on.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:
This PR fixes an issue when context.DeadlineExceeded occurs when trying to attach a replica volume attachment to a node. The code had an issue where 'err' was referenced while 'attachErr' should have been referenced. 

As a result, the `disk.csi.azure.com/replica-volume-attach-retry: true` annotation was not added to the replica attachment CRI. When `disk.csi.azure.com/replica-volume-attach-retry` is not `true` and attachment failed, the CRI will be deleted and a new one will be created.

This caused a new CRI to be created to attach to a new node. This fails because the volume is already attached to the other node for which deadline exceeded. I added a test to check that the annotation gets added in this scenario. 

We also noticed an issue where the error check for updating the intermediate/final state of the azVolumeAttachment CRI was incorrect. 

We also removed an unnecessary address operation on driverConfig, as it is already a pointer.


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
