### PR TITLE
feat: Use WMI to implement Disk API to reduce PowerShell overhead#2

### DIFF
--- a/pkg/os/cim/disk.go
+++ b/pkg/os/cim/disk.go
@@ -27,6 +27,22 @@ import (
 	"github.com/microsoft/wmi/server2019/root/microsoft/windows/storage"
 )
 
+const (
+	// PartitionStyleUnknown indicates an unknown partition table format
+	PartitionStyleUnknown = 0
+	// PartitionStyleMBR indicates the disk uses Master Boot Record (MBR) format
+	PartitionStyleMBR = 1
+	// PartitionStyleGPT indicates the disk uses GUID Partition Table (GPT) format
+	PartitionStyleGPT = 2
+
+	// GPTPartitionTypeBasicData is the GUID for basic data partitions in GPT
+	// Used for general purpose storage partitions
+	GPTPartitionTypeBasicData = "{ebd0a0a2-b9e5-4433-87c0-68b6b72699c7}"
+	// GPTPartitionTypeMicrosoftReserved is the GUID for Microsoft Reserved Partition (MSR)
+	// Reserved by Windows for system use
+	GPTPartitionTypeMicrosoftReserved = "{e3c9e316-0b5c-4db8-817d-f92df00215ae}"
+)
+
 // QueryDiskByNumber retrieves disk information for a specific disk identified by its number.
 //
 // The equivalent WMI query is:
@@ -49,4 +65,32 @@ func QueryDiskByNumber(diskNumber uint32, selectorList []string) (*storage.MSFT_
 	}
 
 	return disk, nil
+}
+
+// ListDisks retrieves information about all available disks.
+//
+// The equivalent WMI query is:
+//
+//	SELECT [selectors] FROM MSFT_Disk
+//
+// Refer to https://learn.microsoft.com/en-us/windows-hardware/drivers/storage/msft-disk
+// for the WMI class definition.
+func ListDisks(selectorList []string) ([]*storage.MSFT_Disk, error) {
+	diskQuery := query.NewWmiQueryWithSelectList("MSFT_Disk", selectorList)
+	instances, err := QueryInstances(WMINamespaceStorage, diskQuery)
+	if IgnoreNotFound(err) != nil {
+		return nil, err
+	}
+
+	var disks []*storage.MSFT_Disk
+	for _, instance := range instances {
+		disk, err := storage.NewMSFT_DiskEx1(instance)
+		if err != nil {
+			return nil, fmt.Errorf("failed to query disk %v. error: %v", instance, err)
+		}
+
+		disks = append(disks, disk)
+	}
+
+	return disks, nil
 }

