### PR TITLE
[WIP]vendor: adopt autolun API

### DIFF
--- a/pkg/azuredisk/azure_controller_common.go
+++ b/pkg/azuredisk/azure_controller_common.go
@@ -124,6 +124,7 @@ func (c *controllerCommon) AttachDisk(ctx context.Context, diskName, diskURI str
 			if err != nil {
 				return -1, err
 			}
+			klog.V(4).Infof("azureDisk - found disk(%s) is already attached to node %s", diskURI, *disk.ManagedBy)
 			attachedNode, err := vmset.GetNodeNameByProviderID(ctx, *disk.ManagedBy)
 			if err != nil {
 				return -1, err

--- a/vendor/sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachinescalesetvmclient/custom.go
+++ b/vendor/sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachinescalesetvmclient/custom.go
@@ -118,3 +118,8 @@ func (client *Client) ListVMInstanceView(ctx context.Context, resourceGroupName 
 	}
 	return result, nil
 }
+
+// AttachDetachDataDisks attaches or detaches a list of managed data disks to/from a VM.
+func (client *Client) AttachDetachDataDisks(ctx context.Context, resourceGroupName, VMScaleSetName, instanceID string, parameters armcompute.AttachDetachDataDisksRequest) (*armcompute.VirtualMachineScaleSetVMsClientAttachDetachDataDisksResponse, error) {
+	return utils.NewPollerWrapper(client.VirtualMachineScaleSetVMsClient.BeginAttachDetachDataDisks(ctx, resourceGroupName, VMScaleSetName, instanceID, parameters, nil)).WaitforPollerResp(ctx)
+}

--- a/vendor/sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachinescalesetvmclient/interface.go
+++ b/vendor/sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachinescalesetvmclient/interface.go
@@ -37,4 +37,7 @@ type Interface interface {
 	Update(ctx context.Context, resourceGroupName string, VMScaleSetName string, instanceID string, parameters armcompute.VirtualMachineScaleSetVM) (*armcompute.VirtualMachineScaleSetVM, error)
 	GetInstanceView(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string) (*armcompute.VirtualMachineScaleSetVMInstanceView, error)
 	BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, parameters armcompute.VirtualMachineScaleSetVM, options *armcompute.VirtualMachineScaleSetVMsClientBeginUpdateOptions) (*runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse], error)
+
+	// AttachDetachDataDisks attaches or detaches a list of managed data disks to/from a VM.
+	AttachDetachDataDisks(ctx context.Context, resourceGroupName, VMScaleSetName, instanceID string, parameters armcompute.AttachDetachDataDisksRequest) (*armcompute.VirtualMachineScaleSetVMsClientAttachDetachDataDisksResponse, error)
 }

--- a/vendor/sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachinescalesetvmclient/mock_virtualmachinescalesetvmclient/interface.go
+++ b/vendor/sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachinescalesetvmclient/mock_virtualmachinescalesetvmclient/interface.go
@@ -310,6 +310,22 @@ func (mr *MockInterfaceMockRecorder) Update(ctx, resourceGroupName, VMScaleSetNa
 	return &MockInterfaceUpdateCall{Call: call}
 }
 
