### PR TITLE
fix: incorrect disk num discovery on Windows 2019 node

### DIFF
--- a/pkg/os/disk/disk.go
+++ b/pkg/os/disk/disk.go
@@ -58,7 +58,7 @@ func ListDisksUsingCIM() (map[uint32]Location, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to list disk location. cmd: %q, output: %q, err %v", cmd, string(out), err)
 	}
-	klog.V(6).Infof("ListDisksUsingCIM output: %s", string(out))
+	klog.V(5).Infof("ListDisksUsingCIM output: %s", string(out))
 
 	var getCimInstance []struct {
 		Index           uint32 `json:"Index"`
@@ -97,7 +97,7 @@ func ListDiskLocations() (map[uint32]Location, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to list disk location. cmd: %q, output: %q, err %v", cmd, string(out), err)
 	}
-	klog.V(6).Infof("ListDiskLocations output: %s", string(out))
+	klog.V(5).Infof("ListDiskLocations output: %s", string(out))
 
 	var getDisk []map[string]interface{}
 	err = json.Unmarshal(out, &getDisk)
@@ -127,12 +127,16 @@ func ListDiskLocations() (map[uint32]Location, error) {
 					switch strings.TrimSpace(itemSplit[0]) {
 					case "Adapter":
 						d.Adapter = strings.TrimSpace(itemSplit[1])
+						if d.Adapter == "0" {
+							klog.V(2).Infof("skipping adapter 0 disk, number: %d, location: %s", int(num), str)
+							found = false
+						}
 					case "Target":
 						d.Target = strings.TrimSpace(itemSplit[1])
 					case "LUN":
 						d.LUNID = strings.TrimSpace(itemSplit[1])
 					default:
-						klog.Warningf("Got unknown field : %s=%s", itemSplit[0], itemSplit[1])
+						klog.V(6).Infof("Got unknown field : %s=%s", itemSplit[0], itemSplit[1])
 					}
 				}
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: incorrect disk num discovery on Windows 2019 node

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3029

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
<details>
```
ConvertTo-Json @(Get-CimInstance win32_diskdrive | Where-Object { $_.Model -eq "Virtual_Disk NVME Premium" -or $_.SCSIPort -eq 3 })

ConvertTo-Json @(Get-CimInstance win32_diskdrive | Where-Object { $_.Model -eq "Virtual_Disk NVME Premium" -or $_.SCSIPort -eq 3 } | Select-Object Index, SCSILogicalUnit, SCSITargetId, SCSIPort, SCSIBus, Model)

PS C:\hpc> ConvertTo-Json @(Get-CimInstance win32_diskdrive | Where-Object { $_.Model -eq "Virtual_Disk NVME Premium" -or $_.SCSIPort -Ne 0 } | Select-Object Index, SCSILogicalUnit, SCSITargetId, SCSIPort, SCSIBus, Model)
[
    {
        "Index":  1,
        "SCSILogicalUnit":  1,
        "SCSITargetId":  0,
        "SCSIPort":  4,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  3,
        "SCSILogicalUnit":  3,
        "SCSITargetId":  0,
        "SCSIPort":  4,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  2,
        "SCSILogicalUnit":  2,
        "SCSITargetId":  0,
        "SCSIPort":  4,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  5,
        "SCSILogicalUnit":  4,
        "SCSITargetId":  0,
        "SCSIPort":  4,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  4,
        "SCSILogicalUnit":  5,
        "SCSITargetId":  0,
        "SCSIPort":  4,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  13,
        "SCSILogicalUnit":  6,
        "SCSITargetId":  0,
        "SCSIPort":  4,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  6,
        "SCSILogicalUnit":  7,
        "SCSITargetId":  0,
        "SCSIPort":  4,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  7,
        "SCSILogicalUnit":  8,
        "SCSITargetId":  0,
        "SCSIPort":  4,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  8,
        "SCSILogicalUnit":  9,
        "SCSITargetId":  0,
        "SCSIPort":  4,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  9,
        "SCSILogicalUnit":  10,
        "SCSITargetId":  0,
        "SCSIPort":  4,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  10,
        "SCSILogicalUnit":  11,
        "SCSITargetId":  0,
        "SCSIPort":  4,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  11,
        "SCSILogicalUnit":  12,
        "SCSITargetId":  0,
        "SCSIPort":  4,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  12,
        "SCSILogicalUnit":  13,
        "SCSITargetId":  0,
        "SCSIPort":  4,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  17,
        "SCSILogicalUnit":  14,
        "SCSITargetId":  0,
        "SCSIPort":  4,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  14,
        "SCSILogicalUnit":  15,
        "SCSITargetId":  0,
        "SCSIPort":  4,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  15,
        "SCSILogicalUnit":  0,
        "SCSITargetId":  0,
        "SCSIPort":  3,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  19,
        "SCSILogicalUnit":  16,
        "SCSITargetId":  0,
        "SCSIPort":  4,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  18,
        "SCSILogicalUnit":  17,
        "SCSITargetId":  0,
        "SCSIPort":  4,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  16,
        "SCSILogicalUnit":  1,
        "SCSITargetId":  0,
        "SCSIPort":  3,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
    {
        "Index":  20,
        "SCSILogicalUnit":  18,
        "SCSITargetId":  0,
        "SCSIPort":  4,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    }
]

PS C:\hpc> ConvertTo-Json @(Get-CimInstance win32_diskdrive | Where-Object { $_.Model -eq "Virtual_Disk NVME Premium" -or $_.SCSIPort -Ne 0 } | Select-Object Index, SCSILogicalUnit, SCSITargetId, SCSIPort, SCSIBus, Model)
[
    {
        "Index":  1,
        "SCSILogicalUnit":  0,
        "SCSITargetId":  0,
        "SCSIPort":  3,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    }
]



PS C:\hpc> ConvertTo-Json @(Get-Disk | select Number, Location)
[
    {
        "Number":  0,
        "Location":  "PCI Slot 0 : Adapter 0 : Channel 0 : Device 0"
    },
    {
        "Number":  15,
        "Location":  "Integrated : Adapter 3 : Port 0 : Target 0 : LUN 0"
    },
    {
        "Number":  16,
        "Location":  "Integrated : Adapter 3 : Port 0 : Target 0 : LUN 1"
    },
    {
        "Number":  1,
        "Location":  "C:\\ProgramData\\containerd\\root\\io.containerd.snapshotter.v1.windows\\snapshots\\141\\sandbox.vhdx"
    },
    {
        "Number":  2,
        "Location":  "C:\\ProgramData\\containerd\\root\\io.containerd.snapshotter.v1.windows\\snapshots\\136\\sandbox.vhdx"
    },
    {
        "Number":  3,
        "Location":  "C:\\ProgramData\\containerd\\root\\io.containerd.snapshotter.v1.windows\\snapshots\\159\\sandbox.vhdx"
    },
    {
        "Number":  5,
        "Location":  "C:\\ProgramData\\containerd\\root\\io.containerd.snapshotter.v1.windows\\snapshots\\149\\sandbox.vhdx"
    },
    {
        "Number":  4,
        "Location":  "C:\\ProgramData\\containerd\\root\\io.containerd.snapshotter.v1.windows\\snapshots\\140\\sandbox.vhdx"
    },
    {
        "Number":  13,
        "Location":  "C:\\ProgramData\\containerd\\root\\io.containerd.snapshotter.v1.windows\\snapshots\\212\\sandbox.vhdx"
    },
    {
        "Number":  6,
        "Location":  "C:\\ProgramData\\containerd\\root\\io.containerd.snapshotter.v1.windows\\snapshots\\161\\sandbox.vhdx"
    },
    {
        "Number":  7,
        "Location":  "C:\\ProgramData\\containerd\\root\\io.containerd.snapshotter.v1.windows\\snapshots\\166\\sandbox.vhdx"
    },
    {
        "Number":  8,
        "Location":  "C:\\ProgramData\\containerd\\root\\io.containerd.snapshotter.v1.windows\\snapshots\\169\\sandbox.vhdx"
    },
    {
        "Number":  9,
        "Location":  "C:\\ProgramData\\containerd\\root\\io.containerd.snapshotter.v1.windows\\snapshots\\175\\sandbox.vhdx"
    },
    {
        "Number":  10,
        "Location":  "C:\\ProgramData\\containerd\\root\\io.containerd.snapshotter.v1.windows\\snapshots\\176\\sandbox.vhdx"
    },
    {
        "Number":  11,
        "Location":  "C:\\ProgramData\\containerd\\root\\io.containerd.snapshotter.v1.windows\\snapshots\\177\\sandbox.vhdx"
    },
    {
        "Number":  12,
        "Location":  "C:\\ProgramData\\containerd\\root\\io.containerd.snapshotter.v1.windows\\snapshots\\178\\sandbox.vhdx"
    },
    {
        "Number":  17,
        "Location":  "C:\\ProgramData\\containerd\\root\\io.containerd.snapshotter.v1.windows\\snapshots\\219\\sandbox.vhdx"
    },
    {
        "Number":  14,
        "Location":  "C:\\ProgramData\\containerd\\root\\io.containerd.snapshotter.v1.windows\\snapshots\\214\\sandbox.vhdx"
    },
    {
        "Number":  19,
        "Location":  "C:\\ProgramData\\containerd\\root\\io.containerd.snapshotter.v1.windows\\snapshots\\220\\sandbox.vhdx"
    },
    {
        "Number":  18,
        "Location":  "C:\\ProgramData\\containerd\\root\\io.containerd.snapshotter.v1.windows\\snapshots\\217\\sandbox.vhdx"
    },
    {
        "Number":  20,
        "Location":  "C:\\ProgramData\\containerd\\root\\io.containerd.snapshotter.v1.windows\\snapshots\\221\\sandbox.vhdx"
    }
]


PS C:\hpc> Get-Disk -Number 16

Number Friendly Name                                      Serial Number                    HealthStatus         OperationalStatus      Total Size Partition
                                                                                                                                                  Style
------ -------------                                      -------------                    ------------         -----------------      ---------- ----------
16     Msft Virtual Disk                                                                   Healthy              Online                     100 GB RAW


    {
        "Index":  1,
        "SCSILogicalUnit":  1,
        "SCSITargetId":  0,
        "SCSIPort":  4,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },
	
    {
        "Index":  16,
        "SCSILogicalUnit":  1,
        "SCSITargetId":  0,
        "SCSIPort":  3,
        "SCSIBus":  0,
        "Model":  "Microsoft Virtual Disk"
    },

# Gen2 Windows node
I0419 14:02:40.317733     752 utils.go:105] GRPC call: /csi.v1.Node/NodeStageVolume
I0419 14:02:40.317733     752 utils.go:106] GRPC request: {"publish_context":{"LUN":"0"},"staging_target_path":"\\var\\lib\\kubelet\\plugins\\kubernetes.io\\csi\\disk.csi.azure.com\\a63e2d3886284cfbdb45cce97cb66a469f363a5574afdefac52747fc5ca18b42\\globalmount","volume_capability":{"AccessType":{"Mount":{}},"access_mode":{"mode":7}},"volume_context":{"csi.storage.k8s.io/pv/name":"pvc-eec2e808-ec85-4cd0-bf30-e80cbaa117be","csi.storage.k8s.io/pvc/name":"persistent-storage-statefulset-azuredisk-win-0","csi.storage.k8s.io/pvc/namespace":"default","requestedsizegib":"100","skuName":"StandardSSD_LRS","storage.kubernetes.io/csiProvisionerIdentity":"1744986261215-3879-disk.csi.azure.com"},"volume_id":"/subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks131euap_andy-aks131euap_eastus2euap/providers/Microsoft.Compute/disks/pvc-eec2e808-ec85-4cd0-bf30-e80cbaa117be"}
I0419 14:02:49.551773     752 disk.go:100] ListDiskLocations output: [
    {
        "Number":  2,
        "Location":  "Integrated : Bus 0 : Device 63667 : Function 30747 : Adapter 1 : Port 0 : Target 0 : LUN 0",
        "PartitionStyle":  "GPT"
    },
    {
        "Number":  0,
        "Location":  "Integrated : Bus 0 : Device 63667 : Function 30746 : Adapter 0 : Port 0 : Target 0 : LUN 0",
        "PartitionStyle":  "GPT"
    },
    {
        "Number":  1,
        "Location":  "Integrated : Bus 0 : Device 63667 : Function 30746 : Adapter 0 : Port 0 : Target 0 : LUN 1",
        "PartitionStyle":  "MBR"
    }
]
W0419 14:02:49.551773     752 disk.go:139] Got unknown field : Bus=0
W0419 14:02:49.552308     752 disk.go:139] Got unknown field : Device=63667
W0419 14:02:49.552404     752 disk.go:139] Got unknown field : Function=30747
W0419 14:02:49.552404     752 disk.go:139] Got unknown field : Port=0
W0419 14:02:49.552404     752 disk.go:139] Got unknown field : Bus=0
W0419 14:02:49.552404     752 disk.go:139] Got unknown field : Device=63667
W0419 14:02:49.552404     752 disk.go:139] Got unknown field : Function=30746
I0419 14:02:49.552404     752 disk.go:131] skipping adapter 0 disk, number: 0, location: Integrated : Bus 0 : Device 63667 : Function 30746 : Adapter 0 : Port 0 : Target 0 : LUN 0
W0419 14:02:49.552404     752 disk.go:139] Got unknown field : Port=0
I0419 14:02:49.552404     752 disk.go:114] skipping MBR disk, number: 1, location: Integrated : Bus 0 : Device 63667 : Function 30746 : Adapter 0 : Port 0 : Target 0 : LUN 1
I0419 14:02:49.553069     752 nodeserver.go:164] NodeStageVolume: formatting 2 and mounting at \var\lib\kubelet\plugins\kubernetes.io\csi\disk.csi.azure.com\a63e2d3886284cfbdb45cce97cb66a469f363a5574afdefac52747fc5ca18b42\globalmount with mount options([])
I0419 14:02:56.460058     752 disk.go:415] Disk 2 already initialized


```

</details>

**Release note**:
```
fix: incorrect disk num discovery on Windows 2019 node
```