--- a/pkg/os/disk/disk_cim.go
+++ b/pkg/os/disk/disk_cim.go
@@ -1,0 +1,451 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"github.com/microsoft/wmi/pkg/base/query"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/azuredisk-csi-driver/pkg/os/cim"
+)
+
+var _ DiskAPI = &cimDiskAPI{}
+
+type cimDiskAPI struct{}
+
+func NewCIMDiskAPI() *cimDiskAPI {
+	return &cimDiskAPI{}
+}
+
+// ListDiskLocations - constructs a map with the disk number as the key and the DiskLocation structure
+// as the value. The DiskLocation struct has various fields like the Adapter, Bus, Target and LUNID.
+func (*cimDiskAPI) ListDiskLocations() (map[uint32]Location, error) {
+	// sample response
+	// [{
+	//    "number":  0,
+	//    "location":  "PCI Slot 3 : Adapter 0 : Port 0 : Target 1 : LUN 0"
+	// }, ...]
+	disks, err := cim.ListDisks([]string{"Number", "Location", "PartitionStyle"})
+	if err != nil {
+		return nil, fmt.Errorf("could not query disk locations")
+	}
+
+	m := make(map[uint32]Location)
+	for _, disk := range disks {
+		num, err := disk.GetProperty("Number")
+		if err != nil {
+			return m, fmt.Errorf("failed to query disk number: %v, %w", disk, err)
+		}
+
+		location, err := disk.GetPropertyLocation()
+		if err != nil {
+			return m, fmt.Errorf("failed to query disk location: %v, %w", disk, err)
+		}
+
+		partitionStyle, err := disk.GetProperty("PartitionStyle")
+		if err == nil {
+			if partitionStyle.(int32) == int32(cim.PartitionStyleMBR) {
+				klog.V(2).Infof("skipping MBR disk, number: %d, location: %s", num, location)
+				continue
+			}
+		} else {
+			klog.Warningf("failed to query partition style of disk %d: %v", num, err)
+		}
+
+		klog.V(5).Infof("disk number: %d, location: %s, partitionStyle: %d", num, location, partitionStyle)
+		found := false
+		s := strings.Split(location, ":")
+		if len(s) >= 5 {
+			var d Location
+			for _, item := range s {
+				item = strings.TrimSpace(item)
+				itemSplit := strings.Split(item, " ")
+				if len(itemSplit) == 2 {
+					found = true
+					switch strings.TrimSpace(itemSplit[0]) {
+					case "Adapter":
+						d.Adapter = strings.TrimSpace(itemSplit[1])
+						if d.Adapter == "0" {
+							klog.V(2).Infof("skipping adapter 0 disk, number: %d, location: %s", num, location)
+							found = false
+						}
+					case "Target":
+						d.Target = strings.TrimSpace(itemSplit[1])
+					case "LUN":
+						d.LUNID = strings.TrimSpace(itemSplit[1])
+					default:
+						klog.V(6).Infof("Got unknown field : %s=%s", itemSplit[0], itemSplit[1])
+					}
+				}
+			}
+
+			if found {
+				m[uint32(num.(int32))] = d
+			}
+		}
+	}
+	return m, nil
+}
+
+func (*cimDiskAPI) Rescan() error {
+	result, _, err := cim.InvokeCimMethod(cim.WMINamespaceStorage, "MSFT_StorageSetting", "UpdateHostStorageCache", nil)
+	if err != nil {
+		return fmt.Errorf("error updating host storage cache output. result: %d, err: %v", result, err)
+	}
+	return nil
+}
+
+func (*cimDiskAPI) IsDiskInitialized(diskNumber uint32) (bool, error) {
+	var partitionStyle int32
+	disk, err := cim.QueryDiskByNumber(diskNumber, []string{"PartitionStyle"})
+	if err != nil {
+		return false, fmt.Errorf("error checking initialized status of disk %d. %v", diskNumber, err)
+	}
+
+	retValue, err := disk.GetProperty("PartitionStyle")
+	if err != nil {
+		return false, fmt.Errorf("failed to query partition style of disk %d: %w", diskNumber, err)
+	}
+
+	partitionStyle = retValue.(int32)
+	return partitionStyle != cim.PartitionStyleUnknown, nil
+}
+
+func (*cimDiskAPI) InitializeDisk(diskNumber uint32) error {
+	disk, err := cim.QueryDiskByNumber(diskNumber, nil)
+	if err != nil {
+		return fmt.Errorf("failed to initializing disk %d. error: %w", diskNumber, err)
+	}
+
+	result, err := disk.InvokeMethodWithReturn("Initialize", int32(cim.PartitionStyleGPT))
+	if result != 0 || err != nil {
+		return fmt.Errorf("failed to initializing disk %d: result %d, error: %w", diskNumber, result, err)
+	}
+
+	return nil
+}
+
+func (*cimDiskAPI) BasicPartitionsExist(diskNumber uint32) (bool, error) {
+	partitions, err := cim.ListPartitionsWithFilters(nil,
+		query.NewWmiQueryFilter("DiskNumber", strconv.Itoa(int(diskNumber)), query.Equals),
+		query.NewWmiQueryFilter("GptType", cim.GPTPartitionTypeMicrosoftReserved, query.NotEquals))
+	if cim.IgnoreNotFound(err) != nil {
+		return false, fmt.Errorf("error checking presence of partitions on disk %d:, %v", diskNumber, err)
+	}
+
+	return len(partitions) > 0, nil
+}
+
+func (*cimDiskAPI) CreateBasicPartition(diskNumber uint32) error {
+	disk, err := cim.QueryDiskByNumber(diskNumber, nil)
+	if err != nil {
+		return err
+	}
+
+	result, err := disk.InvokeMethodWithReturn(
+		"CreatePartition",
+		nil,                           // Size
+		true,                          // UseMaximumSize
+		nil,                           // Offset
+		nil,                           // Alignment
+		nil,                           // DriveLetter
+		false,                         // AssignDriveLetter
+		nil,                           // MbrType,
+		cim.GPTPartitionTypeBasicData, // GPT Type
+		false,                         // IsHidden
+		false,                         // IsActive,
+	)
+	// 42002 is returned by driver letter failed to assign after partition
+	if (result != 0 && result != 42002) || err != nil {
+		return fmt.Errorf("error creating partition on disk %d. result: %d, err: %v", diskNumber, result, err)
+	}
+
+	var status string
+	result, err = disk.InvokeMethodWithReturn("Refresh", &status)
+	if result != 0 || err != nil {
+		return fmt.Errorf("error rescan disk (%d). result %d, error: %v", diskNumber, result, err)
+	}
+
+	partitions, err := cim.ListPartitionsWithFilters(nil,
+		query.NewWmiQueryFilter("DiskNumber", strconv.Itoa(int(diskNumber)), query.Equals),
+		query.NewWmiQueryFilter("GptType", cim.GPTPartitionTypeMicrosoftReserved, query.NotEquals))
+	if err != nil {
+		return fmt.Errorf("error query basic partition on disk %d:, %v", diskNumber, err)
+	}
+
+	if len(partitions) == 0 {
+		return fmt.Errorf("failed to create basic partition on disk %d:, %v", diskNumber, err)
+	}
+
+	partition := partitions[0]
+	result, err = partition.InvokeMethodWithReturn("Online", status)
+	if result != 0 || err != nil {
+		return fmt.Errorf("error bring partition %v on disk %d online. result: %d, status %s, err: %v", partition, diskNumber, result, status, err)
+	}
+
+	err = partition.Refresh()
+	return err
+}
+
+func (c *cimDiskAPI) GetDiskNumberByName(page83ID string) (uint32, error) {
+	return c.GetDiskNumberWithID(page83ID)
+}
+
+func (*cimDiskAPI) GetDiskNumber(disk syscall.Handle) (uint32, error) {
+	var bytes uint32
+	devNum := StorageDeviceNumber{}
+	buflen := uint32(unsafe.Sizeof(devNum.DeviceType)) + uint32(unsafe.Sizeof(devNum.DeviceNumber)) + uint32(unsafe.Sizeof(devNum.PartitionNumber))
+
+	err := syscall.DeviceIoControl(disk, IOCTL_STORAGE_GET_DEVICE_NUMBER, nil, 0, (*byte)(unsafe.Pointer(&devNum)), buflen, &bytes, nil)
+	return devNum.DeviceNumber, err
+}
+
+func (*cimDiskAPI) GetDiskPage83ID(disk syscall.Handle) (string, error) {
+	query := StoragePropertyQuery{}
+
+	bufferSize := uint32(4 * 1024)
+	buffer := make([]byte, 4*1024)
+	var size uint32
+	var n uint32
+	var m uint16
+
+	query.QueryType = PropertyStandardQuery
+	query.PropertyID = StorageDeviceIDProperty
+
+	querySize := uint32(unsafe.Sizeof(query.PropertyID)) + uint32(unsafe.Sizeof(query.QueryType)) + uint32(unsafe.Sizeof(query.Byte))
+	querySize = uint32(unsafe.Sizeof(query))
+	err := syscall.DeviceIoControl(disk, IOCTL_STORAGE_QUERY_PROPERTY, (*byte)(unsafe.Pointer(&query)), querySize, (*byte)(unsafe.Pointer(&buffer[0])), bufferSize, &size, nil)
+	if err != nil {
+		return "", fmt.Errorf("IOCTL_STORAGE_QUERY_PROPERTY failed: %v", err)
+	}
+
+	devIDDesc := (*StorageDeviceIDDescriptor)(unsafe.Pointer(&buffer[0]))
+
+	pID := (*StorageIdentifier)(unsafe.Pointer(&devIDDesc.Identifiers[0]))
+
+	page83ID := []byte{}
+	byteSize := unsafe.Sizeof(byte(0))
+	for n = 0; n < devIDDesc.NumberOfIdentifiers; n++ {
+		if pID.Association == StorageIDAssocDevice && (pID.CodeSet == StorageIDCodeSetBinary || pID.CodeSet == StorageIDCodeSetASCII) {
+			for m = 0; m < pID.IdentifierSize; m++ {
+				page83ID = append(page83ID, *(*byte)(unsafe.Pointer(uintptr(unsafe.Pointer(&pID.Identifier[0])) + byteSize*uintptr(m))))
+			}
+
+			if pID.CodeSet == StorageIDCodeSetASCII {
+				return string(page83ID), nil
+			} else if pID.CodeSet == StorageIDCodeSetBinary {
+				return hex.EncodeToString(page83ID), nil
+			}
+		}
+		pID = (*StorageIdentifier)(unsafe.Pointer(uintptr(unsafe.Pointer(pID)) + byteSize*uintptr(pID.NextOffset)))
+	}
+	return "", nil
+}
+
+func (c *cimDiskAPI) GetDiskNumberWithID(page83ID string) (uint32, error) {
+	disks, err := cim.ListDisks([]string{"Path", "SerialNumber"})
+	if err != nil {
+		return 0, err
+	}
+
+	for _, disk := range disks {
+		path, err := disk.GetPropertyPath()
+		if err != nil {
+			return 0, fmt.Errorf("failed to query disk path: %v, %w", disk, err)
+		}
+
+		diskNumber, diskPage83ID, err := c.GetDiskNumberAndPage83ID(path)
+		if err != nil {
+			return 0, err
+		}
+
+		if diskPage83ID == page83ID {
+			return diskNumber, nil
+		}
+	}
+
+	return 0, fmt.Errorf("could not find disk with Page83 ID %s", page83ID)
+}
+
+func (c *cimDiskAPI) GetDiskNumberAndPage83ID(path string) (uint32, string, error) {
+	h, err := syscall.Open(path, syscall.O_RDONLY, 0)
+	defer syscall.Close(h)
+	if err != nil {
+		return 0, "", err
+	}
+
+	diskNumber, err := c.GetDiskNumber(h)
+	if err != nil {
+		return 0, "", err
+	}
+
+	page83ID, err := c.GetDiskPage83ID(h)
+	if err != nil {
+		return 0, "", err
+	}
+
+	return diskNumber, page83ID, nil
+}
+
+// ListDiskIDs - constructs a map with the disk number as the key and the DiskID structure
+// as the value. The DiskID struct has a field for the page83 ID.
+func (c *cimDiskAPI) ListDiskIDs() (map[uint32]IDs, error) {
+	// sample response
+	// [
+	// {
+	//     "Path":  "\\\\?\\scsi#disk\u0026ven_google\u0026prod_persistentdisk#4\u002621cb0360\u00260\u0026000100#{53f56307-b6bf-11d0-94f2-00a0c91efb8b}",
+	//     "SerialNumber":  "                    "
+	// },
+	// {
+	//     "Path":  "\\\\?\\scsi#disk\u0026ven_msft\u0026prod_virtual_disk#2\u00261f4adffe\u00260\u0026000001#{53f56307-b6bf-11d0-94f2-00a0c91efb8b}",
+	//     "SerialNumber":  null
+	// }, ]
+	disks, err := cim.ListDisks([]string{"Path", "SerialNumber"})
+	if err != nil {
+		return nil, err
+	}
+
+	m := make(map[uint32]IDs)
+	for _, disk := range disks {
+		path, err := disk.GetPropertyPath()
+		if err != nil {
+			return m, fmt.Errorf("failed to query disk path: %v, %w", disk, err)
+		}
+
+		sn, err := disk.GetPropertySerialNumber()
+		if err != nil {
+			return m, fmt.Errorf("failed to query disk serial number: %v, %w", disk, err)
+		}
+
+		diskNumber, page83, err := c.GetDiskNumberAndPage83ID(path)
+		if err != nil {
+			return m, err
+		}
+
+		m[diskNumber] = IDs{
+			Page83:       page83,
+			SerialNumber: sn,
+		}
+	}
+	return m, nil
+}
+
+func (*cimDiskAPI) GetDiskStats(diskNumber uint32) (int64, error) {
+	// TODO: change to uint64 as it does not make sense to use int64 for size
+	var size int64
+	disk, err := cim.QueryDiskByNumber(diskNumber, []string{"Size"})
+	if err != nil {
+		return -1, err
+	}
+
+	sz, err := disk.GetProperty("Size")
+	if err != nil {
+		return -1, fmt.Errorf("failed to query size of disk %d. %v", diskNumber, err)
+	}
+
+	size, err = strconv.ParseInt(sz.(string), 10, 64)
+	return size, err
+}
+
+func (*cimDiskAPI) SetDiskState(diskNumber uint32, isOnline bool) error {
+	disk, err := cim.QueryDiskByNumber(diskNumber, []string{"IsOffline"})
+	if err != nil {
+		return err
+	}
+
+	offline, err := disk.GetPropertyIsOffline()
+	if err != nil {
+		return fmt.Errorf("error setting disk %d attach state. error: %v", diskNumber, err)
+	}
+
+	if isOnline == !offline {
+		return nil
+	}
+
+	method := "Offline"
+	if isOnline {
+		method = "Online"
+	}
+
+	result, err := disk.InvokeMethodWithReturn(method)
+	if result != 0 || err != nil {
+		return fmt.Errorf("setting disk %d attach state %s: result %d, error: %w", diskNumber, method, result, err)
+	}
+
+	return nil
+}
+
+func (*cimDiskAPI) GetDiskState(diskNumber uint32) (bool, error) {
+	disk, err := cim.QueryDiskByNumber(diskNumber, []string{"IsOffline"})
+	if err != nil {
+		return false, err
+	}
+
+	isOffline, err := disk.GetPropertyIsOffline()
+	if err != nil {
+		return false, fmt.Errorf("error parsing disk %d state. error: %v", diskNumber, err)
+	}
+
+	return !isOffline, nil
+}
+
+func (c *cimDiskAPI) PartitionDisk(diskNumber uint32) error {
+	klog.V(6).Infof("Request: PartitionDisk with diskNumber=%d", diskNumber)
+
+	initialized, err := c.IsDiskInitialized(diskNumber)
+	if err != nil {
+		klog.Errorf("IsDiskInitialized failed: %v", err)
+		return err
+	}
+	if !initialized {
+		klog.V(4).Infof("Initializing disk %d", diskNumber)
+		err = c.InitializeDisk(diskNumber)
+		if err != nil {
+			klog.Errorf("failed InitializeDisk %v", err)
+			return err
+		}
+	} else {
+		klog.V(4).Infof("Disk %d already initialized", diskNumber)
+	}
+
+	klog.V(6).Infof("Checking if disk %d has basic partitions", diskNumber)
+	partitioned, err := c.BasicPartitionsExist(diskNumber)
+	if err != nil {
+		klog.Errorf("failed check BasicPartitionsExist %v", err)
+		return err
+	}
+	if !partitioned {
+		klog.V(4).Infof("Creating basic partition on disk %d", diskNumber)
+		err = c.CreateBasicPartition(diskNumber)
+		if err != nil {
+			klog.Errorf("failed CreateBasicPartition %v", err)
+			return err
+		}
+	} else {
+		klog.V(4).Infof("Disk %d already partitioned", diskNumber)
+	}
+	return nil
+}

