### PR TITLE
[release-1.30] feat: add noformat option to fix fsck stuck issue on Linux node

### DIFF
--- a/pkg/azuredisk/azure_common_linux.go
+++ b/pkg/azuredisk/azure_common_linux.go
@@ -120,6 +120,10 @@ func findDiskByLun(lun int, io azureutils.IOHandler, _ *mount.SafeFormatAndMount
 }
 
 func formatAndMount(source, target, fstype string, options []string, m *mount.SafeFormatAndMount) error {
+	if newOptions, exists := azureutils.RemoveOptionIfExists(options, "noformat"); exists {
+		klog.V(2).Infof("formatAndMount - skip format for %s, old options: %v, new options: %v", target, options, newOptions)
+		return m.Mount(source, target, fstype, newOptions)
+	}
 	return m.FormatAndMount(source, target, fstype, options)
 }
 

--- a/pkg/azureutils/azure_disk_utils.go
+++ b/pkg/azureutils/azure_disk_utils.go
@@ -839,3 +839,14 @@ func RunPowershellCmd(command string, envs ...string) ([]byte, error) {
 	klog.V(6).Infof("Executing command: %q", cmd.String())
 	return cmd.CombinedOutput()
 }
+
+// RemoveOptionIfExists removes the given option from the list of options
+// return the new list and a boolean indicating whether the option was found.
+func RemoveOptionIfExists(options []string, removeOption string) ([]string, bool) {
+	for i, option := range options {
+		if option == removeOption {
+			return append(options[:i], options[i+1:]...), true
+		}
+	}
+	return options, false
+}

--- a/pkg/azureutils/azure_disk_utils_test.go
+++ b/pkg/azureutils/azure_disk_utils_test.go
@@ -1964,3 +1964,64 @@ func TestIsThrottlingError(t *testing.T) {
 		}
 	}
 }
+
+func TestRemoveOptionIfExists(t *testing.T) {
+	tests := []struct {
+		desc            string
+		options         []string
+		removeOption    string
+		expectedOptions []string
+		expected        bool
+	}{
+		{
+			desc:         "nil options",
+			removeOption: "option",
+			expected:     false,
+		},
+		{
+			desc:            "empty options",
+			options:         []string{},
+			removeOption:    "option",
+			expectedOptions: []string{},
+			expected:        false,
+		},
+		{
+			desc:            "option not found",
+			options:         []string{"option1", "option2"},
+			removeOption:    "option",
+			expectedOptions: []string{"option1", "option2"},
+			expected:        false,
+		},
+		{
+			desc:            "option found in the last element",
+			options:         []string{"option1", "option2", "option"},
+			removeOption:    "option",
+			expectedOptions: []string{"option1", "option2"},
+			expected:        true,
+		},
+		{
+			desc:            "option found in the first element",
+			options:         []string{"option", "option1", "option2"},
+			removeOption:    "option",
+			expectedOptions: []string{"option1", "option2"},
+			expected:        true,
+		},
+		{
+			desc:            "option found in the middle element",
+			options:         []string{"option1", "option", "option2"},
+			removeOption:    "option",
+			expectedOptions: []string{"option1", "option2"},
+			expected:        true,
+		},
+	}
+
+	for _, test := range tests {
+		result, exists := RemoveOptionIfExists(test.options, test.removeOption)
+		if !reflect.DeepEqual(result, test.expectedOptions) {
+			t.Errorf("test[%s]: unexpected output: %v, expected result: %v", test.desc, result, test.expectedOptions)
+		}
+		if exists != test.expected {
+			t.Errorf("test[%s]: unexpected output: %v, expected result: %v", test.desc, exists, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: add noformat option to fix fsck stuck issue on Linux node
when disk PV is quite big(e.g. 30TB) and it contains lots of files, fsck could be stuck there for long time, this PR supports adding a `noformat` mount option in disk pv, then the already formatted disk will not be fsck check again, this could save a lot of time for fsck

cherrypick of https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/2751

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
