### PR TITLE
[release-1.30] fix: detach disk should have more priority than attach disk on the same node

### DIFF
--- a/pkg/azuredisk/azure_controller_common.go
+++ b/pkg/azuredisk/azure_controller_common.go
@@ -102,8 +102,6 @@ type controllerCommon struct {
 	// AttachDetachInitialDelayInMs determines initial delay in milliseconds for batch disk attach/detach
 	AttachDetachInitialDelayInMs int
 	ForceDetachBackoff           bool
-	// a timed cache for disk attach hitting max data disk count, <nodeName, "">
-	hitMaxDataDiskCountCache azcache.Resource
 }
 
 // ExtendedLocation contains additional info about the location of resources.
@@ -190,21 +188,13 @@ func (c *controllerCommon) AttachDisk(ctx context.Context, diskName, diskURI str
 	}
 	node := strings.ToLower(string(nodeName))
 	diskuri := strings.ToLower(diskURI)
-
-	isMaxDataDiskCountExceeded := c.isMaxDataDiskCountExceeded(ctx, node)
-	if isMaxDataDiskCountExceeded {
-		c.lockMap.LockEntry(node)
-		defer c.lockMap.UnlockEntry(node)
-	}
-
 	requestNum, err := c.insertAttachDiskRequest(diskuri, node, &options)
 	if err != nil {
 		return -1, err
 	}
