### PR TITLE
[release-1.28] fix: cache GetVolumeStats on Windows node

### DIFF
--- a/pkg/azuredisk/azure_common_darwin.go
+++ b/pkg/azuredisk/azure_common_darwin.go
@@ -119,6 +119,6 @@ func rescanAllVolumes(io azureutils.IOHandler) error {
 	return nil
 }
 
-func GetVolumeStats(ctx context.Context, m *mount.SafeFormatAndMount, target string, hostutil hostUtil) ([]*csi.VolumeUsage, error) {
+func (d *DriverCore) GetVolumeStats(ctx context.Context, m *mount.SafeFormatAndMount, volumeID, target string, hostutil hostUtil) ([]*csi.VolumeUsage, error) {
 	return []*csi.VolumeUsage{}, nil
 }

--- a/pkg/azuredisk/azure_common_linux.go
+++ b/pkg/azuredisk/azure_common_linux.go
@@ -269,7 +269,7 @@ func rescanAllVolumes(io azureutils.IOHandler) error {
 	return nil
 }
 
-func GetVolumeStats(_ context.Context, m *mount.SafeFormatAndMount, target string, hostutil hostUtil) ([]*csi.VolumeUsage, error) {
+func (d *DriverCore) GetVolumeStats(_ context.Context, m *mount.SafeFormatAndMount, _, target string, hostutil hostUtil) ([]*csi.VolumeUsage, error) {
 	var volUsages []*csi.VolumeUsage
 	_, err := os.Stat(target)
 	if err != nil {

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -444,7 +444,7 @@ func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeS
 		return nil, status.Error(codes.InvalidArgument, "NodeGetVolumeStats volume path was empty")
 	}
 
-	volUsage, err := GetVolumeStats(ctx, d.mounter, req.VolumePath, d.hostUtil)
+	volUsage, err := d.GetVolumeStats(ctx, d.mounter, req.VolumeId, req.VolumePath, d.hostUtil)
 	return &csi.NodeGetVolumeStatsResponse{
 		Usage: volUsage,
 	}, err

--- a/pkg/azuredisk/nodeserver_v2.go
+++ b/pkg/azuredisk/nodeserver_v2.go
@@ -405,7 +405,7 @@ func (d *DriverV2) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolum
 		return nil, status.Error(codes.InvalidArgument, "NodeGetVolumeStats volume path was empty")
 	}
 
-	volUsage, err := GetVolumeStats(ctx, d.mounter, req.VolumePath, d.hostUtil)
+	volUsage, err := d.GetVolumeStats(ctx, d.mounter, req.VolumeId, req.VolumePath, d.hostUtil)
 	return &csi.NodeGetVolumeStatsResponse{
 		Usage: volUsage,
 	}, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: cache GetVolumeStats on Windows node

cherrypick of https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/2273

`(Get-Item -Path $Env:mount).Target` powershell command is an expensive call on Windows node, this PR adds a 10min expire cache into GetVolumeStats on Windows node, thus to reduce the calling number

```
I0411 02:02:50.830339   23500 utils.go:105] GRPC call: /csi.v1.Node/NodeGetVolumeStats
I0411 02:02:50.830339   23500 utils.go:106] GRPC request: {"volume_id":"/subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks127_andy-aks127_eastus2euap/providers/Microsoft.Compute/disks/pvc-f2aab55f-72a2-459b-bd78-eb865864afcf","volume_path":"c:\\var\\lib\\kubelet\\pods\\05906335-fed7-4564-abc5-2e3a1ae55f4e\\volumes\\kubernetes.io~csi\\pvc-f2aab55f-72a2-459b-bd78-eb865864afcf\\mount"}
I0411 02:02:50.831825   23500 azure_disk_utils.go:830] Executing command: "C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -Mta -NoProfile -Command (Get-Item -Path $Env:mount).Target"
I0411 02:02:51.127112   23500 azure_disk_utils.go:830] Executing command: "C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -Mta -NoProfile -Command (Get-Item -Path $Env:mount).Target"
I0411 02:02:51.409105   23500 safe_mounter_host_process_windows.go:243] GetVolumeStats(c:\var\lib\kubelet\pods\05906335-fed7-4564-abc5-2e3a1ae55f4e\volumes\kubernetes.io~csi\pvc-f2aab55f-72a2-459b-bd78-eb865864afcf\mount) returned volumeID(\\?\Volume{9f75c746-4b8f-4e38-8ef2-7ce79f6ad55f}\)
I0411 02:02:51.411294   23500 azure_disk_utils.go:830] Executing command: "C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -Mta -NoProfile -Command (Get-Volume -UniqueId \"$Env:volumeID\" | Select SizeRemaining,Size) | ConvertTo-Json"
I0411 02:02:53.534717   23500 utils.go:112] GRPC response: {"usage":[{"available":107219058688,"total":107356352512,"unit":1,"used":137293824}]}
I0411 02:03:21.142675   23500 utils.go:105] GRPC call: /csi.v1.Node/NodeGetCapabilities
I0411 02:03:21.142675   23500 utils.go:106] GRPC request: {}
I0411 02:03:21.142675   23500 utils.go:112] GRPC response: {"capabilities":[{"Type":{"Rpc":{"type":1}}},{"Type":{"Rpc":{"type":3}}},{"Type":{"Rpc":{"type":2}}},{"Type":{"Rpc":{"type":5}}}]}
I0411 02:03:21.146027   23500 utils.go:105] GRPC call: /csi.v1.Node/NodeGetVolumeStats
I0411 02:03:21.146027   23500 utils.go:106] GRPC request: {"volume_id":"/subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks127_andy-aks127_eastus2euap/providers/Microsoft.Compute/disks/pvc-dd0cf69e-4031-4b23-82c4-8b649188c059","volume_path":"c:\\var\\lib\\kubelet\\pods\\e29b9bc8-bdce-466c-a647-7093425340b7\\volumes\\kubernetes.io~csi\\pvc-dd0cf69e-4031-4b23-82c4-8b649188c059\\mount"}
I0411 02:03:21.146513   23500 azure_common_windows.go:175] NodeGetVolumeStats: volume stats for volume /subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks127_andy-aks127_eastus2euap/providers/Microsoft.Compute/disks/pvc-dd0cf69e-4031-4b23-82c4-8b649188c059 path c:\var\lib\kubelet\pods\e29b9bc8-bdce-466c-a647-7093425340b7\volumes\kubernetes.io~csi\pvc-dd0cf69e-4031-4b23-82c4-8b649188c059\mount is cached
I0411 02:03:21.146513   23500 utils.go:112] GRPC response: {"usage":[{"available":107224064000,"total":107356352512,"unit":1,"used":132288512}]}
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2235

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
<details>

```
(Get-Item -Path C:\var\lib\kubelet\pods\01b6c711-6226-4df9-8fd9-c4886319d48f\volumes\kubernetes.io~csi\pvc-c8096712-6a5a-43f8-a33b-1060a4cd412d\mount).Target
c:\var\lib\kubelet\plugins\kubernetes.io\csi\file.csi.azure.com\426aaea866bfa6e7db031404028042a2460256f5b454e0727c921138389be445\globalmount

(Get-Item -Path c:\var\lib\kubelet\plugins\kubernetes.io\csi\file.csi.azure.com\426aaea866bfa6e7db031404028042a2460256f5b454e0727c921138389be445\globalmount).Target
UNC\fc07931f463f043a5bd1a0b.file.core.windows.net\pvc-c8096712-6a5a-43f8-a33b-1060a4cd412d\

(Get-Item -Path C:\var\lib\kubelet\plugins\kubernetes.io\csi\disk.csi.azure.com\95d764218d14515cced832a6fa730d0cd34db9315b93e1fb89d8d9eaf7e7903a\globalmount).Target
Volume{5119f826-d03c-4d16-9fd1-5e9c1c29c939}\

I0409 13:38:51.650865   20420 volume.go:239] Readlink: c:\var\lib\kubelet\plugins\kubernetes.io\csi\disk.csi.azure.com\95d764218d14515cced832a6fa730d0cd34db9315b93e1fb89d8d9eaf7e7903a\globalmount
I0409 13:38:51.651481   20420 volume.go:239] Readlink: G:\
E0409 13:38:51.656304   20420 utils.go:110] GRPC error: GetVolumeIDFromMount(c:\var\lib\kubelet\pods\1e8d0def-30cd-4571-bb7d-2d366a186b0d\volumes\kubernetes.io~csi\pvc-62b91cd8-17c7-4bbe-a819-0461d396bc6c\mount) failed with error: readlink G:\: The file or directory is not a reparse point.
```

</details>

**Release note**:
```
fix: cache GetVolumeStats on Windows node
```
