### PR TITLE
fix: support attach operations after premiumV2 disk migration

### DIFF
--- a/pkg/azuredisk/azure_controller_common.go
+++ b/pkg/azuredisk/azure_controller_common.go
@@ -167,6 +167,10 @@ func (c *controllerCommon) AttachDisk(ctx context.Context, diskName, diskURI str
 				return -1, fmt.Errorf("state of disk(%s) is %s, not in expected %s state", diskURI, *disk.Properties.DiskState, armcompute.DiskStateUnattached)
 			}
 		}
+		if disk.SKU != nil && disk.SKU.Name != nil && *disk.SKU.Name == armcompute.DiskStorageAccountTypesPremiumV2LRS {
+			klog.V(2).Infof("disk(%s) is PremiumV2LRS and only supports None caching mode", diskURI)
+			cachingMode = armcompute.CachingTypesNone
+		}
 
 		if v, ok := disk.Tags[WriteAcceleratorEnabled]; ok {
 			if v != nil && strings.EqualFold(*v, "true") {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Customers can use VAC to migrate `PremiumLRS` disks to `PremiumV2LRS` disks while they are detached from the VM. While the driver already sets caching mode to `None` when it creates a `PremiumV2LRS` disk, it still defaults to either the caching mode set in the `VolumeContext` or to `ReadOnly` caching when it attaches the disk. Because caching in the `VolumeContext` defaults and is set to `ReadOnly` for `PremiumLRS` disks, to support attach operation after the migration, the driver must set the caching mode to `None` explicitly when it attaches a `PremiumV2LRS` disk.


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