+// AttachDetachDataDisks mocks base method.
+func (m *MockInterface) AttachDetachDataDisks(ctx context.Context, resourceGroupName, VMScaleSetName, instanceID string, parameters armcompute.AttachDetachDataDisksRequest) (*armcompute.VirtualMachineScaleSetVMsClientAttachDetachDataDisksResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AttachDetachDataDisks", ctx, resourceGroupName, VMScaleSetName, instanceID, parameters)
+	ret0, _ := ret[0].(*armcompute.VirtualMachineScaleSetVMsClientAttachDetachDataDisksResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AttachDetachDataDisks indicates an expected call of Update.
+func (mr *MockInterfaceMockRecorder) AttachDetachDataDisks(ctx, resourceGroupName, VMScaleSetName, instanceID, parameters any) *MockInterfaceUpdateCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachDetachDataDisks", reflect.TypeOf((*MockInterface)(nil).Update), ctx, resourceGroupName, VMScaleSetName, instanceID, parameters)
+	return &MockInterfaceUpdateCall{Call: call}
+}
+
 // MockInterfaceUpdateCall wrap *gomock.Call
 type MockInterfaceUpdateCall struct {
 	*gomock.Call


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
adopt autolun API as POC, while since we have not migrated to track2 sdk for VMSSVM client, this is missing updateCache functionality which could reduce vmss list API calls

https://learn.microsoft.com/en-us/rest/api/compute/virtual-machines/attach-detach-data-disks

testing image: andyzhangx/azuredisk-csi:v1.33.0

```
	newVM := compute.VirtualMachineScaleSetVM{
		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
			StorageProfile: &compute.StorageProfile{
				DataDisks: result.StorageProfile.DataDisks,
			},
		},
	}

	// clean node cache first and then update cache
	_ = ss.DeleteCacheForNode(ctx, vmName)
	if err := ss.updateCache(ctx, vmName, nodeResourceGroup, vm.VMSSName, vm.InstanceID, &newVM); err != nil {
		klog.Errorf("updateCache(%s, %s, %s, %s) failed with error: %v", vmName, nodeResourceGroup, vm.VMSSName, vm.InstanceID, err)
	}
	return nil
```

<details>

```
I0414 02:09:25.947019       1 utils.go:105] GRPC call: /csi.v1.Controller/ControllerPublishVolume
I0414 02:09:25.947045       1 utils.go:106] GRPC request: {"node_id":"aks-azlinux-22469925-vmss000000","volume_capability":{"AccessType":{"Mount":{}},"access_mode":{"mode":7}},"volume_context":{"csi.storage.k8s.io/pv/name":"pvc-a70d01eb-dfd2-4825-971c-7d93d91fddc2","csi.storage.k8s.io/pvc/name":"persistent-storage-statefulset-azuredisk-3","csi.storage.k8s.io/pvc/namespace":"default","requestedsizegib":"10","skuName":"StandardSSD_LRS","storage.kubernetes.io/csiProvisionerIdentity":"1729987942300-7415-disk.csi.azure.com"},"volume_id":"/subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks130_andy-aks130_eastus2/providers/Microsoft.Compute/disks/pvc-a70d01eb-dfd2-4825-971c-7d93d91fddc2"}
I0414 02:09:26.168103       1 azure_vmss_cache.go:425] Node aks-azlinux-22469925-vmss000000 has joined the cluster since the last VM cache refresh in NonVmssUniformNodesEntry, refreshing the cache
I0414 02:09:26.168123       1 azure_vmss_cache.go:342] refresh the cache of NonVmssUniformNodesCache in rg &{map[mc_andy-aks130_andy-aks130_eastus2:{}]}
I0414 02:09:26.377004       1 controllerserver.go:517] GetDiskLun returned: cannot find Lun for disk pvc-a70d01eb-dfd2-4825-971c-7d93d91fddc2. Initiating attaching volume /subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks130_andy-aks130_eastus2/providers/Microsoft.Compute/disks/pvc-a70d01eb-dfd2-4825-971c-7d93d91fddc2 to node aks-azlinux-22469925-vmss000000 (vmState Succeeded).
I0414 02:09:26.431645       1 azuredisk.go:568] volumeAttachments count: 8, nodeName: aks-azlinux-22469925-vmss000000
I0414 02:09:26.431700       1 controllerserver.go:543] Trying to attach volume /subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks130_andy-aks130_eastus2/providers/Microsoft.Compute/disks/pvc-a70d01eb-dfd2-4825-971c-7d93d91fddc2 to node aks-azlinux-22469925-vmss000000
I0414 02:09:26.431735       1 azure_controller_common.go:215] wait 1000ms for more requests on node aks-azlinux-22469925-vmss000000, current disk attach: /subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks130_andy-aks130_eastus2/providers/Microsoft.Compute/disks/pvc-a70d01eb-dfd2-4825-971c-7d93d91fddc2
I0414 02:09:27.432090       1 azure_controller_common.go:229] Trying to attach volume /subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks130_andy-aks130_eastus2/providers/Microsoft.Compute/disks/pvc-a70d01eb-dfd2-4825-971c-7d93d91fddc2 lun 2 to node aks-azlinux-22469925-vmss000000, diskMap len:1, map[/subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourcegroups/mc_andy-aks130_andy-aks130_eastus2/providers/microsoft.compute/disks/pvc-a70d01eb-dfd2-4825-971c-7d93d91fddc2:0xc000889b00]
I0414 02:09:27.432127       1 azure_controller_vmss.go:101] azureDisk - update: rg(MC_andy-aks130_andy-aks130_eastus2) vm(aks-azlinux-22469925-vmss000000) - attach disk list(map[/subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourcegroups/mc_andy-aks130_andy-aks130_eastus2/providers/microsoft.compute/disks/pvc-a70d01eb-dfd2-4825-971c-7d93d91fddc2:0xc000889b00])
I0414 02:09:36.159829       1 azure_controller_vmss.go:103] azureDisk - update: rg(MC_andy-aks130_andy-aks130_eastus2) vm(aks-azlinux-22469925-vmss000000) - attach disk list(map[/subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourcegroups/mc_andy-aks130_andy-aks130_eastus2/providers/microsoft.compute/disks/pvc-a70d01eb-dfd2-4825-971c-7d93d91fddc2:0xc000889b00]) returned with <nil>
I0414 02:09:36.159872       1 azure_vmss_cache.go:328] updateCache(aks-azlinux-22469925-vmss, MC_andy-aks130_andy-aks130_eastus2, aks-azlinux-22469925-vmss000000) for cacheKey(mc_andy-aks130_andy-aks130_eastus2/aks-azlinux-22469925-vmss) updated successfully
I0414 02:09:36.159887       1 azure_vmss_cache.go:286] DeleteCacheForNode(mc_andy-aks130_andy-aks130_eastus2, aks-azlinux-22469925-vmss, aks-azlinux-22469925-vmss000000) successfully
I0414 02:09:36.159899       1 azure_vmss_cache.go:425] Node aks-azlinux-22469925-vmss000000 has joined the cluster since the last VM cache refresh in NonVmssUniformNodesEntry, refreshing the cache
I0414 02:09:36.159908       1 azure_vmss_cache.go:342] refresh the cache of NonVmssUniformNodesCache in rg &{map[mc_andy-aks130_andy-aks130_eastus2:{}]}
I0414 02:09:36.282424       1 azure_vmss.go:253] Couldn't find VMSS VM with nodeName aks-azlinux-22469925-vmss000000, refreshing the cache(vmss: aks-azlinux-22469925-vmss, rg: mc_andy-aks130_andy-aks130_eastus2)
I0414 02:09:36.402422       1 azure_controller_common.go:499] azureDisk - found disk: lun 2 name pvc-a70d01eb-dfd2-4825-971c-7d93d91fddc2 uri /subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks130_andy-aks130_eastus2/providers/Microsoft.Compute/disks/pvc-a70d01eb-dfd2-4825-971c-7d93d91fddc2
I0414 02:09:36.402455       1 controllerserver.go:552] Attach operation successful: volume /subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks130_andy-aks130_eastus2/providers/Microsoft.Compute/disks/pvc-a70d01eb-dfd2-4825-971c-7d93d91fddc2 attached to node aks-azlinux-22469925-vmss000000.
I0414 02:09:36.402470       1 controllerserver.go:576] attach volume /subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks130_andy-aks130_eastus2/providers/Microsoft.Compute/disks/pvc-a70d01eb-dfd2-4825-971c-7d93d91fddc2 to node aks-azlinux-22469925-vmss000000 successfully
I0414 02:09:36.402508       1 azure_metrics.go:105] "Observed Request Latency" latency_seconds=10.234390089 request="azuredisk_csi_driver_controller_publish_volume" resource_group="mc_andy-aks130_andy-aks130_eastus2" subscription_id="b9d2281e-dcd5-4dfd-9a97-0d50377cdf76" source="disk.csi.azure.com" volumeid="/subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks130_andy-aks130_eastus2/providers/Microsoft.Compute/disks/pvc-a70d01eb-dfd2-4825-971c-7d93d91fddc2" node="aks-azlinux-22469925-vmss000000" result_code="succeeded"
I0414 02:09:36.402523       1 utils.go:112] GRPC response: {"publish_context":{"LUN":"2"}}
```

</details>

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
