### PR TITLE
[release-1.29] fix: unmount volume issue on Windows node

### DIFF
--- a/pkg/azuredisk/azure_common_windows.go
+++ b/pkg/azuredisk/azure_common_windows.go
@@ -84,9 +84,12 @@ func preparePublishPath(path string, m *mount.SafeFormatAndMount) error {
 	return fmt.Errorf("could not cast to csi proxy class")
 }
 
-func CleanupMountPoint(path string, m *mount.SafeFormatAndMount, extensiveCheck bool) error {
+func CleanupMountPoint(path string, m *mount.SafeFormatAndMount, unmountVolume bool) error {
 	if proxy, ok := m.Interface.(mounter.CSIProxyMounter); ok {
-		return proxy.Unmount(path)
+		if unmountVolume {
+			return proxy.Unmount(path)
+		}
+		return proxy.Rmdir(path)
 	}
 	return fmt.Errorf("could not cast to csi proxy class")
 }

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -199,8 +199,7 @@ func (d *Driver) NodeUnstageVolume(_ context.Context, req *csi.NodeUnstageVolume
 	defer d.volumeLocks.Release(volumeID)
 
 	klog.V(2).Infof("NodeUnstageVolume: unmounting %s", stagingTargetPath)
-	err := CleanupMountPoint(stagingTargetPath, d.mounter, true /*extensiveMountPointCheck*/)
-	if err != nil {
+	if err := CleanupMountPoint(stagingTargetPath, d.mounter, true /*extensiveMountPointCheck*/); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to unmount staging target %q: %v", stagingTargetPath, err)
 	}
 	klog.V(2).Infof("NodeUnstageVolume: unmount %s successfully", stagingTargetPath)
@@ -299,8 +298,12 @@ func (d *Driver) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpublishVo
 	}
 
 	klog.V(2).Infof("NodeUnpublishVolume: unmounting volume %s on %s", volumeID, targetPath)
-	err := CleanupMountPoint(targetPath, d.mounter, true /*extensiveMountPointCheck*/)
-	if err != nil {
+	extensiveMountPointCheck := true
+	if runtime.GOOS == "windows" {
+		// on Windows, this parameter indicates whether to unmount volume, not necessary in NodeUnpublishVolume
+		extensiveMountPointCheck = false
+	}
+	if err := CleanupMountPoint(targetPath, d.mounter, extensiveMountPointCheck); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to unmount target %q: %v", targetPath, err)
 	}
 

--- a/pkg/azuredisk/nodeserver_test.go
+++ b/pkg/azuredisk/nodeserver_test.go
@@ -717,9 +717,10 @@ func TestNodeUnstageVolume(t *testing.T) {
 			},
 		},
 		{
-			desc:        "[Success] Valid request",
-			req:         csi.NodeUnstageVolumeRequest{StagingTargetPath: targetFile, VolumeId: "vol_1"},
-			expectedErr: testutil.TestError{},
+			desc:          "[Success] Valid request",
+			req:           csi.NodeUnstageVolumeRequest{StagingTargetPath: targetFile, VolumeId: "vol_1"},
+			skipOnWindows: true, // error on Windows
+			expectedErr:   testutil.TestError{},
 		},
 	}
 

