### PR TITLE
fix: revert to go1.22 windows filesystem stdlib behavior

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module sigs.k8s.io/azuredisk-csi-driver
 
 go 1.23.1
 
+godebug winsymlink=0
+
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.16.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Revert to go 1.22 windows filesystem behavior building with go 1.23 until use of Stat/Lstat/EvalSymlinks adjusts to go1.23 behavior

 - golang 1.23.1 building with `godebug winreadlinkvolume=0` 
```
C:\>dir C:\var\lib\kubelet\plugins\kubernetes.io\csi\disk.csi.azure.com\72bb2b07b6028371cea50fb631344dc9113f0846681814572edb765f698195da
 Volume in drive C is Windows
 Volume Serial Number is 663A-A45B

 Directory of C:\var\lib\kubelet\plugins\kubernetes.io\csi\disk.csi.azure.com\72bb2b07b6028371cea50fb631344dc9113f0846681814572edb765f698195da

09/11/2024  03:33 AM    <DIR>          .
12/05/2024  08:21 AM    <DIR>          ..
09/11/2024  03:33 AM    <JUNCTION>     globalmount [\??\Volume{99cc61ac-6fec-11ef-bbb1-cd4785e79c6b}\]
09/11/2024  03:34 AM               230 vol_data.json
               1 File(s)            230 bytes
               3 Dir(s)  80,665,006,080 bytes free

C:\>osreadlink.exe C:\var\lib\kubelet\plugins\kubernetes.io\csi\disk.csi.azure.com\72bb2b07b6028371cea50fb631344dc9113f0846681814572edb765f698195da\globalmount
Symlink target: F:\
```

 - golang 1.23.1 building with `godebug winreadlinkvolume=1`  keeps the original behavior (`os.ReadLink` should return `\\?\Volume{99cc61ac-6fec-11ef-bbb1-cd4785e79c6b}\`)
```
C:\>dir C:\var\lib\kubelet\plugins\kubernetes.io\csi\disk.csi.azure.com\72bb2b07b6028371cea50fb631344dc9113f0846681814572edb765f698195da\
 Volume in drive C is Windows
 Volume Serial Number is 663A-A45B

 Directory of C:\var\lib\kubelet\plugins\kubernetes.io\csi\disk.csi.azure.com\72bb2b07b6028371cea50fb631344dc9113f0846681814572edb765f698195da

09/11/2024  03:33 AM    <DIR>          .
12/05/2024  08:21 AM    <DIR>          ..
09/11/2024  03:33 AM    <JUNCTION>     globalmount [\??\Volume{99cc61ac-6fec-11ef-bbb1-cd4785e79c6b}\]
09/11/2024  03:34 AM               230 vol_data.json
               1 File(s)            230 bytes
               3 Dir(s)  80,661,196,800 bytes free

C:\>osreadlink.exe C:\var\lib\kubelet\plugins\kubernetes.io\csi\disk.csi.azure.com\72bb2b07b6028371cea50fb631344dc9113f0846681814572edb765f698195da\globalmount
Symlink target: \\?\Volume{99cc61ac-6fec-11ef-bbb1-cd4785e79c6b}\
```

for more details, refer to https://github.com/kubernetes/kubernetes/issues/129080

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: revert to go1.22 windows filesystem stdlib behavior building with go 1.23
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: revert to go1.22 windows filesystem stdlib behavior building with go 1.23
```
