### PR TITLE
fix: set get disk timeout as 15s and make it configurable

### DIFF
--- a/pkg/azuredisk/azuredisk.go
+++ b/pkg/azuredisk/azuredisk.go
@@ -122,6 +122,7 @@ type DriverCore struct {
 	vmssCacheTTLInSeconds        int64
 	volStatsCacheExpireInMinutes int64
 	attachDetachInitialDelayInMs int64
+	getDiskTimeoutInSeconds      int64
 	vmType                       string
 	enableWindowsHostProcess     bool
 	listDisksUsingWinCIM         bool
@@ -178,6 +179,7 @@ func newDriverV1(options *DriverOptions) *Driver {
 	driver.trafficManagerPort = options.TrafficManagerPort
 	driver.vmssCacheTTLInSeconds = options.VMSSCacheTTLInSeconds
 	driver.volStatsCacheExpireInMinutes = options.VolStatsCacheExpireInMinutes
+	driver.getDiskTimeoutInSeconds = options.GetDiskTimeoutInSeconds
 	driver.vmType = options.VMType
 	driver.enableWindowsHostProcess = options.EnableWindowsHostProcess
 	driver.listDisksUsingWinCIM = options.ListDisksUsingWinCIM
@@ -414,8 +416,7 @@ func (d *Driver) checkDiskExists(ctx context.Context, diskURI string) (*armcompu
 		return nil, err
 	}
 
-	// get disk operation should timeout within 1min if it takes too long time
-	newCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	newCtx, cancel := context.WithTimeout(ctx, time.Duration(d.getDiskTimeoutInSeconds)*time.Second)
 	defer cancel()
 
 	disk, err := diskClient.Get(newCtx, resourceGroup, diskName)

--- a/pkg/azuredisk/azuredisk_option.go
+++ b/pkg/azuredisk/azuredisk_option.go
@@ -51,6 +51,7 @@ type DriverOptions struct {
 	AttachDetachInitialDelayInMs int64
 	VMSSCacheTTLInSeconds        int64
 	VolStatsCacheExpireInMinutes int64
+	GetDiskTimeoutInSeconds      int64
 	VMType                       string
 	EnableWindowsHostProcess     bool
 	ListDisksUsingWinCIM         bool
@@ -97,6 +98,7 @@ func (o *DriverOptions) AddFlags() *flag.FlagSet {
 	fs.Int64Var(&o.AttachDetachInitialDelayInMs, "attach-detach-initial-delay-ms", 1000, "initial delay in milliseconds for batch disk attach/detach")
 	fs.Int64Var(&o.VMSSCacheTTLInSeconds, "vmss-cache-ttl-seconds", -1, "vmss cache TTL in seconds (600 by default)")
 	fs.Int64Var(&o.VolStatsCacheExpireInMinutes, "vol-stats-cache-expire-in-minutes", 10, "The cache expire time in minutes for volume stats cache")
+	fs.Int64Var(&o.GetDiskTimeoutInSeconds, "get-disk-timeout-seconds", 15, "The timeout in seconds for getting disk")
 	fs.StringVar(&o.VMType, "vm-type", "", "type of agent node. available values: vmss, standard")
 	fs.BoolVar(&o.EnableWindowsHostProcess, "enable-windows-host-process", false, "enable windows host process")
 	fs.BoolVar(&o.ListDisksUsingWinCIM, "list-disks-using-win-cim", true, "list disks using CIM API on Windows")

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -147,12 +147,13 @@ var _ = ginkgo.BeforeSuite(func(ctx ginkgo.SpecContext) {
 		execTestCmd([]testCmd{e2eBootstrap, createMetricsSVC})
 
 		driverOptions := azuredisk.DriverOptions{
-			NodeID:                 os.Getenv("nodeid"),
-			DriverName:             consts.DefaultDriverName,
-			VolumeAttachLimit:      16,
-			EnablePerfOptimization: false,
-			Kubeconfig:             os.Getenv(kubeconfigEnvVar),
-			Endpoint:               fmt.Sprintf("unix:///tmp/csi-%s.sock", string(uuid.NewUUID())),
+			NodeID:                  os.Getenv("nodeid"),
+			DriverName:              consts.DefaultDriverName,
+			VolumeAttachLimit:       16,
+			EnablePerfOptimization:  false,
+			Kubeconfig:              os.Getenv(kubeconfigEnvVar),
+			Endpoint:                fmt.Sprintf("unix:///tmp/csi-%s.sock", string(uuid.NewUUID())),
+			GetDiskTimeoutInSeconds: 15,
 		}
 		os.Setenv("AZURE_CREDENTIAL_FILE", credentials.TempAzureCredentialFilePath)
 		azurediskDriver = azuredisk.NewDriver(&driverOptions)

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -149,7 +149,6 @@ var _ = ginkgo.BeforeSuite(func(ctx ginkgo.SpecContext) {
 		driverOptions := azuredisk.DriverOptions{
 			NodeID:                  os.Getenv("nodeid"),
 			DriverName:              consts.DefaultDriverName,
-			VolumeAttachLimit:       16,
 			EnablePerfOptimization:  false,
 			Kubeconfig:              os.Getenv(kubeconfigEnvVar),
 			Endpoint:                fmt.Sprintf("unix:///tmp/csi-%s.sock", string(uuid.NewUUID())),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: set get disk timeout as 15s and make it configurable

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: set get disk timeout as 15s and make it configurable
```
