### PR TITLE
[release-1.31] fix: detach disk should have more priority than attach disk on the same node

### DIFF
--- a/pkg/azuredisk/azure_controller_common.go
+++ b/pkg/azuredisk/azure_controller_common.go
@@ -101,8 +101,6 @@ type controllerCommon struct {
 	// AttachDetachInitialDelayInMs determines initial delay in milliseconds for batch disk attach/detach
 	AttachDetachInitialDelayInMs int
 	ForceDetachBackoff           bool
-	// a timed cache for disk attach hitting max data disk count, <nodeName, "">
-	hitMaxDataDiskCountCache azcache.Resource
 }
 
 // ExtendedLocation contains additional info about the location of resources.
@@ -189,21 +187,13 @@ func (c *controllerCommon) AttachDisk(ctx context.Context, diskName, diskURI str
 	}
 	node := strings.ToLower(string(nodeName))
 	diskuri := strings.ToLower(diskURI)
-
-	isMaxDataDiskCountExceeded := c.isMaxDataDiskCountExceeded(ctx, node)
-	if isMaxDataDiskCountExceeded {
-		c.lockMap.LockEntry(node)
-		defer c.lockMap.UnlockEntry(node)
-	}
-
 	requestNum, err := c.insertAttachDiskRequest(diskuri, node, &options)
 	if err != nil {
 		return -1, err
 	}