--- a/pkg/os/volume/volume_cim.go
+++ b/pkg/os/volume/volume_cim.go
@@ -175,7 +175,7 @@ func (*cimVolumeAPI) ResizeVolume(volumeID string, size int64) error {
 		var status string
 		result, err := part.InvokeMethodWithReturn("GetSupportedSize", &sizeMin, &sizeMax, &status)
 		if result != 0 || err != nil {
-			return fmt.Errorf("error getting sizemin, sizemax from volume (%s). result: %d, error: %v", volumeID, result, err)
+			return fmt.Errorf("error getting sizemin, sizemax from volume (%s). result: %d, status: %s, error: %v", volumeID, result, status, err)
 		}
 
 		finalSizeStr := sizeMax.ToString()


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
This PR leverages of WMI interfaces to replace the PowerShell functions for Windows related storage operations,
which improve the overall performance 

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

<details>

```
I0427 03:03:18.372866     772 utils.go:105] GRPC call: /csi.v1.Node/NodeStageVolume
I0427 03:03:18.372866     772 utils.go:106] GRPC request: {"publish_context":{"LUN":"0"},"staging_target_path":"\\var\\lib\\kubelet\\plugins\\kubernetes.io\\csi\\disk.csi.azure.com\\a63e2d3886284cfbdb45cce97cb66a469f363a5574afdefac52747fc5ca18b42\\globalmount","volume_capability":{"AccessType":{"Mount":{}},"access_mode":{"mode":7}},"volume_context":{"csi.storage.k8s.io/pv/name":"pvc-eec2e808-ec85-4cd0-bf30-e80cbaa117be","csi.storage.k8s.io/pvc/name":"persistent-storage-statefulset-azuredisk-win-0","csi.storage.k8s.io/pvc/namespace":"default","requestedsizegib":"100","skuName":"StandardSSD_LRS","storage.kubernetes.io/csiProvisionerIdentity":"1744986261215-3879-disk.csi.azure.com"},"volume_id":"/subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks131euap_andy-aks131euap_eastus2euap/providers/Microsoft.Compute/disks/pvc-eec2e808-ec85-4cd0-bf30-e80cbaa117be"}
2025/04/27 03:03:18 [WMI] QueryInstances [SELECT Number,Location,PartitionStyle FROM MSFT_Disk]=> [4]
I0427 03:03:18.516141     772 disk.go:116] skipping MBR disk, number: 0, location: PCI Slot 0 : Adapter 0 : Channel 0 : Device 0
I0427 03:03:18.517018     772 disk.go:123] disk number: 1, location: Integrated : Bus 0 : Device 63667 : Function 30747 : Adapter 3 : Port 0 : Target 0 : LUN 0, partitionStyle: 2
I0427 03:03:18.517307     772 disk.go:123] disk number: 2, location: Integrated : Bus 0 : Device 63667 : Function 30747 : Adapter 3 : Port 0 : Target 0 : LUN 1, partitionStyle: 2
I0427 03:03:18.517307     772 disk.go:123] disk number: 3, location: Integrated : Bus 0 : Device 63667 : Function 30747 : Adapter 3 : Port 0 : Target 0 : LUN 2, partitionStyle: 2
I0427 03:03:18.535169     772 nodeserver.go:164] NodeStageVolume: formatting 1 and mounting at \var\lib\kubelet\plugins\kubernetes.io\csi\disk.csi.azure.com\a63e2d3886284cfbdb45cce97cb66a469f363a5574afdefac52747fc5ca18b42\globalmount with mount options([])
2025/04/27 03:03:18 [WMI] QueryInstances [SELECT IsOffline FROM MSFT_Disk WHERE  Number = '1' ]=> [1]
2025/04/27 03:03:18 [WMI] QueryInstances [SELECT PartitionStyle FROM MSFT_Disk WHERE  Number = '1' ]=> [1]
I0427 03:03:18.576960     772 disk.go:477] Disk 1 already initialized
2025/04/27 03:03:18 [WMI] QueryInstances [SELECT * FROM MSFT_Partition WHERE  DiskNumber = '1' AND GptType <> '{e3c9e316-0b5c-4db8-817d-f92df00215ae}' ]=> [1]
I0427 03:03:18.607204     772 disk.go:494] Disk 1 already partitioned
2025/04/27 03:03:18 [WMI] QueryInstances [SELECT ObjectId FROM MSFT_Partition WHERE  DiskNumber = '1' ]=> [2]
2025/04/27 03:03:18 [WMI] QueryInstances [SELECT ObjectId,UniqueId FROM MSFT_Volume]=> [6]
2025/04/27 03:03:18 [WMI] QueryInstances [SELECT * FROM MSFT_PartitionToVolume]=> [5]
2025/04/27 03:03:18 [WMI] QueryInstances [SELECT FileSystemType,UniqueId FROM MSFT_Volume]=> [6]
I0427 03:03:19.144188     772 nodeserver.go:168] NodeStageVolume: format 1 and mounting at \var\lib\kubelet\plugins\kubernetes.io\csi\disk.csi.azure.com\a63e2d3886284cfbdb45cce97cb66a469f363a5574afdefac52747fc5ca18b42\globalmount successfully.
I0427 03:03:19.144188     772 nodeserver.go:184] NodeStageVolume: fs resize initiating on target(\var\lib\kubelet\plugins\kubernetes.io\csi\disk.csi.azure.com\a63e2d3886284cfbdb45cce97cb66a469f363a5574afdefac52747fc5ca18b42\globalmount) volumeid(/subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks131euap_andy-aks131euap_eastus2euap/providers/Microsoft.Compute/disks/pvc-eec2e808-ec85-4cd0-bf30-e80cbaa117be)
2025/04/27 03:03:19 [WMI] QueryInstances [SELECT ObjectId FROM MSFT_Partition WHERE  DiskNumber = '1' ]=> [2]
2025/04/27 03:03:19 [WMI] QueryInstances [SELECT ObjectId,UniqueId FROM MSFT_Volume]=> [6]
2025/04/27 03:03:19 [WMI] QueryInstances [SELECT * FROM MSFT_PartitionToVolume]=> [5]
2025/04/27 03:03:19 [WMI] QueryInstances [SELECT ObjectId,UniqueId FROM MSFT_Volume]=> [6]
2025/04/27 03:03:19 [WMI] QueryInstances [SELECT * FROM MSFT_Partition]=> [8]
2025/04/27 03:03:19 [WMI] QueryInstances [SELECT * FROM MSFT_PartitionToVolume]=> [5]
I0427 03:03:20.097970     772 volume_cim.go:202] minimum resize difference(1GB) not met, skipping resize. volumeID=\\?\Volume{1ccd369a-05de-438a-a21b-a1422c7cd523}\ currentSize=107356356608 finalSize=107357388288
I0427 03:03:20.097970     772 nodeserver.go:188] NodeStageVolume: fs resize successful on target(\var\lib\kubelet\plugins\kubernetes.io\csi\disk.csi.azure.com\a63e2d3886284cfbdb45cce97cb66a469f363a5574afdefac52747fc5ca18b42\globalmount) volumeid(/subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks131euap_andy-aks131euap_eastus2euap/providers/Microsoft.Compute/disks/pvc-eec2e808-ec85-4cd0-bf30-e80cbaa117be).
I0427 03:03:20.099263     772 azure_metrics.go:105] "Observed Request Latency" latency_seconds=1.7245395000000001 request="azuredisk_csi_driver_node_stage_volume" resource_group="mc_andy-aks131euap_andy-aks131euap_eastus2euap" subscription_id="" source="disk.csi.azure.com" volumeid="/subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks131euap_andy-aks131euap_eastus2euap/providers/Microsoft.Compute/disks/pvc-eec2e808-ec85-4cd0-bf30-e80cbaa117be" result_code="succeeded"
```

</details>

**Does this PR introduce a user-facing change?**:
```release-note
feat: Use WMI to implement Volume API to reduce PowerShell overhead
```

