### PR TITLE
fix: ensure Kubernets conformant format for location

### DIFF
--- a/pkg/azureutils/azure_disk_utils.go
+++ b/pkg/azureutils/azure_disk_utils.go
@@ -224,6 +224,11 @@ func GetCloudProviderFromClient(ctx context.Context, kubeClient *clientset.Clien
 			return nil, fmt.Errorf("no cloud config provided, error: %v", err)
 		}
 	} else {
+		// Location may be either upper case with spaces (e.g. "East US") or lower case without spaces (e.g. "eastus")
+		// Kubernetes does not allow whitespaces in label values, e.g. for topology keys
+		// ensure Kubernetes compatible format for Location by enforcing lowercase-no-space format
+		config.Location = strings.ToLower(strings.ReplaceAll(config.Location, " ", ""))
+
 		// disable disk related rate limit
 		config.DiskRateLimit = &azclients.RateLimitConfig{
 			CloudProviderRateLimit: false,

--- a/pkg/azureutils/azure_disk_utils_test.go
+++ b/pkg/azureutils/azure_disk_utils_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -266,6 +267,7 @@ users:
 }
 
 func TestGetCloudProvider(t *testing.T) {
+	locationRxp := regexp.MustCompile("(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?")
 	fakeCredFile, err := testutil.GetWorkDirPath("fake-cred-file.json")
 	if err != nil {
 		t.Errorf("GetWorkDirPath failed with %v", err)
@@ -317,6 +319,7 @@ users:
 		desc                  string
 		createFakeCredFile    bool
 		createFakeKubeConfig  bool
+		credFile              string
 		kubeconfig            string
 		userAgent             string
 		allowEmptyCloudConfig bool
@@ -352,6 +355,15 @@ users:
 			allowEmptyCloudConfig: true,
 			expectedErr:           nil,
 		},
+		{
+			desc:                  "[success] out of cluster & in cluster, no kubeconfig, a fake credential file with upper case Location format",
+			createFakeCredFile:    true,
+			kubeconfig:            "",
+			credFile:              "location: \"East US\"\n",
+			userAgent:             "useragent",
+			allowEmptyCloudConfig: false,
+			expectedErr:           nil,
+		},
 	}
 
 	for _, test := range tests {
@@ -362,6 +374,10 @@ users:
 			defer func() {
 				os.Remove(fakeCredFile)
 			}()
+
+			if err := os.WriteFile(fakeCredFile, []byte(test.credFile), 0666); err != nil {
+				t.Error(err)
+			}
 
 			t.Setenv(consts.DefaultAzureCredentialFileEnv, fakeCredFile)
 		}
@@ -382,6 +398,7 @@ users:
 			t.Errorf("desc: %s,\n input: %q, GetCloudProvider err: %v, expectedErr: %v", test.desc, test.kubeconfig, err, test.expectedErr)
 		}
 		if cloud != nil {
+			assert.Regexp(t, locationRxp, cloud.Location)
 			assert.Equal(t, cloud.UserAgent, test.userAgent)
 			assert.Equal(t, cloud.DiskRateLimit != nil && cloud.DiskRateLimit.CloudProviderRateLimit, false)
 			assert.Equal(t, cloud.SnapshotRateLimit != nil && cloud.SnapshotRateLimit.CloudProviderRateLimit, false)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

When creating the [cloud provider config file](https://cloud-provider-azure.sigs.k8s.io/install/configs/), one can specify the `location` in two (valid for Azure) formats:
* upper case with spaces, e.g. "East US"
* lower case with no spaces, e.g. "eastus"

The driver (as well as other applications making use of the config) will accept and work with both formats.
An issue only arises if nodes in the cluster are created in specific availability zones, e.g. "East US 2":

The topology key (`topology.disk.csi.azure.com/zone`) of the node will always be set to non zone.

The `CreateVolume` rpc of the controller server will be unable to schedule the disk in the correct zone, since the azuredisk topology key is set to an empty string.
If one sets up  the well-known topology key instead (`topology.kubernetes.io/zone`) (or updates the azuredisk key manually), creating the disk in the correct zone still fails, because of how the [`PickAvailabilityZone`](https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/7e9f4106c06eef1eac81e13425f62f67b23cb715/pkg/azureutils/azure_disk_utils.go#L715) checks for a valid zone.

This PR aims to fix this issue by ensuring the driver is always set up using the lower case no-space format, even if the config declares the format with spaces.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
