### PR TITLE
test: add UT for filewatcher

### DIFF
--- a/pkg/filewatcher/filewatcher.go
+++ b/pkg/filewatcher/filewatcher.go
@@ -25,6 +25,11 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// exit is a separate function to handle program termination
+var exit = func(code int) {
+	os.Exit(code)
+}
+
 var watchCertificateFileOnce sync.Once
 
 // WatchFileForChanges watches the file, fileToWatch, for changes. If the file contents have changed, the pod this
@@ -44,9 +49,7 @@ func WatchFileForChanges(fileToWatch string) error {
 		klog.V(2).Infof("Watching file, %s", fileToWatch)
 
 		// Start the file watcher to monitor file changes
-		go func() {
-			err = checkForFileChanges(fileToWatch)
-		}()
+		err = checkForFileChanges(fileToWatch)
 	})
 	return err
 }
@@ -64,7 +67,7 @@ func checkForFileChanges(path string) error {
 			case event, ok := <-watcher.Events:
 				if ok && (event.Has(fsnotify.Write) || event.Has(fsnotify.Chmod) || event.Has(fsnotify.Remove)) {
 					klog.V(2).Infof("file, %s, was modified, exiting...", event.Name)
-					os.Exit(0)
+					exit(0)
 				}
 			case err, ok := <-watcher.Errors:
 				if ok {

--- a/pkg/filewatcher/filewatcher_test.go
+++ b/pkg/filewatcher/filewatcher_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filewatcher
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestWatchFileForChanges(t *testing.T) {
+	// Set mock exit once.
+	exit = func(_ int) {
+		// Mock, do nothing
+	}
+
+	// Create a temporary file to watch
+	tmpfile, err := os.CreateTemp("", "testfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	// Now call the watcher
+	if err = WatchFileForChanges(tmpfile.Name()); err != nil {
+		t.Errorf("Failed to watch file: %v", err)
+	}
+
+	// Trigger the watcher
+	if err = os.WriteFile(tmpfile.Name(), []byte("new content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Let the watcher see the change
+	time.Sleep(1 * time.Second)
+}


### PR DESCRIPTION
This pull request includes changes to improve the handling of program termination and adds a test for the `WatchFileForChanges` function. The most important changes include the introduction of a separate `exit` function and the addition of a comprehensive test for file watching.

Improvements to program termination handling:

* [`pkg/filewatcher/filewatcher.go`](diffhunk://#diff-5d8d60fa78da8b711b2e021fa0643a9e8d880a4ed6eca069019dd76d9a37677eR28-R32): Introduced a separate `exit` function to handle program termination, replacing direct calls to `os.Exit` with this function. [[1]](diffhunk://#diff-5d8d60fa78da8b711b2e021fa0643a9e8d880a4ed6eca069019dd76d9a37677eR28-R32) [[2]](diffhunk://#diff-5d8d60fa78da8b711b2e021fa0643a9e8d880a4ed6eca069019dd76d9a37677eL67-R72)

Addition of tests:

* [`pkg/filewatcher/filewatcher_test.go`](diffhunk://#diff-1f58eb1a770908ddeb74a9fdfcb0345888f1a6cdf9ac1e2531ea643728fad8f5R1-R67): Added a new test for the `WatchFileForChanges` function, including a mock `exit` function to capture exit codes and simulate file changes.<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
