### PR TITLE
fix: wrong node matching when detaching dangling disk

### DIFF
--- a/pkg/azuredisk/azure_controller_common.go
+++ b/pkg/azuredisk/azure_controller_common.go
@@ -132,7 +132,7 @@ func (c *controllerCommon) AttachDisk(ctx context.Context, diskName, diskURI str
 			if err != nil {
 				return -1, err
 			}
-			if strings.EqualFold(string(nodeName), string(attachedNode)) {
+			if isSameNode(string(nodeName), string(attachedNode)) {
 				klog.Warningf("volume %s is actually attached to current node %s, invalidate vm cache and return error", diskURI, nodeName)
 				// update VM(invalidate vm cache)
 				if errUpdate := c.UpdateVM(ctx, nodeName); errUpdate != nil {

--- a/pkg/azuredisk/azuredisk.go
+++ b/pkg/azuredisk/azuredisk.go
@@ -786,3 +786,38 @@ func checkAllocatable(ctx context.Context, clientset kubernetes.Interface, nodeN
 
 	return fmt.Errorf("isAllocatableSet: driver not found on node %s", nodeName)
 }
+
+// isSameNode checks whether node1 and node2 are the same node
+func isSameNode(node1, node2 string) bool {
+	if strings.EqualFold(node1, node2) {
+		return true
+	}
+	// check whether node1 and node2 are VMSS instance name
+	if len(node1) < 6 || len(node2) < 6 {
+		return false
+	}
+
+	// machineName is composed of computerNamePrefix and 36-based instanceID.
+	// And instanceID part if in fixed length of 6 characters.
+	// Refer https://msftstack.wordpress.com/2017/05/10/figuring-out-azure-vm-scale-set-machine-names/.
+	if strings.EqualFold(node1[:len(node1)-6], node2[:len(node2)-6]) {
+		// check whether node1 is 36-based instanceID and node2 is 10-based instanceID
+		id1, err := strconv.ParseUint(node1[len(node1)-6:], 36, 64)
+		if err == nil {
+			id2, err := strconv.ParseUint(node2[len(node2)-6:], 10, 64)
+			if err == nil && id1 == id2 {
+				return true
+			}
+		}
+
+		// check whether node1 is 10-based instanceID and node2 is 36-based instanceID
+		id1, err = strconv.ParseUint(node1[len(node1)-6:], 10, 64)
+		if err == nil {
+			id2, err := strconv.ParseUint(node2[len(node2)-6:], 36, 64)
+			if err == nil && id1 == id2 {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/azuredisk/azuredisk_test.go
+++ b/pkg/azuredisk/azuredisk_test.go
@@ -589,3 +589,79 @@ func TestGetUsedLunsFromNode(t *testing.T) {
 		}
 	}
 }
+
+func TestIsSameNode(t *testing.T) {
+	tests := []struct {
+		name          string
+		nodeName      string
+		nodeName2     string
+		expectedValue bool
+	}{
+		{
+			name:          "same node",
+			nodeName:      "test-node",
+			nodeName2:     "test-node",
+			expectedValue: true,
+		},
+		{
+			name:          "different node with shorter name",
+			nodeName:      "node1",
+			nodeName2:     "node2",
+			expectedValue: false,
+		},
+		{
+			name:          "different node",
+			nodeName:      "test-node",
+			nodeName2:     "test-node2",
+			expectedValue: false,
+		},
+		{
+			name:          "empty node",
+			nodeName:      "",
+			nodeName2:     "test-node",
+			expectedValue: false,
+		},
+		{
+			name:          "node1 is 10 based instance name, node2 is 36 based instance name",
+			nodeName:      "aks-agentpool-20657377-vmss000012",
+			nodeName2:     "aks-agentpool-20657377-vmss00000c",
+			expectedValue: true,
+		},
+		{
+			name:          "node1 is 36 based instance name, node2 is 10 based instance name",
+			nodeName:      "aks-agentpool-20657377-vmss00000c",
+			nodeName2:     "aks-agentpool-20657377-vmss000012",
+			expectedValue: true,
+		},
+		{
+			name:          "node1 is 10 based instance name, node2 is 36 based instance name, but different vmss",
+			nodeName:      "aks-agentpool-20657377-vmss000019",
+			nodeName2:     "aks-agentpool-20657377-vmss00000c",
+			expectedValue: false,
+		},
+		{
+			name:          "node1 is 36 based instance name, node2 is 10 based instance name, but different vmss",
+			nodeName:      "aks-agentpool-20657377-vmss00000c",
+			nodeName2:     "aks-agentpool-20657377-vmss000019",
+			expectedValue: false,
+		},
+		{
+			name:          "node1 is 10 based instance name, node2 is 10 based instance name, but different vmss",
+			nodeName:      "aks-agentpool-20657377-vmss000019",
+			nodeName2:     "aks-agentpool-20657377-vmss000017",
+			expectedValue: false,
+		},
+		{
+			name:          "node1 is 36 based instance name, node2 is 36 based instance name, but different vmss",
+			nodeName:      "aks-agentpool-20657377-vmss00000c",
+			nodeName2:     "aks-agentpool-20657377-vmss00000a",
+			expectedValue: false,
+		},
+	}
+	for _, test := range tests {
+		result := isSameNode(test.nodeName, test.nodeName2)
+		if result != test.expectedValue {
+			t.Errorf("test(%s): result(%v) != expected result(%v)", test.name, result, test.expectedValue)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: wrong node matching when detaching dangling disk (edge case)
in following logs, the two VMSS nodes are actually the same node, with this fix, CSI driver will regard that this disk is already attached to the correct node instead of detaching the disk and re-attach it to the same node.

![image](https://github.com/user-attachments/assets/0dcd9691-39b9-4ce5-b051-af13741372b2)

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: wrong node matching when detaching dangling disk
```
