### PR TITLE
[WIP] fix: replace Get-Item powershell cmd with golang api

### DIFF
--- a/pkg/os/volume/volume.go
+++ b/pkg/os/volume/volume.go
@@ -236,6 +236,7 @@ func getTarget(mount string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	klog.V(2).Infof("Readlink: %s", target)
 	if !strings.HasPrefix(target, "Volume") {
 		return getTarget(target)
 	}

--- a/pkg/os/volume/volume.go
+++ b/pkg/os/volume/volume.go
@@ -232,17 +232,15 @@ func GetVolumeIDFromTargetPath(mount string) (string, error) {
 }
 
 func getTarget(mount string) (string, error) {
-	cmd := "(Get-Item -Path $Env:mount).Target"
-	out, err := azureutils.RunPowershellCmd(cmd, fmt.Sprintf("mount=%s", mount))
-	if err != nil || len(out) == 0 {
-		return "", fmt.Errorf("error getting volume from mount. cmd: %s, output: %s, error: %v", cmd, string(out), err)
+	target, err := os.Readlink(mount)
+	if err != nil {
+		return "", err
 	}
-	volumeString := strings.TrimSpace(string(out))
-	if !strings.HasPrefix(volumeString, "Volume") {
-		return getTarget(volumeString)
+	if !strings.HasPrefix(target, "Volume") {
+		return getTarget(target)
 	}
 
-	return ensureVolumePrefix(volumeString), nil
+	return ensureVolumePrefix(target), nil
 }
 
 // GetVolumeIDFromTargetPath returns the volume id of a given target path.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: replace Get-Item powershell cmd with golang api, thus this PR could reduce cpu and memory usage by calling powershell commands

<details>

```
(Get-Item -Path C:\var\lib\kubelet\pods\01b6c711-6226-4df9-8fd9-c4886319d48f\volumes\kubernetes.io~csi\pvc-c8096712-6a5a-43f8-a33b-1060a4cd412d\mount).Target
c:\var\lib\kubelet\plugins\kubernetes.io\csi\file.csi.azure.com\426aaea866bfa6e7db031404028042a2460256f5b454e0727c921138389be445\globalmount

(Get-Item -Path c:\var\lib\kubelet\plugins\kubernetes.io\csi\file.csi.azure.com\426aaea866bfa6e7db031404028042a2460256f5b454e0727c921138389be445\globalmount).Target
UNC\fc07931f463f043a5bd1a0b.file.core.windows.net\pvc-c8096712-6a5a-43f8-a33b-1060a4cd412d\

(Get-Item -Path C:\var\lib\kubelet\plugins\kubernetes.io\csi\disk.csi.azure.com\95d764218d14515cced832a6fa730d0cd34db9315b93e1fb89d8d9eaf7e7903a\globalmount).Target
Volume{5119f826-d03c-4d16-9fd1-5e9c1c29c939}\

I0409 13:38:51.650865   20420 volume.go:239] Readlink: c:\var\lib\kubelet\plugins\kubernetes.io\csi\disk.csi.azure.com\95d764218d14515cced832a6fa730d0cd34db9315b93e1fb89d8d9eaf7e7903a\globalmount
I0409 13:38:51.651481   20420 volume.go:239] Readlink: G:\
E0409 13:38:51.656304   20420 utils.go:110] GRPC error: GetVolumeIDFromMount(c:\var\lib\kubelet\pods\1e8d0def-30cd-4571-bb7d-2d366a186b0d\volumes\kubernetes.io~csi\pvc-62b91cd8-17c7-4bbe-a819-0461d396bc6c\mount) failed with error: readlink G:\: The file or directory is not a reparse point.
```

</details>

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2235

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: replace Get-Item powershell cmd with golang api
```
