### PR TITLE
fix: incorrect cloud provider setting in sovereign cloud

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	k8s.io/mount-utils v0.32.2
 	k8s.io/pod-security-admission v0.32.0
 	k8s.io/utils v0.0.0-20241210054802-24370beab758
-	sigs.k8s.io/cloud-provider-azure v1.29.1-0.20250228070425-857f2b8a7a12
+	sigs.k8s.io/cloud-provider-azure v1.29.1-0.20250305024401-4c771d529327
 	sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.5.4
 	sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.4.0
 	sigs.k8s.io/yaml v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -833,8 +833,8 @@ k8s.io/utils v0.0.0-20241210054802-24370beab758 h1:sdbE21q2nlQtFh65saZY+rRM6x6aJ
 k8s.io/utils v0.0.0-20241210054802-24370beab758/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.1 h1:uOuSLOMBWkJH0TWa9X6l+mj5nZdm6Ay6Bli8HL8rNfk=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.1/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
-sigs.k8s.io/cloud-provider-azure v1.29.1-0.20250228070425-857f2b8a7a12 h1:Y5//Vz3b9xsK+umqvOqzY1HThQxTmn0LBFse9ajkNZA=
-sigs.k8s.io/cloud-provider-azure v1.29.1-0.20250228070425-857f2b8a7a12/go.mod h1:0Bca/ySkQrlalgEgOZne7xeQVU6KFheDWD3CYGma7AE=
+sigs.k8s.io/cloud-provider-azure v1.29.1-0.20250305024401-4c771d529327 h1:Ykk7PsDismZ+yIlqob8fSyivMhm9q1uziZttxhGrNKU=
+sigs.k8s.io/cloud-provider-azure v1.29.1-0.20250305024401-4c771d529327/go.mod h1:0Bca/ySkQrlalgEgOZne7xeQVU6KFheDWD3CYGma7AE=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.5.4 h1:qxBak/m6Rj2xYo7faBKsCdU4xbPXsa+MwnX4ymTxEhQ=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.5.4/go.mod h1:EiBF+gLie9K19GaYbmGEIpT4s+WCpMFXLmjlu3hGEmY=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.4.0 h1:n6NEFrYsUKuoaujmyddxS2ztXrIsbMwwcU9W3xbhjf4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1858,7 +1858,7 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client/metrics
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/common/metrics
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client
-# sigs.k8s.io/cloud-provider-azure v1.29.1-0.20250228070425-857f2b8a7a12
+# sigs.k8s.io/cloud-provider-azure v1.29.1-0.20250305024401-4c771d529327
 ## explicit; go 1.23.2
 sigs.k8s.io/cloud-provider-azure/pkg/cache
 sigs.k8s.io/cloud-provider-azure/pkg/consts

--- a/vendor/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure.go
+++ b/vendor/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure.go
@@ -326,7 +326,7 @@ func (az *Cloud) InitializeCloudFromConfig(ctx context.Context, config *config.C
 		config.ClusterServiceSharedLoadBalancerHealthProbePath = consts.ClusterServiceLoadBalancerHealthProbeDefaultPath
 	}
 
-	clientOps, env, err := azclient.GetAzCoreClientOption(&az.ARMClientConfig)
+	clientOps, env, err := azclient.GetAzCoreClientOption(&config.ARMClientConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
fix: incorrect cloud provider setting in sovereign cloud

related to https://github.com/kubernetes-sigs/cloud-provider-azure/pull/8504

the cloud provider with track2 sdk does not work in Azure China cloud, error is like following:
```
E0304 04:59:58.032152       1 utils.go:110] GRPC error: rpc error: code = Internal desc = ManagedIdentityCredential authentication failed. the requested identity isn't assigned to this resource
GET http://169.254.169.254/metadata/identity/oauth2/token
--------------------------------------------------------------------------------
RESPONSE 400: 400 Bad Request
--------------------------------------------------------------------------------
{
  "error": "invalid_resource",
  "error_description": "AADSTS500011: The resource principal named https://management.core.windows.net/ was not found in the tenant named 89e1b688-8d74-4446-9680-54d0a43a4f0d. This can happen if the application has not been installed by the administrator of the tenant or consented to by any user in the tenant. You might have sent your authentication request to the wrong tenant. Trace ID: 6a689abb-8652-4860-a3de-e78777b84a00 Correlation ID: f0ca1610-f212-4f15-86c4-5af98cd15940 Timestamp: 2025-03-04 04:59:58Z",
  "error_codes": [
    500011
  ],
  "timestamp": "2025-03-04 04:59:58Z",
  "trace_id": "6a689abb-8652-4860-a3de-e78777b84a00",
  "correlation_id": "f0ca1610-f212-4f15-86c4-5af98cd15940",
  "error_uri": "[https://chinaeast2.login.partner.microsoftonline.cn/error?code=500011"](https://chinaeast2.login.partner.microsoftonline.cn/error?code=500011%22)
}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: incorrect cloud provider setting in sovereign cloud
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: incorrect cloud provider setting in sovereign cloud
```
