### PR TITLE
[release-1.28] fix: refine GetFreeSpace call on Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.2.0
 	github.com/jongio/azidext/go/azidext v0.4.0
 	github.com/onsi/ginkgo/v2 v2.11.0
+	golang.org/x/sys v0.15.0
 	k8s.io/client-go v0.27.8
 	k8s.io/pod-security-admission v0.27.8
 )
@@ -126,7 +127,6 @@ require (
 	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/oauth2 v0.11.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect
-	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.3.0 // indirect

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -513,6 +513,10 @@ func (d *Driver) NodeExpandVolume(_ context.Context, req *csi.NodeExpandVolumeRe
 		klog.Errorf("%v, will continue checking whether the volume has been resized", retErr)
 	}
 
+	if runtime.GOOS == "windows" && d.enableWindowsHostProcess {
+		// in windows host process mode, this driver could get the volume size from the volume path
+		devicePath = volumePath
+	}
 	gotBlockSizeBytes, err := getBlockSizeBytes(devicePath, d.mounter)
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("could not get size of block volume at path %s: %v", devicePath, err))

--- a/pkg/os/volume/volume.go
+++ b/pkg/os/volume/volume.go
@@ -177,30 +177,6 @@ func ResizeVolume(volumeID string, size int64) error {
 	return nil
 }
 
-// GetVolumeStats - retrieves the volume stats for a given volume
-func GetVolumeStats(volumeID string) (int64, int64, error) {
-	// get the size and sizeRemaining for the volume
-	cmd := "(Get-Volume -UniqueId \"$Env:volumeID\" | Select SizeRemaining,Size) | ConvertTo-Json"
-	out, err := azureutils.RunPowershellCmd(cmd, fmt.Sprintf("volumeID=%s", volumeID))
-
-	if err != nil {
-		return -1, -1, fmt.Errorf("error getting capacity and used size of volume. cmd: %s, output: %s, error: %v", cmd, string(out), err)
-	}
-
-	var getVolume map[string]int64
-	outString := string(out)
-	err = json.Unmarshal([]byte(outString), &getVolume)
-	if err != nil {
-		return -1, -1, fmt.Errorf("out %v outstring %v err %v", out, outString, err)
-	}
-
-	volumeSize := getVolume["Size"]
-	volumeSizeRemaining := getVolume["SizeRemaining"]
-
-	volumeUsedSize := volumeSize - volumeSizeRemaining
-	return volumeSize, volumeUsedSize, nil
-}
-
 // GetDiskNumberFromVolumeID - gets the disk number where the volume is.
 func GetDiskNumberFromVolumeID(volumeID string) (uint32, error) {
 	// get the size and sizeRemaining for the volume


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: refine GetFreeSpace call on Windows

cherrypick of https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/2287

this PR could get rid of expensive powershell command `(Get-Item -Path $Env:mount).Target`

```
I0412 11:24:54.552255   21436 utils.go:105] GRPC call: /csi.v1.Node/NodeGetVolumeStats
I0412 11:24:54.552255   21436 utils.go:106] GRPC request: {"volume_id":"/subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks127_andy-aks127_eastus2euap/providers/Microsoft.Compute/disks/pvc-9a2a1408-7661-46d6-ae6f-53f8139d501b","volume_path":"c:\\var\\lib\\kubelet\\pods\\ff7d184e-9672-447e-8036-7c3425f85233\\volumes\\kubernetes.io~csi\\pvc-9a2a1408-7661-46d6-ae6f-53f8139d501b\\mount"}
I0412 11:24:54.552255   21436 utils.go:112] GRPC response: {"usage":[{"available":3183468544,"total":3204378624,"unit":1,"used":20910080}]}
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: refine GetFreeSpace call on Windows
```
