### PR TITLE
chore: increase format timeout as 300s by default

### DIFF
--- a/pkg/azuredisk/azuredisk_option.go
+++ b/pkg/azuredisk/azuredisk_option.go
@@ -106,7 +106,7 @@ func (o *DriverOptions) AddFlags() *flag.FlagSet {
 	fs.BoolVar(&o.RemoveNotReadyTaint, "remove-not-ready-taint", true, "remove NotReady taint from node when node is ready")
 	fs.StringVar(&o.Endpoint, "endpoint", "unix://tmp/csi.sock", "CSI endpoint")
 	fs.Int64Var(&o.MaxConcurrentFormat, "max-concurrent-format", 2, "maximum number of concurrent format exec calls")
-	fs.Int64Var(&o.ConcurrentFormatTimeout, "concurrent-format-timeout", 100, "maximum time in seconds duration of a format operation before its concurrency token is released")
+	fs.Int64Var(&o.ConcurrentFormatTimeout, "concurrent-format-timeout", 300, "maximum time in seconds duration of a format operation before its concurrency token is released")
 
 	return fs
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
chore: increase format timeout as 300s by default

I have observed that it costs 83s to format a 30TB disk:
```
I1126 07:00:17.583179       1 utils.go:105] GRPC call: /csi.v1.Node/NodeStageVolume
I1126 07:00:17.583205       1 utils.go:106] GRPC request: {"publish_context":{"LUN":"0"},"staging_target_path":"/var/lib/kubelet/plugins/kubernetes.io/csi/disk.csi.azure.com/a621ec8e71c62e341ae812c978f90f00af8507b7dcb7380a9430e86b5fe65ac8/globalmount","volume_capability":{"AccessType":{"Mount":{}},"access_mode":{"mode":7}},"volume_context":{"csi.storage.k8s.io/pv/name":"pvc-c0cc6ce6-039c-43a2-a0e1-99f9261364b0","csi.storage.k8s.io/pvc/name":"persistent-storage-statefulset-azuredisk-bigdisk-1","csi.storage.k8s.io/pvc/namespace":"default","requestedsizegib":"30720","skuName":"StandardSSD_LRS","storage.kubernetes.io/csiProvisionerIdentity":"1730541755160-5145-disk.csi.azure.com"},"volume_id":"/subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks129_andy-aks129_eastus2/providers/Microsoft.Compute/disks/pvc-c0cc6ce6-039c-43a2-a0e1-99f9261364b0"}
I1126 07:00:17.589777       1 azure_common_linux.go:185] azureDisk - found /dev/disk/azure/scsi1/lun0 by sdc under /dev/disk/azure/scsi1/
I1126 07:00:17.590191       1 nodeserver.go:157] NodeStageVolume: formatting /dev/disk/azure/scsi1/lun0 and mounting at /var/lib/kubelet/plugins/kubernetes.io/csi/disk.csi.azure.com/a621ec8e71c62e341ae812c978f90f00af8507b7dcb7380a9430e86b5fe65ac8/globalmount with mount options([])
I1126 07:00:17.590211       1 mount_linux.go:577] Attempting to determine if disk "/dev/disk/azure/scsi1/lun0" is formatted using blkid with args: ([-p -s TYPE -s PTTYPE -o export /dev/disk/azure/scsi1/lun0])
I1126 07:00:17.650717       1 mount_linux.go:580] Output: ""
I1126 07:00:17.650773       1 mount_linux.go:515] Disk "/dev/disk/azure/scsi1/lun0" appears to be unformatted, attempting to format as type: "ext4" with options: [-F -m0 /dev/disk/azure/scsi1/lun0]
I1126 07:01:40.772543       1 mount_linux.go:526] Disk successfully formatted (mkfs): ext4 - /dev/disk/azure/scsi1/lun0 /var/lib/kubelet/plugins/kubernetes.io/csi/disk.csi.azure.com/a621ec8e71c62e341ae812c978f90f00af8507b7dcb7380a9430e86b5fe65ac8/globalmount
I1126 07:01:40.772572       1 mount_linux.go:544] Attempting to mount disk /dev/disk/azure/scsi1/lun0 in ext4 format at /var/lib/kubelet/plugins/kubernetes.io/csi/disk.csi.azure.com/a621ec8e71c62e341ae812c978f90f00af8507b7dcb7380a9430e86b5fe65ac8/globalmount
I1126 07:01:40.776172       1 mount_linux.go:218] Mounting cmd (mount) with arguments (-t ext4 -o defaults /dev/disk/azure/scsi1/lun0 /var/lib/kubelet/plugins/kubernetes.io/csi/disk.csi.azure.com/a621ec8e71c62e341ae812c978f90f00af8507b7dcb7380a9430e86b5fe65ac8/globalmount)
I1126 07:01:42.708854       1 nodeserver.go:161] NodeStageVolume: format /dev/disk/azure/scsi1/lun0 and mounting at /var/lib/kubelet/plugins/kubernetes.io/csi/disk.csi.azure.com/a621ec8e71c62e341ae812c978f90f00af8507b7dcb7380a9430e86b5fe65ac8/globalmount successfully.
I1126 07:01:42.713965       1 mount_linux.go:577] Attempting to determine if disk "/dev/disk/azure/scsi1/lun0" is formatted using blkid with args: ([-p -s TYPE -s PTTYPE -o export /dev/disk/azure/scsi1/lun0])
I1126 07:01:42.722061       1 mount_linux.go:580] Output: "DEVNAME=/dev/disk/azure/scsi1/lun0\nTYPE=ext4\n"
I1126 07:01:42.727231       1 resizefs_linux.go:137] ResizeFs.needResize - checking mounted volume /dev/disk/azure/scsi1/lun0
I1126 07:01:42.740734       1 resizefs_linux.go:141] Ext size: filesystem size=32985348833280, block size=4096
I1126 07:01:42.743251       1 resizefs_linux.go:156] Volume /dev/disk/azure/scsi1/lun0: device size=32985348833280, filesystem size=32985348833280, block size=4096
I1126 07:01:42.755924       1 utils.go:112] GRPC response: {}
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
