### PR TITLE
fix: stop attaching disk when get disk lun failed

### DIFF
--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -43,6 +43,7 @@ import (
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/azureutils"
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/optimization"
 	volumehelper "sigs.k8s.io/azuredisk-csi-driver/pkg/util"
+	azureconsts "sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/metrics"
 	azure "sigs.k8s.io/cloud-provider-azure/pkg/provider"
 )
@@ -456,8 +457,8 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 		// Volume is already attached to node.
 		klog.V(2).Infof("Attach operation is successful. volume %s is already attached to node %s at lun %d.", diskURI, nodeName, lun)
 	} else {
-		if azureutils.IsThrottlingError(err) {
-			return nil, status.Errorf(codes.Internal, err.Error())
+		if !strings.Contains(err.Error(), azureconsts.CannotFindDiskLUN) {
+			return nil, status.Errorf(codes.Internal, "could not get disk lun for volume %s: %v", diskURI, err)
 		}
 		var cachingMode armcompute.CachingTypes
 		if cachingMode, err = azureutils.GetCachingMode(volumeContext); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: stop attaching disk when get disk lun failed
the driver should only attach disk when disk lun is not found on that VM

- current error messages
```
E0326 01:48:28.227240 1 azure_controller_common.go:547] error of getting data disks for node aks-xxx-vmss000002: Retriable: true, RetryAfter: 0s, HTTPStatusCode: 500, RawError: {"error":{"code":"InternalServerError","message":"Encountered internal server error. Diagnostic information: timestamp '20240326T014828Z', subscription id 'xxx', tracking id 'c336091e-8e0e-4f9f-a21e-27faeed73a94', request correlation id 'c336091e-8e0e-4f9f-a21e-27faeed73a94'."}}
2024-03-26 01:48:28.0000000	csi-azuredisk-controller			I0326 01:48:28.227258 1 controllerserver.go:411] GetDiskLun returned: Retriable: true, RetryAfter: 0s, HTTPStatusCode: 500, RawError: {"error":{"code":"InternalServerError","message":"Encountered internal server error. Diagnostic information: timestamp '20240326T014828Z', subscription id 'xxx', tracking id 'c336091e-8e0e-4f9f-a21e-27faeed73a94', request correlation id 'c336091e-8e0e-4f9f-a21e-27faeed73a94'."}}. Initiating attaching volume /subscriptions/xxx/resourceGroups/sirius-aks-prod-cluster/providers/Microsoft.Compute/disks/xxx to node aks-xxx-vmss000002 (vmState <nil>).
2024-03-26 01:48:28.0000000	csi-azuredisk-controller			I0326 01:48:28.227285 1 controllerserver.go:438] Trying to attach volume /subscriptions/xxx/resourceGroups/sirius-aks-prod-cluster/providers/Microsoft.Compute/disks/xxx to node aks-xxx-vmss000002
2024-03-26 01:48:28.0000000	csi-azuredisk-controller			I0326 01:48:28.227388 1 azure_controller_common.go:203] found dangling volume /subscriptions/xxx/resourceGroups/sirius-aks-prod-cluster/providers/Microsoft.Compute/disks/xxx attached to node aks-static100822-61594791-vmss00003c, could not be attached to node(aks-xxx-vmss000002)
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: stop attaching disk when get disk lun failed
```
