### PR TITLE
fix: create snapshot failure in edge zone

### DIFF
--- a/pkg/azuredisk/azure_managedDiskController.go
+++ b/pkg/azuredisk/azure_managedDiskController.go
@@ -254,6 +254,7 @@ func (c *ManagedDiskController) CreateManagedDisk(ctx context.Context, options *
 	}
 
 	if c.cloud.HasExtendedLocation() {
+		klog.V(2).Infof("extended location Name:%s Type:%s is set on disk(%s)", c.cloud.ExtendedLocationName, c.cloud.ExtendedLocationType, options.DiskName)
 		model.ExtendedLocation = &armcompute.ExtendedLocation{
 			Name: pointer.String(c.cloud.ExtendedLocationName),
 			Type: to.Ptr(armcompute.ExtendedLocationTypes(c.cloud.ExtendedLocationType)),

--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -1052,6 +1052,7 @@ func (d *Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequ
 	}
 
 	if d.cloud.HasExtendedLocation() {
+		klog.V(2).Infof("extended location Name:%s Type:%s is set on snapshot %s, source volume %s", d.cloud.ExtendedLocationName, d.cloud.ExtendedLocationType, snapshotName, sourceVolumeID)
 		snapshot.ExtendedLocation = &armcompute.ExtendedLocation{
 			Name: to.Ptr(d.cloud.ExtendedLocationName),
 			Type: to.Ptr(armcompute.ExtendedLocationTypes(d.cloud.ExtendedLocationType)),

--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -1051,6 +1051,13 @@ func (d *Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequ
 		Tags:     tags,
 	}
 
+	if d.cloud.HasExtendedLocation() {
+		snapshot.ExtendedLocation = &armcompute.ExtendedLocation{
+			Name: to.Ptr(d.cloud.ExtendedLocationName),
+			Type: to.Ptr(armcompute.ExtendedLocationTypes(d.cloud.ExtendedLocationType)),
+		}
+	}
+
 	if dataAccessAuthMode != "" {
 		if err := azureutils.ValidateDataAccessAuthMode(dataAccessAuthMode); err != nil {
 			return nil, status.Error(codes.InvalidArgument, err.Error())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: create snapshot failure in edge zone

<details>

```
I0801 17:27:57.425602       1 utils.go:77] GRPC call: /csi.v1.Controller/CreateSnapshot
I0801 17:27:57.425628       1 utils.go:78] GRPC request: {"name":"snapshot-ec660e34-1f38-41de-9b1a-093aee63d751","source_volume_id":"/subscriptions/xxx/resourceGroups/mc_e2erg-ebld99563156-pzypqanubzn_e2eaks-qpj_westus/providers/Microsoft.Compute/disks/pvc-54b33ee8-ab52-444e-874e-82845edf6564"}
I0801 17:27:57.425862       1 controllerserver.go:986] begin to create snapshot(snapshot-ec660e34-1f38-41de-9b1a-093aee63d751, incremental: true) under rg(mc_e2erg-ebld99563156-pzypqanubzn_e2eaks-qpj_westus) region(westus)
I0801 17:27:57.765070       1 azure_armclient.go:301] Received error in sendAsync.send: resourceID:
http://localhost:7788/subscriptions/xxx/resourceGroups/mc_e2erg-ebld99563156-pzypqanubzn_e2eaks-qpj_westus/providers/Microsoft.Compute/snapshots/snapshot-ec660e34-1f38-41de-9b1a-093aee63d751?api-version=2022-03-02
, error: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 400, RawError: {
"error": {
"code": "InvalidParameter",
"message": "The ExtendedLocation '' of the target resource does not match the ExtendedLocation 'losangeles' of the source resource.",
"target": "extendedLocation"
}
}
I0801 17:27:57.765106       1 azure_armclient.go:548] Received error in put.send: resourceID: /subscriptions/xxx/resourceGroups/mc_e2erg-ebld99563156-pzypqanubzn_e2eaks-qpj_westus/providers/Microsoft.Compute/snapshots/snapshot-ec660e34-1f38-41de-9b1a-093aee63d751, error: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 400, RawError: {
"error": {
"code": "InvalidParameter",
"message": "The ExtendedLocation '' of the target resource does not match the ExtendedLocation 'losangeles' of the source resource.",
"target": "extendedLocation"
}
}
I0801 17:27:57.765145       1 azure_snapshotclient.go:245] Received error in snapshot.put.request: resourceID: /subscriptions/xxx/resourceGroups/mc_e2erg-ebld99563156-pzypqanubzn_e2eaks-qpj_westus/providers/Microsoft.Compute/snapshots/snapshot-ec660e34-1f38-41de-9b1a-093aee63d751, error: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 400, RawError: {
"error": {
"code": "InvalidParameter",
"message": "The ExtendedLocation '' of the target resource does not match the ExtendedLocation 'losangeles' of the source resource.",
"target": "extendedLocation"
}
}
I0801 17:27:57.765293       1 azure_metrics.go:115] "Observed Request Latency" latency_seconds=0.33944254 request="azuredisk_csi_driver_controller_create_snapshot" resource_group="mc_e2erg-ebld99563156-pzypqanubzn_e2eaks-qpj_westus" subscription_id="xxx" source="disk.csi.azure.com" source_resource_id="/subscriptions/xxx/resourceGroups/mc_e2erg-ebld99563156-pzypqanubzn_e2eaks-qpj_westus/providers/Microsoft.Compute/disks/pvc-54b33ee8-ab52-444e-874e-82845edf6564" snapshot_name="snapshot-ec660e34-1f38-41de-9b1a-093aee63d751" result_code="failed_csi_driver_controller_create_snapshot"
E0801 17:27:57.765321       1 utils.go:82] GRPC error: rpc error: code = Internal desc = create snapshot error: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 400, RawError: {
"error": {
"code": "InvalidParameter",
"message": "The ExtendedLocation '' of the target resource does not match the ExtendedLocation 'losangeles' of the source resource.",
"target": "extendedLocation"
}
}
```

</details>

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