-	if !isMaxDataDiskCountExceeded {
-		c.lockMap.LockEntry(node)
-		defer c.lockMap.UnlockEntry(node)
-	}
+
+	c.lockMap.LockEntry(node)
+	defer c.lockMap.UnlockEntry(node)
 
 	if c.AttachDetachInitialDelayInMs > 0 && requestNum == 1 {
 		klog.V(2).Infof("wait %dms for more requests on node %s, current disk attach: %s", c.AttachDetachInitialDelayInMs, node, diskURI)
@@ -250,10 +240,6 @@ func (c *controllerCommon) AttachDisk(ctx context.Context, diskName, diskURI str
 
 	err = vmset.AttachDisk(ctx, nodeName, diskMap)
 	if err != nil {
-		if strings.Contains(err.Error(), "maximum number of data disks") {
-			klog.Warningf("hit max data disk count, set cache for node(%s)", nodeName)
-			c.hitMaxDataDiskCountCache.Set(node, "")
-		}
 		if IsOperationPreempted(err) {
 			klog.Errorf("Retry VM Update on node (%s) due to error (%v)", nodeName, err)
 			err = vmset.UpdateVM(ctx, nodeName)
@@ -692,13 +678,4 @@ func isInstanceNotFoundError(err error) bool {
 		return true
 	}
 	return strings.Contains(errMsg, errStatusCode400) && strings.Contains(errMsg, errInvalidParameter) && strings.Contains(errMsg, errTargetInstanceIDs)
-}
-
-func (c *controllerCommon) isMaxDataDiskCountExceeded(_ context.Context, nodeName string) bool {
-	cache, err := c.hitMaxDataDiskCountCache.Get(nodeName, azcache.CacheReadTypeDefault)
-	if err != nil {
-		klog.Warningf("throttlingCache(%s) return with error: %s", nodeName, err)
-		return false
-	}
-	return cache != nil
 }

--- a/pkg/azuredisk/azure_controller_common.go
+++ b/pkg/azuredisk/azure_controller_common.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
 
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
 	volerr "k8s.io/cloud-provider/volume/errors"
@@ -75,7 +76,7 @@ const (
 )
 
 var defaultBackOff = kwait.Backoff{
-	Steps:    20,
+	Steps:    7,
 	Duration: 2 * time.Second,
 	Factor:   1.5,
 	Jitter:   0.0,
@@ -102,6 +103,7 @@ type controllerCommon struct {
 	// AttachDetachInitialDelayInMs determines initial delay in milliseconds for batch disk attach/detach
 	AttachDetachInitialDelayInMs int
 	ForceDetachBackoff           bool
+	WaitForDetach                bool
 }
 
 // ExtendedLocation contains additional info about the location of resources.
@@ -193,10 +195,29 @@ func (c *controllerCommon) AttachDisk(ctx context.Context, diskName, diskURI str
 		return -1, err
 	}
 
+	var waitForDetachHappened bool
+	if c.WaitForDetach {
+		// wait for disk detach to finish first on the same node
+		if err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 30*time.Second, true, func(context.Context) (bool, error) {
+			detachDiskReqeustNum, err := c.getDetachDiskRequestNum(node)
+			if err != nil {
+				return false, err
+			}
+			if detachDiskReqeustNum == 0 {
+				return true, nil
+			}
+			klog.V(4).Infof("there are still %d detach disk requests on node %s, wait for detach to finish, current disk: %s", detachDiskReqeustNum, node, diskName)
+			waitForDetachHappened = true
+			return false, nil
+		}); err != nil {
+			klog.Errorf("current disk: %s, wait for detach disk requests on node %s failed: %v", diskName, node, err)
+		}
+	}
+
 	c.lockMap.LockEntry(node)
 	defer c.lockMap.UnlockEntry(node)
 
-	if c.AttachDetachInitialDelayInMs > 0 && requestNum == 1 {
+	if !waitForDetachHappened && c.AttachDetachInitialDelayInMs > 0 && requestNum == 1 {
 		klog.V(2).Infof("wait %dms for more requests on node %s, current disk attach: %s", c.AttachDetachInitialDelayInMs, node, diskURI)
 		time.Sleep(time.Duration(c.AttachDetachInitialDelayInMs) * time.Millisecond)
 	}
@@ -437,6 +458,20 @@ func (c *controllerCommon) cleanDetachDiskRequests(nodeName string) (map[string]
 	// clean up original requests in disk map
 	c.detachDiskMap.Store(nodeName, make(map[string]string))
 	return diskMap, nil
+}
+
+func (c *controllerCommon) getDetachDiskRequestNum(nodeName string) (int, error) {
+	detachDiskMapKey := nodeName + detachDiskMapKeySuffix
+	c.lockMap.LockEntry(detachDiskMapKey)
+	defer c.lockMap.UnlockEntry(detachDiskMapKey)
+	v, ok := c.detachDiskMap.Load(nodeName)
+	if !ok {
+		return 0, nil
+	}
+	if diskMap, ok := v.(map[string]string); ok {
+		return len(diskMap), nil
+	}
+	return -1, fmt.Errorf("convert detachDiskMap failure on node(%s)", nodeName)
 }
 
 // GetNodeDataDisks invokes vmSet interfaces to get data disks for the node.

--- a/pkg/azuredisk/azure_controller_common_test.go
+++ b/pkg/azuredisk/azure_controller_common_test.go
@@ -256,6 +256,7 @@ func TestCommonAttachDisk(t *testing.T) {
 				cloud:               testCloud,
 				lockMap:             newLockMap(),
 				DisableDiskLunCheck: true,
+				WaitForDetach:       true,
 			}
 			lun, err := testdiskController.AttachDisk(ctx, test.diskName, diskURI, tt.nodeName, armcompute.CachingTypesReadOnly, tt.existedDisk, nil)
 
@@ -305,8 +306,9 @@ func TestCommonDetachDisk(t *testing.T) {
 	for i, test := range testCases {
 		testCloud := provider.GetTestCloud(ctrl)
 		common := &controllerCommon{
-			cloud:   testCloud,
-			lockMap: newLockMap(),
+			cloud:              testCloud,
+			lockMap:            newLockMap(),
+			ForceDetachBackoff: true,
 		}
 		diskURI := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/disk-name",
 			testCloud.SubscriptionID, testCloud.ResourceGroup)
@@ -823,7 +825,7 @@ func TestIsInstanceNotFoundError(t *testing.T) {
 	}
 }
 
-func TestAttachDiskRequestFuncs(t *testing.T) {
+func TestAttachDiskRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -899,7 +901,7 @@ func TestAttachDiskRequestFuncs(t *testing.T) {
 	}
 }
 
-func TestDetachDiskRequestFuncs(t *testing.T) {
+func TestDetachDiskRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -971,6 +973,77 @@ func TestDetachDiskRequestFuncs(t *testing.T) {
 			assert.Equal(t, strings.Contains(diskURI, test.diskURI), true, "TestCase[%d]: %s", i, test.desc)
 			assert.Equal(t, strings.Contains(diskName, test.diskName), true, "TestCase[%d]: %s", i, test.desc)
 		}
+	}
+}
+
+func TestGetDetachDiskRequestNum(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	testCases := []struct {
+		desc                 string
+		diskURI              string
+		nodeName             string
+		diskName             string
+		diskNum              int
+		duplicateDiskRequest bool
+		expectedErr          bool
+	}{
+		{
+			desc:        "one disk request in queue",
+			diskURI:     "diskURI",
+			nodeName:    "nodeName",
+			diskName:    "diskName",
+			diskNum:     1,
+			expectedErr: false,
+		},
+		{
+			desc:        "multiple disk requests in queue",
+			diskURI:     "diskURI",
+			nodeName:    "nodeName",
+			diskName:    "diskName",
+			diskNum:     10,
+			expectedErr: false,
+		},
+		{
+			desc:        "zero disk request in queue",
+			diskURI:     "diskURI",
+			nodeName:    "nodeName",
+			diskName:    "diskName",
+			diskNum:     0,
+			expectedErr: false,
+		},
+		{
+			desc:                 "multiple disk requests in queue",
+			diskURI:              "diskURI",
+			nodeName:             "nodeName",
+			diskName:             "diskName",
+			duplicateDiskRequest: true,
+			diskNum:              10,
+			expectedErr:          false,
+		},
+	}
+
+	for i, test := range testCases {
+		testCloud := provider.GetTestCloud(ctrl)
+		common := &controllerCommon{
+			cloud:   testCloud,
+			lockMap: newLockMap(),
+		}
+		for i := 1; i <= test.diskNum; i++ {
+			diskURI := fmt.Sprintf("%s%d", test.diskURI, i)
+			diskName := fmt.Sprintf("%s%d", test.diskName, i)
+			_, err := common.insertDetachDiskRequest(diskName, diskURI, test.nodeName)
+			assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s", i, test.desc)
+			if test.duplicateDiskRequest {
+				_, err := common.insertDetachDiskRequest(diskName, diskURI, test.nodeName)
+				assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s", i, test.desc)
+			}
+		}
+
+		detachDiskReqeustNum, err := common.getDetachDiskRequestNum(test.nodeName)
+		assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s", i, test.desc)
+		assert.Equal(t, test.diskNum, detachDiskReqeustNum, "TestCase[%d]: %s", i, test.desc)
 	}
 }
 

--- a/pkg/azuredisk/azure_controller_common_test.go
+++ b/pkg/azuredisk/azure_controller_common_test.go
@@ -46,7 +46,6 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/diskclient/mock_diskclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/mock_azclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
-	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/provider"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
@@ -92,8 +91,6 @@ func TestCommonAttachDisk(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	getter := func(_ string) (interface{}, error) { return nil, nil }
-
 	initVM := func(testCloud *provider.Cloud, expectedVMs []compute.VirtualMachine) {
 		mockVMsClient := testCloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
 		for _, vm := range expectedVMs {
@@ -118,22 +115,21 @@ func TestCommonAttachDisk(t *testing.T) {
 	testTags := make(map[string]*string)
 	testTags[WriteAcceleratorEnabled] = pointer.String("true")
 	testCases := []struct {
-		desc                       string
-		diskName                   string
-		existedDisk                *armcompute.Disk
-		nodeName                   types.NodeName
-		vmList                     map[string]string
-		isDataDisksFull            bool
-		isBadDiskURI               bool
-		isDiskUsed                 bool
-		isMaxDataDiskCountExceeded bool
-		setup                      func(testCloud *provider.Cloud, expectedVMs []compute.VirtualMachine, statusCode int, result *retry.Error)
-		expectErr                  bool
-		isContextDeadlineErr       bool
-		statusCode                 int
-		waitResult                 *retry.Error
-		expectedLun                int32
-		contextDuration            time.Duration
+		desc                 string
+		diskName             string
+		existedDisk          *armcompute.Disk
+		nodeName             types.NodeName
+		vmList               map[string]string
+		isDataDisksFull      bool
+		isBadDiskURI         bool
+		isDiskUsed           bool
+		setup                func(testCloud *provider.Cloud, expectedVMs []compute.VirtualMachine, statusCode int, result *retry.Error)
+		expectErr            bool
+		isContextDeadlineErr bool
+		statusCode           int
+		waitResult           *retry.Error
+		expectedLun          int32
+		contextDuration      time.Duration
 	}{
 		{
 			desc:        "correct LUN and no error shall be returned if disk is nil",
@@ -144,17 +140,6 @@ func TestCommonAttachDisk(t *testing.T) {
 			expectedLun: 3,
 			expectErr:   false,
 			statusCode:  200,
-		},
-		{
-			desc:                       "correct LUN and no error shall be returned if disk is nil with max data disk count exceeded",
-			vmList:                     map[string]string{"vm1": "PowerState/Running"},
-			nodeName:                   "vm1",
-			diskName:                   "disk-name",
-			isMaxDataDiskCountExceeded: true,
-			existedDisk:                nil,
-			expectedLun:                3,
-			expectErr:                  false,
-			statusCode:                 200,
 		},
 		{
 			desc:        "LUN -1 and error shall be returned if there's no such instance corresponding to given nodeName",
@@ -271,10 +256,6 @@ func TestCommonAttachDisk(t *testing.T) {
 				cloud:               testCloud,
 				lockMap:             newLockMap(),
 				DisableDiskLunCheck: true,
-			}
-			testdiskController.hitMaxDataDiskCountCache, _ = azcache.NewTimedCache(5*time.Minute, getter, false)
-			if tt.isMaxDataDiskCountExceeded {
-				testdiskController.hitMaxDataDiskCountCache.Set(string(tt.nodeName), "")
 			}
 			lun, err := testdiskController.AttachDisk(ctx, test.diskName, diskURI, tt.nodeName, armcompute.CachingTypesReadOnly, tt.existedDisk, nil)
 
@@ -990,50 +971,6 @@ func TestDetachDiskRequestFuncs(t *testing.T) {
 			assert.Equal(t, strings.Contains(diskURI, test.diskURI), true, "TestCase[%d]: %s", i, test.desc)
 			assert.Equal(t, strings.Contains(diskName, test.diskName), true, "TestCase[%d]: %s", i, test.desc)
 		}
-	}
-}
-
-func TestIsMaxDataDiskCountExceeded(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	testCloud := provider.GetTestCloud(ctrl)
-	common := &controllerCommon{
-		cloud:   testCloud,
-		lockMap: newLockMap(),
-	}
-	getter := func(_ string) (interface{}, error) { return nil, nil }
-	common.hitMaxDataDiskCountCache, _ = azcache.NewTimedCache(5*time.Minute, getter, false)
-
-	testCases := []struct {
-		desc           string
-		nodeName       string
-		expectedResult bool
-	}{
-		{
-			desc:           "max data disk count is not exceeded",
-			nodeName:       "",
-			expectedResult: false,
-		},
-		{
-			desc:           "max data disk count is not exceeded though another node has exceeded",
-			nodeName:       "node1",
-			expectedResult: false,
-		},
-		{
-			desc:           "max data disk count is exceeded",
-			nodeName:       "node1",
-			expectedResult: true,
-		},
-	}
-
-	for i, test := range testCases {
-		if test.expectedResult {
-			common.hitMaxDataDiskCountCache.Set(test.nodeName, "")
-		} else if test.nodeName != "" {
-			common.hitMaxDataDiskCountCache.Set("node2", "")
-		}
-		result := common.isMaxDataDiskCountExceeded(context.Background(), test.nodeName)
-		assert.Equal(t, test.expectedResult, result, "TestCase[%d]: %s", i, test.desc)
 	}
 }
 

--- a/pkg/azuredisk/azure_managedDiskController.go
+++ b/pkg/azuredisk/azure_managedDiskController.go
@@ -24,7 +24,6 @@ import (
 	"path"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -37,7 +36,6 @@ import (
 	"k8s.io/utils/pointer"
 
 	azureconsts "sigs.k8s.io/azuredisk-csi-driver/pkg/azureconstants"
-	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/provider"
 )
@@ -55,8 +53,6 @@ func NewManagedDiskController(provider *provider.Cloud) *ManagedDiskController {
 		clientFactory:                provider.ComputeClientFactory,
 	}
 
-	getter := func(_ string) (interface{}, error) { return nil, nil }
-	common.hitMaxDataDiskCountCache, _ = azcache.NewTimedCache(5*time.Minute, getter, false)
 	return &ManagedDiskController{common}
 }
 

--- a/pkg/azuredisk/azuredisk.go
+++ b/pkg/azuredisk/azuredisk.go
@@ -120,6 +120,7 @@ type DriverCore struct {
 	shouldWaitForSnapshotReady   bool
 	checkDiskLUNCollision        bool
 	forceDetachBackoff           bool
+	waitForDetach                bool
 	endpoint                     string
 	disableAVSetNodes            bool
 	removeNotReadyTaint          bool
@@ -176,6 +177,7 @@ func newDriverV1(options *DriverOptions) *Driver {
 	driver.shouldWaitForSnapshotReady = options.WaitForSnapshotReady
 	driver.checkDiskLUNCollision = options.CheckDiskLUNCollision
 	driver.forceDetachBackoff = options.ForceDetachBackoff
+	driver.waitForDetach = options.WaitForDetach
 	driver.endpoint = options.Endpoint
 	driver.disableAVSetNodes = options.DisableAVSetNodes
 	driver.removeNotReadyTaint = options.RemoveNotReadyTaint
@@ -257,6 +259,7 @@ func newDriverV1(options *DriverOptions) *Driver {
 		driver.diskController.DisableUpdateCache = driver.disableUpdateCache
 		driver.diskController.AttachDetachInitialDelayInMs = int(driver.attachDetachInitialDelayInMs)
 		driver.diskController.ForceDetachBackoff = driver.forceDetachBackoff
+		driver.diskController.WaitForDetach = driver.waitForDetach
 	}
 
 	driver.deviceHelper = optimization.NewSafeDeviceHelper()

--- a/pkg/azuredisk/azuredisk_option.go
+++ b/pkg/azuredisk/azuredisk_option.go
@@ -58,6 +58,7 @@ type DriverOptions struct {
 	WaitForSnapshotReady         bool
 	CheckDiskLUNCollision        bool
 	ForceDetachBackoff           bool
+	WaitForDetach                bool
 	Kubeconfig                   string
 	Endpoint                     string
 	DisableAVSetNodes            bool
@@ -103,6 +104,7 @@ func (o *DriverOptions) AddFlags() *flag.FlagSet {
 	fs.BoolVar(&o.WaitForSnapshotReady, "wait-for-snapshot-ready", true, "boolean flag to wait for snapshot ready when creating snapshot in same region")
 	fs.BoolVar(&o.CheckDiskLUNCollision, "check-disk-lun-collision", true, "boolean flag to check disk lun collisio before attaching disk")
 	fs.BoolVar(&o.ForceDetachBackoff, "force-detach-backoff", true, "boolean flag to force detach in disk detach backoff")
+	fs.BoolVar(&o.WaitForDetach, "wait-for-detach", true, "boolean flag to wait for detach before attaching disk on the same node")
 	fs.StringVar(&o.Kubeconfig, "kubeconfig", "", "Absolute path to the kubeconfig file. Required only when running out of cluster.")
 	fs.BoolVar(&o.DisableAVSetNodes, "disable-avset-nodes", false, "disable DisableAvailabilitySetNodes in cloud config for controller")
 	fs.BoolVar(&o.RemoveNotReadyTaint, "remove-not-ready-taint", true, "remove NotReady taint from node when node is ready")

--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -138,6 +138,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 				DisableDiskLunCheck: true,
 				clientFactory:       localCloud.ComputeClientFactory,
 				ForceDetachBackoff:  d.forceDetachBackoff,
+				WaitForDetach:       d.waitForDetach,
 			},
 		}
 		localDiskController.DisableUpdateCache = d.disableUpdateCache


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: detach disk should have more priority than attach disk on the same node, this could reduce the MaximumDataDisksExceeded error occurrence. 
cherrypick of https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/2992

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: detach disk should have more priority than attach disk on the same node
```
