### PR TITLE
feat: add noformat option to fix fsck stuck issue

### DIFF
--- a/pkg/azuredisk/azure_common_linux.go
+++ b/pkg/azuredisk/azure_common_linux.go
@@ -120,6 +120,10 @@ func findDiskByLun(lun int, io azureutils.IOHandler, _ *mount.SafeFormatAndMount
 }
 
 func formatAndMount(source, target, fstype string, options []string, m *mount.SafeFormatAndMount) error {
+	if newOptions, exists := azureutils.RemoveOptionIfExists(options, "noformat"); exists {
+		klog.V(2).Infof("formatAndMount - skip format for %s, old options: %v, new options: %v", target, options, newOptions)
+		return m.Mount(source, target, fstype, newOptions)
+	}
 	return m.FormatAndMount(source, target, fstype, options)
 }
 

--- a/pkg/azureutils/azure_disk_utils.go
+++ b/pkg/azureutils/azure_disk_utils.go
@@ -855,3 +855,14 @@ func GenerateVolumeName(clusterName, pvName string, maxLength int) string {
 	}
 	return prefix + "-" + pvName
 }
+
+// RemoveOptionIfExists removes the given option from the list of options
+// return the new list and a boolean indicating whether the option was found.
+func RemoveOptionIfExists(options []string, removeOption string) ([]string, bool) {
+	for i, option := range options {
+		if option == removeOption {
+			return append(options[:i], options[i+1:]...), true
+		}
+	}
+	return options, false
+}

--- a/pkg/azureutils/azure_disk_utils_test.go
+++ b/pkg/azureutils/azure_disk_utils_test.go
@@ -2005,3 +2005,64 @@ func TestGenerateVolumeName(t *testing.T) {
 		t.Errorf("Expected %s, got %s", expect, v3)
 	}
 }
