### PR TITLE
[release-1.32] feat: add option to override ARM retry-after header

### DIFF
--- a/pkg/azuredisk/azuredisk.go
+++ b/pkg/azuredisk/azuredisk.go
@@ -138,6 +138,7 @@ type DriverCore struct {
 	volStatsCache           azcache.Resource
 	maxConcurrentFormat     int64
 	concurrentFormatTimeout int64
+	enableMinimumRetryAfter bool
 }
 
 // Driver is the v1 implementation of the Azure Disk CSI Driver.
@@ -193,6 +194,7 @@ func newDriverV1(options *DriverOptions) *Driver {
 	driver.removeNotReadyTaint = options.RemoveNotReadyTaint
 	driver.maxConcurrentFormat = options.MaxConcurrentFormat
 	driver.concurrentFormatTimeout = options.ConcurrentFormatTimeout
+	driver.enableMinimumRetryAfter = options.EnableMinimumRetryAfter
 	driver.volumeLocks = volumehelper.NewVolumeLocks()
 	driver.ioHandler = azureutils.NewOSIOHandler()
 	driver.hostUtil = hostutil.NewHostUtil()
@@ -229,7 +231,7 @@ func newDriverV1(options *DriverOptions) *Driver {
 	driver.kubeClient = kubeClient
 
 	cloud, err := azureutils.GetCloudProviderFromClient(context.Background(), kubeClient, driver.cloudConfigSecretName, driver.cloudConfigSecretNamespace,
-		userAgent, driver.allowEmptyCloudConfig, driver.enableTrafficManager, driver.trafficManagerPort)
+		userAgent, driver.allowEmptyCloudConfig, driver.enableTrafficManager, driver.enableMinimumRetryAfter, driver.trafficManagerPort)
 	if err != nil {
 		klog.Fatalf("failed to get Azure Cloud Provider, error: %v", err)
 	}

--- a/pkg/azuredisk/azuredisk_option.go
+++ b/pkg/azuredisk/azuredisk_option.go
@@ -36,6 +36,7 @@ type DriverOptions struct {
 	UserAgentSuffix            string
 	UseCSIProxyGAInterface     bool
 	EnableOtelTracing          bool
+	EnableMinimumRetryAfter    bool
 
 	//only used in v1
 	EnableDiskOnlineResize            bool
@@ -86,6 +87,7 @@ func (o *DriverOptions) AddFlags() *flag.FlagSet {
 	fs.StringVar(&o.UserAgentSuffix, "user-agent-suffix", "", "userAgent suffix")
 	fs.BoolVar(&o.UseCSIProxyGAInterface, "use-csiproxy-ga-interface", true, "boolean flag to enable csi-proxy GA interface on Windows")
 	fs.BoolVar(&o.EnableOtelTracing, "enable-otel-tracing", false, "If set, enable opentelemetry tracing for the driver. The tracing is disabled by default. Configure the exporter endpoint with OTEL_EXPORTER_OTLP_ENDPOINT and other env variables, see https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration.")
+	fs.BoolVar(&o.EnableMinimumRetryAfter, "enable-minimum-retry-after", true, "boolean flag to enable minimum retry after policy in azclient")
 	//only used in v1
 	fs.BoolVar(&o.EnableDiskOnlineResize, "enable-disk-online-resize", true, "boolean flag to enable disk online resize")
 	fs.BoolVar(&o.AllowEmptyCloudConfig, "allow-empty-cloud-config", true, "Whether allow running driver without cloud config")

--- a/pkg/azuredisk/azuredisk_v2.go
+++ b/pkg/azuredisk/azuredisk_v2.go
@@ -96,8 +96,7 @@ func newDriverV2(options *DriverOptions) *DriverV2 {
 	}
 	driver.kubeClient = kubeClient
 
-	cloud, err := azureutils.GetCloudProviderFromClient(context.Background(), kubeClient, driver.cloudConfigSecretName, driver.cloudConfigSecretNamespace,
-		userAgent, driver.allowEmptyCloudConfig, driver.enableTrafficManager, driver.trafficManagerPort)
+	cloud, err := azureutils.GetCloudProviderFromClient(context.Background(), kubeClient, driver.cloudConfigSecretName, driver.cloudConfigSecretNamespace, userAgent, driver.allowEmptyCloudConfig, driver.enableTrafficManager, driver.enableMinimumRetryAfter, driver.trafficManagerPort)
 	if err != nil {
 		klog.Fatalf("failed to get Azure Cloud Provider, error: %v", err)
 	}

--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -128,7 +128,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 
 	if diskParams.UserAgent != "" {
 		localCloud, err = azureutils.GetCloudProviderFromClient(ctx, d.kubeClient, d.cloudConfigSecretName, d.cloudConfigSecretNamespace, diskParams.UserAgent,
-			d.allowEmptyCloudConfig, d.enableTrafficManager, d.trafficManagerPort)
+			d.allowEmptyCloudConfig, d.enableTrafficManager, d.enableMinimumRetryAfter, d.trafficManagerPort)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "create cloud with UserAgent(%s) failed with: (%s)", diskParams.UserAgent, err)
 		}
@@ -1001,7 +1001,7 @@ func (d *Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequ
 		case consts.UserAgentField:
 			newUserAgent := v
 			localCloud, err = azureutils.GetCloudProviderFromClient(ctx, d.kubeClient, d.cloudConfigSecretName, d.cloudConfigSecretNamespace, newUserAgent,
-				d.allowEmptyCloudConfig, d.enableTrafficManager, d.trafficManagerPort)
+				d.allowEmptyCloudConfig, d.enableTrafficManager, d.enableMinimumRetryAfter, d.trafficManagerPort)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "create cloud with UserAgent(%s) failed with: (%s)", newUserAgent, err)
 			}

