### PR TITLE
fix: panic on Windows node when getFreeSpace failed on volume path

### DIFF
--- a/pkg/azuredisk/azure_common_windows.go
+++ b/pkg/azuredisk/azure_common_windows.go
@@ -178,8 +178,10 @@ func (d *DriverCore) GetVolumeStats(ctx context.Context, m *mount.SafeFormatAndM
 
 	if proxy, ok := m.Interface.(mounter.CSIProxyMounter); ok {
 		volUsage, err := proxy.GetVolumeStats(ctx, target)
-		// cache the volume stats per volume
-		d.volStatsCache.Set(volumeID, *volUsage)
+		if err == nil && volUsage != nil {
+			// cache the volume stats per volume
+			d.volStatsCache.Set(volumeID, *volUsage)
+		}
 		return []*csi.VolumeUsage{volUsage}, err
 	}
 	return []*csi.VolumeUsage{}, fmt.Errorf("could not cast to csi proxy class")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: panic on Windows node when getFreeSpace failed on volume path

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2361

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: panic on Windows node when getFreeSpace failed on volume path
```
