### PR TITLE
Revert "chore: upgrade to base image alpine 3.20.2"

### DIFF
--- a/pkg/azurediskplugin/Dockerfile
+++ b/pkg/azurediskplugin/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.20.2
+FROM alpine:3.18.4
 RUN apk upgrade --available --no-cache && \
     apk add --no-cache util-linux e2fsprogs e2fsprogs-extra ca-certificates udev xfsprogs xfsprogs-extra btrfs-progs btrfs-progs-extra
 


### PR DESCRIPTION
Reverts kubernetes-sigs/azuredisk-csi-driver#2490

alpine base image 3.20.2 works on `Ubuntu 22.04.4 LTS   6.5.0-1024-azure`, but it's broken on `Ubuntu 22.04.5 LTS   5.15.0-1073-azure` with xfs mount with following error:

```
'could not format /dev/disk/azure/scsi1/lun0(lun: 0), and mount it at /var/lib/kubelet/plugins/kubernetes.io/csi/disk.csi.azure.com/90564df3fd2ed9991ce81f6ca7aab17a7f871e17839da16460c96c3f5dceb0da/globalmount, failed with mount failed: exit status 32

Mounting command: mount
Mounting arguments: -t xfs -o nouuid,defaults /dev/disk/azure/scsi1/lun0 /var/lib/kubelet/plugins/kubernetes.io/csi/disk.csi.azure.com/90564df3fd2ed9991ce81f6ca7aab17a7f871e17839da16460c96c3f5dceb0da/globalmount
Output: mount: /var/lib/kubelet/plugins/kubernetes.io/csi/disk.csi.azure.com/90564df3fd2ed9991ce81f6ca7aab17a7f871e17839da16460c96c3f5dceb0da/globalmount: wrong fs type, bad option, bad superblock on /dev/sdc, missing codepage or helper program, or other error.'
```