### PR TITLE
fix: vm-type is not overriding as expected

### DIFF
--- a/pkg/azuredisk/azuredisk.go
+++ b/pkg/azuredisk/azuredisk.go
@@ -218,10 +218,6 @@ func newDriverV1(options *DriverOptions) *Driver {
 	driver.cloud = cloud
 
 	if driver.cloud != nil {
-		driver.diskController = NewManagedDiskController(driver.cloud)
-		driver.diskController.DisableUpdateCache = driver.disableUpdateCache
-		driver.diskController.AttachDetachInitialDelayInMs = int(driver.attachDetachInitialDelayInMs)
-		driver.diskController.ForceDetachBackoff = driver.forceDetachBackoff
 		driver.clientFactory = driver.cloud.ComputeClientFactory
 		if driver.vmType != "" {
 			klog.V(2).Infof("override VMType(%s) in cloud config as %s", driver.cloud.VMType, driver.vmType)
@@ -251,6 +247,11 @@ func newDriverV1(options *DriverOptions) *Driver {
 			driver.cloud.VMCacheTTLInSeconds = int(driver.vmssCacheTTLInSeconds)
 			driver.cloud.VmssCacheTTLInSeconds = int(driver.vmssCacheTTLInSeconds)
 		}
+
+		driver.diskController = NewManagedDiskController(driver.cloud)
+		driver.diskController.DisableUpdateCache = driver.disableUpdateCache
+		driver.diskController.AttachDetachInitialDelayInMs = int(driver.attachDetachInitialDelayInMs)
+		driver.diskController.ForceDetachBackoff = driver.forceDetachBackoff
 	}
 
 	driver.deviceHelper = optimization.NewSafeDeviceHelper()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

**What this PR does / why we need it**:

fix: vm-type is not overriding as expected

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2533 

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
azuredisk log:
```
I1104 06:08:41.447295       1 azuredisk.go:223] override VMType(vmss) in cloud config as standard
I1104 06:08:41.447305       1 azuredisk.go:230] disable UseInstanceMetadata for controller
I1104 06:08:41.447316       1 azuredisk.go:242] cloud: AzurePublicCloud, location: eastus2, rg: MC_aks-yxytest_group_aks-yxytest_eastus2, VMType: standard, PrimaryScaleSetName: aks-userpool-34645390-vmss, PrimaryAvailabilitySetName: , DisableAvailabilitySetNodes: false
I1104 06:08:41.450388       1 mount_linux.go:285] 'umount /tmp/kubelet-detect-safe-umount492110992' failed with: exit status 32, output: umount: /tmp/kubelet-detect-safe-umount492110992: must be superuser to unmount.
I1104 06:08:41.450432       1 mount_linux.go:287] Detected umount with unsafe 'not mounted' behavior
I1104 06:08:41.450485       1 driver.go:82] Enabling controller service capability: CREATE_DELETE_VOLUME
I1104 06:08:41.450493       1 driver.go:82] Enabling controller service capability: PUBLISH_UNPUBLISH_VOLUME
```
test to add a log in `GetNodeVMSet` function to print az.VMType, and it returns:
```
I1104 08:09:17.486821       1 azure.go:1498] getNodeVMSet: vmType is "standard", return VMSet directly
```
The VMType is overrided as standard

**Release note**:
```
none
```