--- a/pkg/mounter/safe_mounter_host_process_windows.go
+++ b/pkg/mounter/safe_mounter_host_process_windows.go
@@ -58,7 +58,14 @@ func (mounter *winMounter) Rmdir(path string) error {
 
 // Unmount - Removes the directory - equivalent to unmount on Linux.
 func (mounter *winMounter) Unmount(target string) error {
-	klog.V(4).Infof("Unmount: %s", target)
+	volumeID, err := mounter.GetDeviceNameFromMount(target, "")
+	if err != nil {
+		return err
+	}
+	klog.V(2).Infof("Unmounting volume %s from %s", volumeID, target)
+	if err = volume.UnmountVolume(volumeID, normalizeWindowsPath(target)); err != nil {
+		return err
+	}
 	return mounter.Rmdir(target)
 }
 

--- a/pkg/os/volume/volume.go
+++ b/pkg/os/volume/volume.go
@@ -123,7 +123,7 @@ func UnmountVolume(volumeID, path string) error {
 	cmd := "Get-Volume -UniqueId \"$Env:volumeID\" | Get-Partition | Remove-PartitionAccessPath -AccessPath $Env:path"
 	out, err := azureutils.RunPowershellCmd(cmd, fmt.Sprintf("volumeID=%s", volumeID), fmt.Sprintf("path=%s", path))
 	if err != nil {
-		return fmt.Errorf("error getting driver letter to mount volume. cmd: %s, output: %s,error: %v", cmd, string(out), err)
+		return fmt.Errorf("failed to mount volume. cmd: %s, output: %s,error: %v", cmd, string(out), err)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: unmount volume issue on Windows node, original behavior is just deleting the mounted directory which may lead to mount failure in frequent unmount and mount the same volume on the same node

cherrypick of https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/2691

```
I1204 14:39:28.920234    1336 utils.go:105] GRPC call: /csi.v1.Node/NodeUnpublishVolume
I1204 14:39:28.920234    1336 utils.go:106] GRPC request: {"target_path":"c:\\var\\lib\\kubelet\\pods\\d17b945a-2f91-4bfc-b5c9-28e886c86525\\volumes\\kubernetes.io~csi\\pvc-6afee86b-e9b9-4e63-a8a0-d49b887fd682\\mount","volume_id":"/subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks129_andy-aks129_eastus2/providers/Microsoft.Compute/disks/pvc-6afee86b-e9b9-4e63-a8a0-d49b887fd682"}
I1204 14:39:28.920916    1336 nodeserver.go:300] NodeUnpublishVolume: unmounting volume /subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks129_andy-aks129_eastus2/providers/Microsoft.Compute/disks/pvc-6afee86b-e9b9-4e63-a8a0-d49b887fd682 on c:\var\lib\kubelet\pods\d17b945a-2f91-4bfc-b5c9-28e886c86525\volumes\kubernetes.io~csi\pvc-6afee86b-e9b9-4e63-a8a0-d49b887fd682\mount
I1204 14:39:28.920916    1336 nodeserver.go:310] NodeUnpublishVolume: unmount volume /subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks129_andy-aks129_eastus2/providers/Microsoft.Compute/disks/pvc-6afee86b-e9b9-4e63-a8a0-d49b887fd682 on c:\var\lib\kubelet\pods\d17b945a-2f91-4bfc-b5c9-28e886c86525\volumes\kubernetes.io~csi\pvc-6afee86b-e9b9-4e63-a8a0-d49b887fd682\mount successfully
I1204 14:39:28.920916    1336 utils.go:112] GRPC response: {}
I1204 14:39:29.034346    1336 utils.go:105] GRPC call: /csi.v1.Node/NodeUnstageVolume
I1204 14:39:29.034346    1336 utils.go:106] GRPC request: {"staging_target_path":"\\var\\lib\\kubelet\\plugins\\kubernetes.io\\csi\\disk.csi.azure.com\\fef91c0445c24e34b58d31008ed7020a6502e7017b09a1b5b7012d4e3d28a1f6\\globalmount","volume_id":"/subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks129_andy-aks129_eastus2/providers/Microsoft.Compute/disks/pvc-6afee86b-e9b9-4e63-a8a0-d49b887fd682"}
I1204 14:39:29.034346    1336 nodeserver.go:201] NodeUnstageVolume: unmounting \var\lib\kubelet\plugins\kubernetes.io\csi\disk.csi.azure.com\fef91c0445c24e34b58d31008ed7020a6502e7017b09a1b5b7012d4e3d28a1f6\globalmount
I1204 14:39:29.035850    1336 safe_mounter_host_process_windows.go:69] Unmounting volume \\?\Volume{6a72717b-3413-4f50-a487-f46516fdb617}\ from \var\lib\kubelet\plugins\kubernetes.io\csi\disk.csi.azure.com\fef91c0445c24e34b58d31008ed7020a6502e7017b09a1b5b7012d4e3d28a1f6\globalmount
I1204 14:39:31.313932    1336 nodeserver.go:205] NodeUnstageVolume: unmount \var\lib\kubelet\plugins\kubernetes.io\csi\disk.csi.azure.com\fef91c0445c24e34b58d31008ed7020a6502e7017b09a1b5b7012d4e3d28a1f6\globalmount successfully
I1204 14:39:31.314177    1336 utils.go:112] GRPC response: {}
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2690

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: unmount volume issue on Windows node
```
