### PR TITLE
fix: obsolete vmss cache issue after disk is resized successfully

### DIFF
--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -943,6 +943,18 @@ func (d *Driver) ControllerExpandVolume(ctx context.Context, req *csi.Controller
 	isOperationSucceeded = true
 	klog.V(2).Infof("expand azure disk(%s) successfully, currentSize(%d)", diskURI, currentSize)
 
+	if result.ManagedBy != nil {
+		attachedNode, err := d.cloud.VMSet.GetNodeNameByProviderID(ctx, *result.ManagedBy)
+		if err == nil {
+			klog.V(2).Infof("delete cache for node (%s, %s) after disk(%s) expanded", attachedNode, *result.ManagedBy, diskURI)
+			if err = d.cloud.VMSet.DeleteCacheForNode(ctx, string(attachedNode)); err != nil {
+				klog.Warningf("failed to delete cache for node %s with error(%v)", attachedNode, err)
+			}
+		} else {
+			klog.Warningf("failed to get attached node for disk(%s) with error(%v)", diskURI, err)
+		}
+	}
+
 	return &csi.ControllerExpandVolumeResponse{
 		CapacityBytes:         currentSize,
 		NodeExpansionRequired: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: obsolete vmss cache issue after disk is resized successfully

```
I0210 09:51:07.224054       1 azure_managedDiskController.go:412] azureDisk - resize disk(pvc-32b5d157-73d6-46be-bbb3-f261360623ae) with new size(20) completed
I0210 09:51:07.224084       1 controllerserver.go:944] expand azure disk(/subscriptions/46678f10-4bbb-447e-98e8-d2829589f2d8/resourceGroups/capz-1zdete/providers/Microsoft.Compute/disks/pvc-32b5d157-73d6-46be-bbb3-f261360623ae) successfully, currentSize(21474836480)
I0210 09:51:07.224180       1 controllerserver.go:949] delete cache for node (capz-1zdete-mp-0000001, /subscriptions/46678f10-4bbb-447e-98e8-d2829589f2d8/resourceGroups/capz-1zdete/providers/Microsoft.Compute/virtualMachineScaleSets/capz-1zdete-mp-0/virtualMachines/capz-1zdete-mp-0_1) after disk(/subscriptions/46678f10-4bbb-447e-98e8-d2829589f2d8/resourceGroups/capz-1zdete/providers/Microsoft.Compute/disks/pvc-32b5d157-73d6-46be-bbb3-f261360623ae) expanded
I0210 09:51:07.224370       1 azure_vmss_cache.go:286] DeleteCacheForNode(capz-1zdete, capz-1zdete-mp-0, capz-1zdete-mp-0000001) successfully
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2860

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: obsolete vmss cache issue after disk is resized successfully
```