+
+func TestRemoveOptionIfExists(t *testing.T) {
+	tests := []struct {
+		desc            string
+		options         []string
+		removeOption    string
+		expectedOptions []string
+		expected        bool
+	}{
+		{
+			desc:         "nil options",
+			removeOption: "option",
+			expected:     false,
+		},
+		{
+			desc:            "empty options",
+			options:         []string{},
+			removeOption:    "option",
+			expectedOptions: []string{},
+			expected:        false,
+		},
+		{
+			desc:            "option not found",
+			options:         []string{"option1", "option2"},
+			removeOption:    "option",
+			expectedOptions: []string{"option1", "option2"},
+			expected:        false,
+		},
+		{
+			desc:            "option found in the last element",
+			options:         []string{"option1", "option2", "option"},
+			removeOption:    "option",
+			expectedOptions: []string{"option1", "option2"},
+			expected:        true,
+		},
+		{
+			desc:            "option found in the first element",
+			options:         []string{"option", "option1", "option2"},
+			removeOption:    "option",
+			expectedOptions: []string{"option1", "option2"},
+			expected:        true,
+		},
+		{
+			desc:            "option found in the middle element",
+			options:         []string{"option1", "option", "option2"},
+			removeOption:    "option",
+			expectedOptions: []string{"option1", "option2"},
+			expected:        true,
+		},
+	}
+
+	for _, test := range tests {
+		result, exists := RemoveOptionIfExists(test.options, test.removeOption)
+		if !reflect.DeepEqual(result, test.expectedOptions) {
+			t.Errorf("test[%s]: unexpected output: %v, expected result: %v", test.desc, result, test.expectedOptions)
+		}
+		if exists != test.expected {
+			t.Errorf("test[%s]: unexpected output: %v, expected result: %v", test.desc, exists, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: add noformat option to fix fsck stuck issue
when disk PV is quite big(e.g. 30TB) and it contains lots of files, fsck could be stuck there for long time, this PR supports adding a `noformat` mount option in disk pv, then the already formatted disk will not be fsck check again, this could save a lot of time for fsck

<details>

```
I1222 03:15:01.101253       1 utils.go:105] GRPC call: /csi.v1.Node/NodeStageVolume
I1222 03:15:01.101281       1 utils.go:106] GRPC request: {"publish_context":{"LUN":"0"},"staging_target_path":"/var/lib/kubelet/plugins/kubernetes.io/csi/disk.csi.azure.com/6315f0e19af4e6a13e09168e7165aa7f08235b3e975873eccfa6db02a4c3ec97/globalmount","volume_capability":{"AccessType":{"Mount":{"mount_flags":["noformat"]}},"access_mode":{"mode":7}},"volume_context":{"csi.storage.k8s.io/pv/name":"pvc-4ca6432b-2f22-42e2-baa6-0e911a768d65","csi.storage.k8s.io/pvc/name":"persistent-storage-statefulset-azuredisk-v6-0","csi.storage.k8s.io/pvc/namespace":"default","requestedsizegib":"10","skuName":"StandardSSD_LRS","storage.kubernetes.io/csiProvisionerIdentity":"1730541755160-5145-disk.csi.azure.com"},"volume_id":"/subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks129_andy-aks129_eastus2/providers/Microsoft.Compute/disks/pvc-4ca6432b-2f22-42e2-baa6-0e911a768d65"}
I1222 03:15:02.067198       1 azure_common_linux.go:207] azureDisk - found /dev/disk/azure/scsi1/lun0 by sdc under /dev/disk/azure/scsi1/
I1222 03:15:02.068283       1 nodeserver.go:157] NodeStageVolume: formatting /dev/disk/azure/scsi1/lun0 and mounting at /var/lib/kubelet/plugins/kubernetes.io/csi/disk.csi.azure.com/6315f0e19af4e6a13e09168e7165aa7f08235b3e975873eccfa6db02a4c3ec97/globalmount with mount options([noformat])
I1222 03:15:02.068359       1 azure_common_linux.go:124] formatAndMount - skip format for /var/lib/kubelet/plugins/kubernetes.io/csi/disk.csi.azure.com/6315f0e19af4e6a13e09168e7165aa7f08235b3e975873eccfa6db02a4c3ec97/globalmount, old options: [noformat], new options: []
I1222 03:15:02.068510       1 mount_linux.go:295] Detected OS without systemd
I1222 03:15:02.068526       1 mount_linux.go:270] Mounting cmd (mount) with arguments (-t ext4 /dev/disk/azure/scsi1/lun0 /var/lib/kubelet/plugins/kubernetes.io/csi/disk.csi.azure.com/6315f0e19af4e6a13e09168e7165aa7f08235b3e975873eccfa6db02a4c3ec97/globalmount)
I1222 03:15:02.754466       1 nodeserver.go:161] NodeStageVolume: format /dev/disk/azure/scsi1/lun0 and mounting at /var/lib/kubelet/plugins/kubernetes.io/csi/disk.csi.azure.com/6315f0e19af4e6a13e09168e7165aa7f08235b3e975873eccfa6db02a4c3ec97/globalmount successfully.
I1222 03:15:02.763220       1 mount_linux.go:680] Attempting to determine if disk "/dev/disk/azure/scsi1/lun0" is formatted using blkid with args: ([-p -s TYPE -s PTTYPE -o export /dev/disk/azure/scsi1/lun0])
I1222 03:15:02.774327       1 mount_linux.go:683] Output: "DEVNAME=/dev/disk/azure/scsi1/lun0\nTYPE=ext4\n"
I1222 03:15:02.774424       1 resizefs_linux.go:137] ResizeFs.needResize - checking mounted volume /dev/disk/azure/scsi1/lun0
I1222 03:15:02.777011       1 resizefs_linux.go:141] Ext size: filesystem size=10737418240, block size=4096
I1222 03:15:02.777037       1 resizefs_linux.go:156] Volume /dev/disk/azure/scsi1/lun0: device size=10737418240, filesystem size=10737418240, block size=4096
I1222 03:15:02.777063       1 utils.go:112] GRPC response: {}
```

</details>

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
