### PR TITLE
fix: support disk discovery on Windows Gen2 and v6 VM sku

### DIFF
--- a/pkg/azuredisk/azuredisk.go
+++ b/pkg/azuredisk/azuredisk.go
@@ -115,6 +115,7 @@ type DriverCore struct {
 	attachDetachInitialDelayInMs int64
 	vmType                       string
 	enableWindowsHostProcess     bool
+	listDisksUsingWinCIM         bool
 	getNodeIDFromIMDS            bool
 	enableOtelTracing            bool
 	shouldWaitForSnapshotReady   bool
@@ -170,6 +171,7 @@ func newDriverV1(options *DriverOptions) *Driver {
 	driver.volStatsCacheExpireInMinutes = options.VolStatsCacheExpireInMinutes
 	driver.vmType = options.VMType
 	driver.enableWindowsHostProcess = options.EnableWindowsHostProcess
+	driver.listDisksUsingWinCIM = options.ListDisksUsingWinCIM
 	driver.getNodeIDFromIMDS = options.GetNodeIDFromIMDS
 	driver.enableOtelTracing = options.EnableOtelTracing
 	driver.shouldWaitForSnapshotReady = options.WaitForSnapshotReady
@@ -267,7 +269,7 @@ func newDriverV1(options *DriverOptions) *Driver {
 		}
 	}
 
-	driver.mounter, err = mounter.NewSafeMounter(driver.enableWindowsHostProcess, driver.useCSIProxyGAInterface, int(driver.maxConcurrentFormat), time.Duration(driver.concurrentFormatTimeout)*time.Second)
+	driver.mounter, err = mounter.NewSafeMounter(driver.enableWindowsHostProcess, driver.listDisksUsingWinCIM, driver.useCSIProxyGAInterface, int(driver.maxConcurrentFormat), time.Duration(driver.concurrentFormatTimeout)*time.Second)
 	if err != nil {
 		klog.Fatalf("Failed to get safe mounter. Error: %v", err)
 	}

--- a/pkg/azuredisk/azuredisk_option.go
+++ b/pkg/azuredisk/azuredisk_option.go
@@ -53,6 +53,7 @@ type DriverOptions struct {
 	VolStatsCacheExpireInMinutes int64
 	VMType                       string
 	EnableWindowsHostProcess     bool
+	ListDisksUsingWinCIM         bool
 	GetNodeIDFromIMDS            bool
 	WaitForSnapshotReady         bool
 	CheckDiskLUNCollision        bool
@@ -97,6 +98,7 @@ func (o *DriverOptions) AddFlags() *flag.FlagSet {
 	fs.Int64Var(&o.VolStatsCacheExpireInMinutes, "vol-stats-cache-expire-in-minutes", 10, "The cache expire time in minutes for volume stats cache")
 	fs.StringVar(&o.VMType, "vm-type", "", "type of agent node. available values: vmss, standard")
 	fs.BoolVar(&o.EnableWindowsHostProcess, "enable-windows-host-process", false, "enable windows host process")
+	fs.BoolVar(&o.ListDisksUsingWinCIM, "list-disks-using-win-cim", true, "list disks using CIM API on Windows")
 	fs.BoolVar(&o.GetNodeIDFromIMDS, "get-nodeid-from-imds", false, "boolean flag to get NodeID from IMDS")
 	fs.BoolVar(&o.WaitForSnapshotReady, "wait-for-snapshot-ready", true, "boolean flag to wait for snapshot ready when creating snapshot in same region")
 	fs.BoolVar(&o.CheckDiskLUNCollision, "check-disk-lun-collision", true, "boolean flag to check disk lun collisio before attaching disk")

--- a/pkg/azuredisk/azuredisk_v2.go
+++ b/pkg/azuredisk/azuredisk_v2.go
@@ -144,7 +144,7 @@ func newDriverV2(options *DriverOptions) *DriverV2 {
 		}
 	}
 
-	driver.mounter, err = mounter.NewSafeMounter(driver.enableWindowsHostProcess, driver.useCSIProxyGAInterface, int(driver.maxConcurrentFormat), time.Duration(driver.concurrentFormatTimeout)*time.Second)
+	driver.mounter, err = mounter.NewSafeMounter(driver.enableWindowsHostProcess, driver.listDisksUsingWinCIM, driver.useCSIProxyGAInterface, int(driver.maxConcurrentFormat), time.Duration(driver.concurrentFormatTimeout)*time.Second)
 	if err != nil {
 		klog.Fatalf("Failed to get safe mounter. Error: %v", err)
 	}

--- a/pkg/azuredisk/fake_azuredisk.go
+++ b/pkg/azuredisk/fake_azuredisk.go
@@ -125,7 +125,7 @@ func newFakeDriverV1(ctrl *gomock.Controller) (*fakeDriverV1, error) {
 	driver.diskController = NewManagedDiskController(driver.cloud)
 	driver.clientFactory = driver.cloud.ComputeClientFactory
 
-	mounter, err := mounter.NewSafeMounter(true, driver.useCSIProxyGAInterface, int(driver.maxConcurrentFormat), time.Duration(driver.concurrentFormatTimeout)*time.Second)
+	mounter, err := mounter.NewSafeMounter(true, true, driver.useCSIProxyGAInterface, int(driver.maxConcurrentFormat), time.Duration(driver.concurrentFormatTimeout)*time.Second)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/azuredisk/fake_azuredisk_v2.go
+++ b/pkg/azuredisk/fake_azuredisk_v2.go
@@ -76,7 +76,7 @@ func newFakeDriverV2(ctrl *gomock.Controller) (*fakeDriverV2, error) {
 	driver.diskController = NewManagedDiskController(driver.cloud)
 	driver.clientFactory = driver.cloud.ComputeClientFactory
 
-	mounter, err := mounter.NewSafeMounter(true, driver.useCSIProxyGAInterface, int(driver.maxConcurrentFormat), time.Duration(driver.concurrentFormatTimeout)*time.Second)
+	mounter, err := mounter.NewSafeMounter(true, true, driver.useCSIProxyGAInterface, int(driver.maxConcurrentFormat), time.Duration(driver.concurrentFormatTimeout)*time.Second)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mounter/fake_safe_mounter.go
+++ b/pkg/mounter/fake_safe_mounter.go
@@ -36,7 +36,7 @@ type FakeSafeMounter struct {
 // NewFakeSafeMounter creates a mount.SafeFormatAndMount instance suitable for use in unit tests.
 func NewFakeSafeMounter() (*mount.SafeFormatAndMount, error) {
 	if runtime.GOOS == "windows" {
-		return NewSafeMounter(true, true, 2, time.Duration(120)*time.Second)
+		return NewSafeMounter(true, true, true, 2, time.Duration(120)*time.Second)
 	}
 
 	fakeSafeMounter := FakeSafeMounter{}

--- a/pkg/mounter/safe_mounter_unix.go
+++ b/pkg/mounter/safe_mounter_unix.go
@@ -26,7 +26,7 @@ import (
 	utilexec "k8s.io/utils/exec"
 )
 
-func NewSafeMounter(_, _ bool, maxConcurrentFormat int, concurrentFormatTimeout time.Duration) (*mount.SafeFormatAndMount, error) {
+func NewSafeMounter(_, _, _ bool, maxConcurrentFormat int, concurrentFormatTimeout time.Duration) (*mount.SafeFormatAndMount, error) {
 	opt := mount.WithMaxConcurrentFormat(maxConcurrentFormat, concurrentFormatTimeout)
 	return mount.NewSafeFormatAndMount(mount.New(""), utilexec.New(), opt), nil
 }

--- a/pkg/mounter/safe_mounter_unix_test.go
+++ b/pkg/mounter/safe_mounter_unix_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestNewSafeMounter(t *testing.T) {
-	resp, err := NewSafeMounter(true, true, 2, time.Duration(120)*time.Second)
+	resp, err := NewSafeMounter(true, true, true, 2, time.Duration(120)*time.Second)
 	assert.NotNil(t, resp)
 	assert.Nil(t, err)
 }

--- a/pkg/mounter/safe_mounter_windows.go
+++ b/pkg/mounter/safe_mounter_windows.go
@@ -412,11 +412,11 @@ func newCSIProxyMounter() (*csiProxyMounter, error) {
 	}, nil
 }
 
-func NewSafeMounter(enableWindowsHostProcess, useCSIProxyGAInterface bool, maxConcurrentFormat int, concurrentFormatTimeout time.Duration) (*mount.SafeFormatAndMount, error) {
+func NewSafeMounter(enableWindowsHostProcess, listDisksUsingWinCIM, useCSIProxyGAInterface bool, maxConcurrentFormat int, concurrentFormatTimeout time.Duration) (*mount.SafeFormatAndMount, error) {
 	if enableWindowsHostProcess {
 		klog.V(2).Infof("using windows host process mounter")
 		opt := mount.WithMaxConcurrentFormat(maxConcurrentFormat, concurrentFormatTimeout)
-		return mount.NewSafeFormatAndMount(NewWinMounter(), utilexec.New(), opt), nil
+		return mount.NewSafeFormatAndMount(NewWinMounter(listDisksUsingWinCIM), utilexec.New(), opt), nil
 	} else {
 		if useCSIProxyGAInterface {
 			csiProxyMounter, err := newCSIProxyMounter()

--- a/pkg/os/disk/disk.go
+++ b/pkg/os/disk/disk.go
@@ -42,9 +42,9 @@ const (
 	IOCTL_STORAGE_QUERY_PROPERTY    = 0x002d1400
 )
 
-// ListDiskLocations - constructs a map with the disk number as the key and the DiskLocation structure
+// ListDisksUsingCIM - constructs a map with the disk number as the key and the DiskLocation structure
 // as the value. The DiskLocation struct has various fields like the Adapter, Bus, Target and LUNID.
-func ListDiskLocations() (map[uint32]Location, error) {
+func ListDisksUsingCIM() (map[uint32]Location, error) {
 	// sample response
 	// [{
 	//    "Index":  3,
@@ -53,11 +53,12 @@ func ListDiskLocations() (map[uint32]Location, error) {
 	//    "SCSIPort":  1,
 	//    "SCSIBus":  0
 	// }, ...]
-	cmd := fmt.Sprintf("ConvertTo-Json @(Get-CimInstance win32_diskdrive|where-object -FilterScript {$_.SCSIPort -Ne 0}|Select Index,SCSILogicalUnit,SCSITargetId,SCSIPort,SCSIBus)")
+	cmd := fmt.Sprintf("ConvertTo-Json @(Get-CimInstance win32_diskdrive|Where-Object { $_.Model -eq \"Virtual_Disk NVME Premium\" -or $_.SCSIPort -Ne 0 }|Select Index,SCSILogicalUnit,SCSITargetId,SCSIPort,SCSIBus)")
 	out, err := azureutils.RunPowershellCmd(cmd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list disk location. cmd: %q, output: %q, err %v", cmd, string(out), err)
 	}
+	klog.V(6).Infof("ListDisksUsingCIM output: %s", string(out))
 
 	var getCimInstance []struct {
 		Index           uint32 `json:"Index"`
@@ -78,6 +79,67 @@ func ListDiskLocations() (map[uint32]Location, error) {
 			Bus:     strconv.Itoa(v.SCSIBus),
 			Target:  strconv.Itoa(v.SCSITargetId),
 			LUNID:   strconv.Itoa(v.SCSILogicalUnit),
+		}
+	}
+	return m, nil
+}
+
+// ListDiskLocations - constructs a map with the disk number as the key and the DiskLocation structure
+// as the value. The DiskLocation struct has various fields like the Adapter, Bus, Target and LUNID.
+func ListDiskLocations() (map[uint32]Location, error) {
+	// sample response
+	// [{
+	//    "number":  0,
+	//    "location":  "PCI Slot 3 : Adapter 0 : Port 0 : Target 1 : LUN 0"
+	// }, ...]
+	cmd := fmt.Sprintf("ConvertTo-Json @(Get-Disk | select Number, Location, PartitionStyle)")
+	out, err := azureutils.RunPowershellCmd(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list disk location. cmd: %q, output: %q, err %v", cmd, string(out), err)
+	}
+	klog.V(6).Infof("ListDiskLocations output: %s", string(out))
+
+	var getDisk []map[string]interface{}
+	err = json.Unmarshal(out, &getDisk)
+	if err != nil {
+		return nil, err
+	}
+
+	m := make(map[uint32]Location)
+	for _, v := range getDisk {
+		str := v["Location"].(string)
+		num := v["Number"].(float64)
+		partitionStyle := v["PartitionStyle"].(string)
+		if strings.EqualFold(partitionStyle, "MBR") {
+			klog.V(2).Infof("skipping MBR disk, number: %d, location: %s", int(num), str)
+			continue
+		}
+
+		found := false
+		s := strings.Split(str, ":")
+		if len(s) >= 5 {
+			var d Location
+			for _, item := range s {
+				item = strings.TrimSpace(item)
+				itemSplit := strings.Split(item, " ")
+				if len(itemSplit) == 2 {
+					found = true
+					switch strings.TrimSpace(itemSplit[0]) {
+					case "Adapter":
+						d.Adapter = strings.TrimSpace(itemSplit[1])
+					case "Target":
+						d.Target = strings.TrimSpace(itemSplit[1])
+					case "LUN":
+						d.LUNID = strings.TrimSpace(itemSplit[1])
+					default:
+						klog.Warningf("Got unknown field : %s=%s", itemSplit[0], itemSplit[1])
+					}
+				}
+			}
+
+			if found {
+				m[uint32(num)] = d
+			}
 		}
 	}
 	return m, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: support disk discovery on Windows Gen2 and v6 VM sku

Windows team provided the following info:
 - normal scsi data disk
`"Model":  "Microsoft Virtual Disk"`
 - v6 nvme controller data disk
 `"Model":  "Virtual_Disk NVME Premium"`

thus I think we could use this filter: `ConvertTo-Json @(Get-CimInstance win32_diskdrive | Where-Object { $_.Model -eq "Virtual_Disk NVME Premium" -or $_.SCSIPort -Ne 0 } | Select-Object Index, SCSILogicalUnit, SCSITargetId, SCSIPort, SCSIBus, Model)`, thus we could fix this issue permanently.

 - original query
 ```
ConvertTo-Json @(Get-Disk | select Number, Location)
```

<details>

```
 - scsi data disk
PS C:\> ConvertTo-Json @(Get-CimInstance win32_diskdrive | Where-Object { $_.Model -like "*Virtual?Disk*" } | Select-Object Index, SCSILogicalUnit, SCSITargetId, SCSIPort, SCSIBus, Model)
[
    {
        "Index":  2,
        "SCSILogicalUnit":  0,
        "SCSITargetId":  0,
        "SCSIPort":  3,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  3,
        "SCSILogicalUnit":  1,
        "SCSITargetId":  0,
        "SCSIPort":  3,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  4,
        "SCSILogicalUnit":  2,
        "SCSITargetId":  0,
        "SCSIPort":  3,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  5,
        "SCSILogicalUnit":  3,
        "SCSITargetId":  0,
        "SCSIPort":  3,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    }
]

- v6 nvme controller data disk
PS C:\hpc> ConvertTo-Json @(Get-CimInstance win32_diskdrive | Where-Object { $_.Model -like "*Virtual?Disk*" } | Select-Object Index, SCSILogicalUnit, SCSITargetId, SCSIPort, SCSIBus, Model)
[
    {
        "Index":  0,
        "SCSILogicalUnit":  0,
        "SCSITargetId":  0,
        "SCSIPort":  0,
        "SCSIBus":  0,
        "Model":  "Virtual_Disk NVME Premium"
    },
    {
        "Index":  2,
        "SCSILogicalUnit":  1,
        "SCSITargetId":  0,
        "SCSIPort":  0,
        "SCSIBus":  0,
        "Model":  "Virtual_Disk NVMe Premium"
    },
    {
        "Index":  3,
        "SCSILogicalUnit":  2,
        "SCSITargetId":  0,
        "SCSIPort":  0,
        "SCSIBus":  0,
        "Model":  "Virtual_Disk NVMe Premium"
    },
    {
        "Index":  4,
        "SCSILogicalUnit":  3,
        "SCSITargetId":  0,
        "SCSIPort":  0,
        "SCSIBus":  0,
        "Model":  "Virtual_Disk NVMe Premium"
    },
    {
        "Index":  5,
        "SCSILogicalUnit":  4,
        "SCSITargetId":  0,
        "SCSIPort":  0,
        "SCSIBus":  0,
        "Model":  "Virtual_Disk NVMe Premium"
    }
]
```

</details>

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2365, #2661

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: support disk discovery on Windows Gen2 and v6 VM sku
```
