### PR TITLE
chore: adding ability to BYO storage classes for pod failover

### DIFF
--- a/test/podFailover/workload/chart/templates/workload.yaml
+++ b/test/podFailover/workload/chart/templates/workload.yaml
@@ -47,7 +47,7 @@ stringData:
   AZURE_TENANT_ID: {{ .Values.azureTenantId }}
 ---
 {{- end }}
-{{- if .Values.storageClass }}
+{{- if and .Values.storageClass .Values.storageClass.create }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adding ability to bring your own storage class to pod failover tests.
