### PR TITLE
fix: refine GetFreeSpace call on Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	go.uber.org/mock v0.4.0
 	golang.org/x/net v0.22.0
 	golang.org/x/sync v0.7.0
+	golang.org/x/sys v0.18.0
 	google.golang.org/grpc v1.62.1
 	google.golang.org/protobuf v1.33.0
 	k8s.io/api v0.29.3
@@ -136,7 +137,6 @@ require (
 	golang.org/x/exp v0.0.0-20231214170342-aacd6d4b4611 // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/oauth2 v0.16.0 // indirect
-	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/term v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -513,6 +513,10 @@ func (d *Driver) NodeExpandVolume(_ context.Context, req *csi.NodeExpandVolumeRe
 		klog.Errorf("%v, will continue checking whether the volume has been resized", retErr)
 	}
 
+	if runtime.GOOS == "windows" && d.enableWindowsHostProcess {
+		// in windows host process mode, this driver could get the volume size from the volume path
+		devicePath = volumePath
+	}
 	gotBlockSizeBytes, err := getBlockSizeBytes(devicePath, d.mounter)
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("could not get size of block volume at path %s: %v", devicePath, err))

--- a/pkg/mounter/safe_mounter_host_process_windows.go
+++ b/pkg/mounter/safe_mounter_host_process_windows.go
@@ -227,9 +227,9 @@ func (mounter *winMounter) GetDeviceNameFromMount(mountPath, pluginMountDir stri
 }
 
 // GetVolumeSizeInBytes returns the size of the volume in bytes.