-	if !isMaxDataDiskCountExceeded {
-		c.lockMap.LockEntry(node)
-		defer c.lockMap.UnlockEntry(node)
-	}
+
+	c.lockMap.LockEntry(node)
+	defer c.lockMap.UnlockEntry(node)
 
 	if c.AttachDetachInitialDelayInMs > 0 && requestNum == 1 {
 		klog.V(2).Infof("wait %dms for more requests on node %s, current disk attach: %s", c.AttachDetachInitialDelayInMs, node, diskURI)
@@ -249,10 +239,6 @@ func (c *controllerCommon) AttachDisk(ctx context.Context, diskName, diskURI str
 
 	err = vmset.AttachDisk(ctx, nodeName, diskMap)
 	if err != nil {
-		if strings.Contains(err.Error(), "maximum number of data disks") {
-			klog.Warningf("hit max data disk count, set cache for node(%s)", nodeName)
-			c.hitMaxDataDiskCountCache.Set(node, "")
-		}
 		if IsOperationPreempted(err) {
 			klog.Errorf("Retry VM Update on node (%s) due to error (%v)", nodeName, err)
 			err = vmset.UpdateVM(ctx, nodeName)
@@ -631,13 +617,4 @@ func isInstanceNotFoundError(err error) bool {
 		return true
 	}
 	return strings.Contains(errMsg, errStatusCode400) && strings.Contains(errMsg, errInvalidParameter) && strings.Contains(errMsg, errTargetInstanceIDs)
-}
-
-func (c *controllerCommon) isMaxDataDiskCountExceeded(ctx context.Context, nodeName string) bool {
-	cache, err := c.hitMaxDataDiskCountCache.Get(ctx, nodeName, azcache.CacheReadTypeDefault)
-	if err != nil {
-		klog.Warningf("throttlingCache(%s) return with error: %s", nodeName, err)
-		return false
-	}
-	return cache != nil
 }

--- a/pkg/azuredisk/azure_controller_common_test.go
+++ b/pkg/azuredisk/azure_controller_common_test.go
@@ -45,7 +45,6 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/diskclient/mock_diskclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/mock_azclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
-	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/provider"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
@@ -91,8 +90,6 @@ func TestCommonAttachDisk(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	getter := func(_ context.Context, _ string) (interface{}, error) { return nil, nil }
-
 	initVM := func(testCloud *provider.Cloud, expectedVMs []compute.VirtualMachine) {
 		mockVMsClient := testCloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
 		for _, vm := range expectedVMs {
@@ -117,22 +114,21 @@ func TestCommonAttachDisk(t *testing.T) {
 	testTags := make(map[string]*string)
 	testTags[WriteAcceleratorEnabled] = ptr.To("true")
 	testCases := []struct {
-		desc                       string
-		diskName                   string
-		existedDisk                *armcompute.Disk
-		nodeName                   types.NodeName
-		vmList                     map[string]string
-		isDataDisksFull            bool
-		isBadDiskURI               bool
-		isDiskUsed                 bool
-		isMaxDataDiskCountExceeded bool
-		setup                      func(testCloud *provider.Cloud, expectedVMs []compute.VirtualMachine, statusCode int, result *retry.Error)
-		expectErr                  bool
-		isContextDeadlineErr       bool
-		statusCode                 int
-		waitResult                 *retry.Error
-		expectedLun                int32
-		contextDuration            time.Duration
+		desc                 string
+		diskName             string
+		existedDisk          *armcompute.Disk
+		nodeName             types.NodeName
+		vmList               map[string]string
+		isDataDisksFull      bool
+		isBadDiskURI         bool
+		isDiskUsed           bool
+		setup                func(testCloud *provider.Cloud, expectedVMs []compute.VirtualMachine, statusCode int, result *retry.Error)
+		expectErr            bool
+		isContextDeadlineErr bool
+		statusCode           int
+		waitResult           *retry.Error
+		expectedLun          int32
+		contextDuration      time.Duration
 	}{
 		{
 			desc:        "correct LUN and no error shall be returned if disk is nil",
@@ -143,17 +139,6 @@ func TestCommonAttachDisk(t *testing.T) {
 			expectedLun: 3,
 			expectErr:   false,
 			statusCode:  200,
-		},
-		{
-			desc:                       "correct LUN and no error shall be returned if disk is nil with max data disk count exceeded",
-			vmList:                     map[string]string{"vm1": "PowerState/Running"},
-			nodeName:                   "vm1",
-			diskName:                   "disk-name",
-			isMaxDataDiskCountExceeded: true,
-			existedDisk:                nil,
-			expectedLun:                3,
-			expectErr:                  false,
-			statusCode:                 200,
 		},
 		{
 			desc:        "LUN -1 and error shall be returned if there's no such instance corresponding to given nodeName",
@@ -270,10 +255,6 @@ func TestCommonAttachDisk(t *testing.T) {
 				cloud:               testCloud,
 				lockMap:             newLockMap(),
 				DisableDiskLunCheck: true,
-			}
-			testdiskController.hitMaxDataDiskCountCache, _ = azcache.NewTimedCache(5*time.Minute, getter, false)
-			if tt.isMaxDataDiskCountExceeded {
-				testdiskController.hitMaxDataDiskCountCache.Set(string(tt.nodeName), "")
 			}
 			lun, err := testdiskController.AttachDisk(ctx, test.diskName, diskURI, tt.nodeName, armcompute.CachingTypesReadOnly, tt.existedDisk, nil)
 
@@ -769,50 +750,6 @@ func TestDetachDiskRequestFuncs(t *testing.T) {
 			assert.Equal(t, strings.Contains(diskURI, test.diskURI), true, "TestCase[%d]: %s", i, test.desc)
 			assert.Equal(t, strings.Contains(diskName, test.diskName), true, "TestCase[%d]: %s", i, test.desc)
 		}
-	}
-}
-
-func TestIsMaxDataDiskCountExceeded(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	testCloud := provider.GetTestCloud(ctrl)
-	common := &controllerCommon{
-		cloud:   testCloud,
-		lockMap: newLockMap(),
-	}
-	getter := func(_ context.Context, _ string) (interface{}, error) { return nil, nil }
-	common.hitMaxDataDiskCountCache, _ = azcache.NewTimedCache(5*time.Minute, getter, false)
-
-	testCases := []struct {
-		desc           string
-		nodeName       string
-		expectedResult bool
-	}{
-		{
-			desc:           "max data disk count is not exceeded",
-			nodeName:       "",
-			expectedResult: false,
-		},
-		{
-			desc:           "max data disk count is not exceeded though another node has exceeded",
-			nodeName:       "node1",
-			expectedResult: false,
-		},
-		{
-			desc:           "max data disk count is exceeded",
-			nodeName:       "node1",
-			expectedResult: true,
-		},
-	}
-
-	for i, test := range testCases {
-		if test.expectedResult {
-			common.hitMaxDataDiskCountCache.Set(test.nodeName, "")
-		} else if test.nodeName != "" {
-			common.hitMaxDataDiskCountCache.Set("node2", "")
-		}
-		result := common.isMaxDataDiskCountExceeded(context.Background(), test.nodeName)
-		assert.Equal(t, test.expectedResult, result, "TestCase[%d]: %s", i, test.desc)
 	}
 }
 

--- a/pkg/azuredisk/azure_managedDiskController.go
+++ b/pkg/azuredisk/azure_managedDiskController.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -37,7 +36,6 @@ import (
 
 	azureconsts "sigs.k8s.io/azuredisk-csi-driver/pkg/azureconstants"
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/azureutils"
-	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/provider"
 )
@@ -55,8 +53,6 @@ func NewManagedDiskController(provider *provider.Cloud) *ManagedDiskController {
 		clientFactory:                provider.ComputeClientFactory,
 	}
 
-	getter := func(_ context.Context, _ string) (interface{}, error) { return nil, nil }
-	common.hitMaxDataDiskCountCache, _ = azcache.NewTimedCache(5*time.Minute, getter, false)
 	return &ManagedDiskController{common}
 }
 

--- a/pkg/azuredisk/azuredisk.go
+++ b/pkg/azuredisk/azuredisk.go
@@ -126,6 +126,7 @@ type DriverCore struct {
 	shouldWaitForSnapshotReady   bool
 	checkDiskLUNCollision        bool
 	forceDetachBackoff           bool
+	waitForDetach                bool
 	endpoint                     string
 	disableAVSetNodes            bool
 	removeNotReadyTaint          bool
@@ -183,6 +184,7 @@ func newDriverV1(options *DriverOptions) *Driver {
 	driver.shouldWaitForSnapshotReady = options.WaitForSnapshotReady
 	driver.checkDiskLUNCollision = options.CheckDiskLUNCollision
 	driver.forceDetachBackoff = options.ForceDetachBackoff
+	driver.waitForDetach = options.WaitForDetach
 	driver.endpoint = options.Endpoint
 	driver.disableAVSetNodes = options.DisableAVSetNodes
 	driver.removeNotReadyTaint = options.RemoveNotReadyTaint
@@ -264,6 +266,7 @@ func newDriverV1(options *DriverOptions) *Driver {
 		driver.diskController.DisableUpdateCache = driver.disableUpdateCache
 		driver.diskController.AttachDetachInitialDelayInMs = int(driver.attachDetachInitialDelayInMs)
 		driver.diskController.ForceDetachBackoff = driver.forceDetachBackoff
+		driver.diskController.WaitForDetach = driver.waitForDetach
 	}
 
 	driver.deviceHelper = optimization.NewSafeDeviceHelper()

--- a/pkg/azuredisk/azuredisk_option.go
+++ b/pkg/azuredisk/azuredisk_option.go
@@ -59,6 +59,7 @@ type DriverOptions struct {
 	WaitForSnapshotReady              bool
 	CheckDiskLUNCollision             bool
 	ForceDetachBackoff                bool
+	WaitForDetach                     bool
 	Kubeconfig                        string
 	Endpoint                          string
 	DisableAVSetNodes                 bool
@@ -107,6 +108,7 @@ func (o *DriverOptions) AddFlags() *flag.FlagSet {
 	fs.BoolVar(&o.WaitForSnapshotReady, "wait-for-snapshot-ready", true, "boolean flag to wait for snapshot ready when creating snapshot in same region")
 	fs.BoolVar(&o.CheckDiskLUNCollision, "check-disk-lun-collision", true, "boolean flag to check disk lun collisio before attaching disk")
 	fs.BoolVar(&o.ForceDetachBackoff, "force-detach-backoff", true, "boolean flag to force detach in disk detach backoff")
+	fs.BoolVar(&o.WaitForDetach, "wait-for-detach", true, "boolean flag to wait for detach before attaching disk on the same node")
 	fs.StringVar(&o.Kubeconfig, "kubeconfig", "", "Absolute path to the kubeconfig file. Required only when running out of cluster.")
 	fs.BoolVar(&o.DisableAVSetNodes, "disable-avset-nodes", false, "disable DisableAvailabilitySetNodes in cloud config for controller")
 	fs.BoolVar(&o.RemoveNotReadyTaint, "remove-not-ready-taint", true, "remove NotReady taint from node when node is ready")

--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -139,6 +139,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 				DisableDiskLunCheck: true,
 				clientFactory:       localCloud.ComputeClientFactory,
 				ForceDetachBackoff:  d.forceDetachBackoff,
+				WaitForDetach:       d.waitForDetach,
 			},
 		}
 		localDiskController.DisableUpdateCache = d.disableUpdateCache


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: detach disk should have more priority than attach disk on the same node, this could reduce the MaximumDataDisksExceeded error occurrence. 
cherrypick of https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/2992

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: detach disk should have more priority than attach disk on the same node
```