--- a/pkg/azureutils/azure_disk_utils.go
+++ b/pkg/azureutils/azure_disk_utils.go
@@ -146,7 +146,7 @@ func GetAttachDiskInitialDelay(attributes map[string]string) int {
 
 // GetCloudProviderFromClient get Azure Cloud Provider
 func GetCloudProviderFromClient(ctx context.Context, kubeClient clientset.Interface, secretName, secretNamespace, userAgent string,
-	allowEmptyCloudConfig bool, enableTrafficMgr bool, trafficMgrPort int64) (*azure.Cloud, error) {
+	allowEmptyCloudConfig bool, enableTrafficMgr bool, enableMinimumRetryAfter bool, trafficMgrPort int64) (*azure.Cloud, error) {
 	var config *azureconfig.Config
 	var fromSecret bool
 	var err error
@@ -231,6 +231,9 @@ func GetCloudProviderFromClient(ctx context.Context, kubeClient clientset.Interf
 			// Watch the certificate for changes; if the certificate changes, the pod will be restarted
 			err = filewatcher.WatchFileForChanges(config.AADClientCertPath)
 			klog.Warningf("Failed to watch certificate file for changes: %v", err)
+		}
+		if enableMinimumRetryAfter {
+			config.EnableMinimumRetryAfter = enableMinimumRetryAfter
 		}
 		if err = az.InitializeCloudFromConfig(ctx, config, fromSecret, false); err != nil {
 			klog.Warningf("InitializeCloudFromConfig failed with error: %v", err)

--- a/pkg/azureutils/azure_disk_utils_test.go
+++ b/pkg/azureutils/azure_disk_utils_test.go
@@ -314,7 +314,7 @@ users:
 				t.Errorf("desc: %s,\n input: %q, GetCloudProvider err: %v, expectedErr: %v", test.desc, test.kubeconfig, err, test.expectedErr)
 			}
 		}
-		cloud, err := GetCloudProviderFromClient(context.Background(), kubeClient, "", "", test.userAgent, test.allowEmptyCloudConfig, false, -1)
+		cloud, err := GetCloudProviderFromClient(context.Background(), kubeClient, "", "", test.userAgent, test.allowEmptyCloudConfig, false, false, -1)
 		if ((err == nil) == (test.expectedErr == nil)) && !reflect.DeepEqual(err, test.expectedErr) && !strings.Contains(err.Error(), test.expectedErr.Error()) {
 			t.Errorf("desc: %s,\n input: %q, GetCloudProvider err: %v, expectedErr: %v", test.desc, test.kubeconfig, err, test.expectedErr)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: add option to override ARM retry-after header

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
<details>

```
# k logs -n kube-system csi-azuredisk-controller-b87f87f85-bwwb7 -c azuredisk
I0512 02:39:48.626649       1 main.go:112] set up prometheus server on [::]:29604
I0512 02:39:48.626719       1 main.go:87] Sys info: NumCPU: 2 MAXPROC: 2
W0512 02:39:48.626730       1 azuredisk.go:204] nodeid is empty
I0512 02:39:48.626738       1 azuredisk.go:225] driver userAgent: disk.csi.azure.com/v1.32.5 OSS-kubectl
W0512 02:39:48.626746       1 client_config.go:667] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I0512 02:39:48.627404       1 azure_disk_utils.go:155] reading cloud config from secret kube-system/azure-cloud-provider
I0512 02:39:48.698747       1 azure_disk_utils.go:165] InitializeCloudFromSecret: failed to get cloud config from secret kube-system/azure-cloud-provider: secrets "azure-cloud-provider" not found
I0512 02:39:48.698774       1 azure_disk_utils.go:174] could not read cloud config from secret kube-system/azure-cloud-provider
I0512 02:39:48.698783       1 azure_disk_utils.go:184] use default AZURE_CREDENTIAL_FILE env var: /etc/kubernetes/azure.json
I0512 02:39:48.699845       1 arm_conf.go:91] Enabling minimum retry-after policy with value 5s
I0512 02:39:48.699866       1 azure.go:607] Azure cloudprovider using try backoff: retries=6, exponent=1.500000, duration=5, jitter=1.000000
I0512 02:39:48.699928       1 arm_conf.go:91] Enabling minimum retry-after policy with value 5s
I0512 02:39:48.700036       1 arm_conf.go:91] Enabling minimum retry-after policy with value 5s
```

</details>

**Release note**:
```
feat: add option to override ARM retry-after header
```
