### PR TITLE
feat: pick region when zonal node pool is in different region

### DIFF
--- a/pkg/azureutils/azure_disk_utils.go
+++ b/pkg/azureutils/azure_disk_utils.go
@@ -432,6 +432,15 @@ func IsValidAvailabilityZone(zone, region string) bool {
 	return strings.HasPrefix(zone, fmt.Sprintf("%s-", region))
 }
 
+// GetRegionFromAvailabilityZone returns region from availability zone if it's in format of <region>-<zone-id>
+func GetRegionFromAvailabilityZone(zone string) string {
+	parts := strings.Split(zone, "-")
+	if len(parts) == 2 {
+		return parts[0]
+	}
+	return ""
+}
+
 func IsValidDiskURI(diskURI string) error {
 	if strings.Index(strings.ToLower(diskURI), "/subscriptions/") != 0 {
 		return fmt.Errorf("invalid DiskURI: %v, correct format: %v", diskURI, diskURISupportedManaged)

--- a/pkg/azureutils/azure_disk_utils_test.go
+++ b/pkg/azureutils/azure_disk_utils_test.go
@@ -864,6 +864,25 @@ func TestIsAvailabilityZone(t *testing.T) {
 	}
 }
 
+func TestGetRegionFromAvailabilityZone(t *testing.T) {
+	tests := []struct {
+		desc     string
+		zone     string
+		expected string
+	}{
+		{"empty string", "", ""},
+		{"invallid zone", "1", ""},
+		{"valid zone", "eastus-2", "eastus"},
+	}
+
+	for _, test := range tests {
+		result := GetRegionFromAvailabilityZone(test.zone)
+		if result != test.expected {
+			t.Errorf("test [%q] got unexpected result: %v != %v", test.desc, result, test.expected)
+		}
+	}
+}
+
 func TestIsAzureStackCloud(t *testing.T) {
 	tests := []struct {
 		cloud                  string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: pick region when zonal node pool is in different region, this only works when in a zonal node pool 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

<details>

```
I1120 08:59:32.941891       1 utils.go:105] GRPC call: /csi.v1.Controller/CreateVolume
I1120 08:59:32.941921       1 utils.go:106] GRPC request: {"accessibility_requirements":{"preferred":[{"segments":{"topology.disk.csi.azure.com/zone":"eastus2-1","topology.kubernetes.io/zone":"eastus2-1"}}],"requisite":[{"segments":{"topology.disk.csi.azure.com/zone":"eastus2-1","topology.kubernetes.io/zone":"eastus2-1"}}]},"capacity_range":{"required_bytes":10737418240},"name":"pvc-a40152bb-3ca5-4951-9368-eb722d871401","parameters":{"csi.storage.k8s.io/pv/name":"pvc-a40152bb-3ca5-4951-9368-eb722d871401","csi.storage.k8s.io/pvc/name":"persistent-storage-statefulset-azuredisk3-3","csi.storage.k8s.io/pvc/namespace":"default","fsType":"xfs","skuName":"StandardSSD_LRS"},"volume_capabilities":[{"AccessType":{"Mount":{"fs_type":"xfs"}},"access_mode":{"mode":7}}]}
I1120 08:59:32.942362       1 controllerserver.go:272] begin to create azure disk(pvc-a40152bb-3ca5-4951-9368-eb722d871401) account type(StandardSSD_LRS) rg(MC_andy-aks130_andy-aks130_eastus2) location(eastus2) size(10) diskZone(eastus2-1) maxShares(0)
I1120 08:59:32.942405       1 azure_managedDiskController.go:112] azureDisk - creating new managed Name:pvc-a40152bb-3ca5-4951-9368-eb722d871401 StorageAccountType:StandardSSD_LRS Size:10
I1120 08:59:35.781252       1 azure_managedDiskController.go:303] azureDisk - created new MD Name:pvc-a40152bb-3ca5-4951-9368-eb722d871401 StorageAccountType:StandardSSD_LRS Size:10
I1120 08:59:35.781314       1 controllerserver.go:332] create azure disk(pvc-a40152bb-3ca5-4951-9368-eb722d871401) account type(StandardSSD_LRS) rg(MC_andy-aks130_andy-aks130_eastus2) location(eastus2) size(10) tags(map[kubernetes.io-created-for-pv-name:pvc-a40152bb-3ca5-4951-9368-eb722d871401 kubernetes.io-created-for-pvc-name:persistent-storage-statefulset-azuredisk3-3 kubernetes.io-created-for-pvc-namespace:default]) successfully
I1120 08:59:35.781383       1 azure_metrics.go:118] "Observed Request Latency" latency_seconds=2.838939704 request="azuredisk_csi_driver_controller_create_volume" resource_group="mc_andy-aks130_andy-aks130_eastus2" subscription_id="b9d2281e-dcd5-4dfd-9a97-0d50377cdf76" source="disk.csi.azure.com" volumeid="/subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks130_andy-aks130_eastus2/providers/Microsoft.Compute/disks/pvc-a40152bb-3ca5-4951-9368-eb722d871401" result_code="succeeded"
I1120 08:59:35.781413       1 utils.go:112] GRPC response: {"volume":{"accessible_topology":[{"segments":{"topology.disk.csi.azure.com/zone":"eastus2-1"}}],"capacity_bytes":10737418240,"content_source":{"Type":null},"volume_context":{"csi.storage.k8s.io/pv/name":"pvc-a40152bb-3ca5-4951-9368-eb722d871401","csi.storage.k8s.io/pvc/name":"persistent-storage-statefulset-azuredisk3-3","csi.storage.k8s.io/pvc/namespace":"default","fsType":"xfs","requestedsizegib":"10","skuName":"StandardSSD_LRS"},"volume_id":"/subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks130_andy-aks130_eastus2/providers/Microsoft.Compute/disks/pvc-a40152bb-3ca5-4951-9368-eb722d871401"}}
```

</details>

**Release note**:
```
feat: pick region when zonal node pool is in different region
```