-func (mounter *winMounter) GetVolumeSizeInBytes(devicePath string) (int64, error) {
-	volumeSize, _, err := volume.GetVolumeStats(devicePath)
-	return volumeSize, err
+func (mounter *winMounter) GetVolumeSizeInBytes(volumePath string) (int64, error) {
+	_, totalBytes, _, err := GetFreeSpace(volumePath)
+	return totalBytes, err
 }
 
 // ResizeVolume resizes the volume to the maximum available size.
@@ -241,10 +241,8 @@ func (mounter *winMounter) ResizeVolume(devicePath string) error {
 func GetFreeSpace(path string) (int64, int64, int64, error) {
 	var totalNumberOfBytes, totalNumberOfFreeBytes uint64
 	dirName := windows.StringToUTF16Ptr(path)
-	if err := windows.GetDiskFreeSpaceEx(dirName, nil, &totalNumberOfBytes, &totalNumberOfFreeBytes); err != nil {
-		return 0, 0, 0, err
-	}
-	return int64(totalNumberOfFreeBytes), int64(totalNumberOfBytes), int64(totalNumberOfBytes - totalNumberOfFreeBytes), nil
+	err := windows.GetDiskFreeSpaceEx(dirName, nil, &totalNumberOfBytes, &totalNumberOfFreeBytes)
+	return int64(totalNumberOfFreeBytes), int64(totalNumberOfBytes), int64(totalNumberOfBytes - totalNumberOfFreeBytes), err
 }
 
 // GetVolumeStats get volume usage

--- a/pkg/mounter/safe_mounter_host_process_windows.go
+++ b/pkg/mounter/safe_mounter_host_process_windows.go
@@ -27,6 +27,9 @@ import (
 	"strings"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"golang.org/x/sys/windows"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
 	mount "k8s.io/mount-utils"
 
@@ -234,22 +237,28 @@ func (mounter *winMounter) ResizeVolume(devicePath string) error {
 	return volume.ResizeVolume(devicePath, 0)
 }
 
+// GetFreeSpace returns the free space of the volume in bytes, total size of the volume in bytes and the used space of the volume in bytes
+func GetFreeSpace(path string) (int64, int64, int64, error) {
+	var totalNumberOfBytes, totalNumberOfFreeBytes uint64
+	dirName := windows.StringToUTF16Ptr(path)
+	if err := windows.GetDiskFreeSpaceEx(dirName, nil, &totalNumberOfBytes, &totalNumberOfFreeBytes); err != nil {
+		return 0, 0, 0, err
+	}
+	return int64(totalNumberOfFreeBytes), int64(totalNumberOfBytes), int64(totalNumberOfBytes - totalNumberOfFreeBytes), nil
+}
+
 // GetVolumeStats get volume usage
 func (mounter *winMounter) GetVolumeStats(ctx context.Context, path string) (*csi.VolumeUsage, error) {
-	volumeID, err := volume.GetVolumeIDFromTargetPath(path)
+	freeBytesAvailable, totalBytes, totalBytesUsed, err := GetFreeSpace(path)
 	if err != nil {
-		return nil, fmt.Errorf("GetVolumeIDFromMount(%s) failed with error: %v", path, err)
+		return nil, status.Errorf(codes.Internal, "failed to get free space on path %s: %v", path, err)
 	}
-	klog.V(6).Infof("GetVolumeStats(%s) returned volumeID(%s)", path, volumeID)
-	volumeSize, volumeUsedSize, err := volume.GetVolumeStats(volumeID)
-	if err != nil {
-		return nil, fmt.Errorf("GetVolumeStats(%s) failed with error: %v", volumeID, err)
-	}
+
 	volUsage := &csi.VolumeUsage{
 		Unit:      csi.VolumeUsage_BYTES,
-		Available: volumeSize - volumeUsedSize,
-		Total:     volumeSize,
-		Used:      volumeUsedSize,
+		Available: freeBytesAvailable,
+		Total:     totalBytes,
+		Used:      totalBytesUsed,
 	}
 	return volUsage, nil
 }

--- a/pkg/os/volume/volume.go
+++ b/pkg/os/volume/volume.go
@@ -175,30 +175,6 @@ func ResizeVolume(volumeID string, size int64) error {
 	return nil
 }
 
-// GetVolumeStats - retrieves the volume stats for a given volume
-func GetVolumeStats(volumeID string) (int64, int64, error) {
-	// get the size and sizeRemaining for the volume
-	cmd := "(Get-Volume -UniqueId \"$Env:volumeID\" | Select SizeRemaining,Size) | ConvertTo-Json"
-	out, err := azureutils.RunPowershellCmd(cmd, fmt.Sprintf("volumeID=%s", volumeID))
-
-	if err != nil {
-		return -1, -1, fmt.Errorf("error getting capacity and used size of volume. cmd: %s, output: %s, error: %v", cmd, string(out), err)
-	}
-
-	var getVolume map[string]int64
-	outString := string(out)
-	err = json.Unmarshal([]byte(outString), &getVolume)
-	if err != nil {
-		return -1, -1, fmt.Errorf("out %v outstring %v err %v", out, outString, err)
-	}
-
-	volumeSize := getVolume["Size"]
-	volumeSizeRemaining := getVolume["SizeRemaining"]
-
-	volumeUsedSize := volumeSize - volumeSizeRemaining
-	return volumeSize, volumeUsedSize, nil
-}
-
 // GetDiskNumberFromVolumeID - gets the disk number where the volume is.
 func GetDiskNumberFromVolumeID(volumeID string) (uint32, error) {
 	// get the size and sizeRemaining for the volume


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: refine GetFreeSpace call on Windows

this PR could get rid of expensive powershell command `(Get-Item -Path $Env:mount).Target`

```
I0412 11:24:54.552255   21436 utils.go:105] GRPC call: /csi.v1.Node/NodeGetVolumeStats
I0412 11:24:54.552255   21436 utils.go:106] GRPC request: {"volume_id":"/subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks127_andy-aks127_eastus2euap/providers/Microsoft.Compute/disks/pvc-9a2a1408-7661-46d6-ae6f-53f8139d501b","volume_path":"c:\\var\\lib\\kubelet\\pods\\ff7d184e-9672-447e-8036-7c3425f85233\\volumes\\kubernetes.io~csi\\pvc-9a2a1408-7661-46d6-ae6f-53f8139d501b\\mount"}
I0412 11:24:54.552255   21436 utils.go:112] GRPC response: {"usage":[{"available":3183468544,"total":3204378624,"unit":1,"used":20910080}]}
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: refine GetFreeSpace call on Windows
```
