### PR TITLE
doc: add linked permissions

### DIFF
--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -19,6 +19,19 @@ Microsoft.Compute/locations/operations/read
 Microsoft.Compute/locations/DiskOperations/read
 Microsoft.Resources/subscriptions/resourceGroups/Microsoft.Compute/read
 Microsoft.Resources/subscriptions/resourceGroups/Microsoft.Compute/*/read
+# Those are needed only when the virtualMachine or virtualMachineScaleSets have these additional resources configured:
+Microsoft.Compute/disks/beginGetAccess/action
+Microsoft.KeyVault/vaults/deploy/action
+Microsoft.ManagedIdentity/userAssignedIdentities/assign/action
+Microsoft.Network/applicationGateways/backendAddressPools/join/action
+Microsoft.Network/applicationSecurityGroups/joinIpConfiguration/action
+Microsoft.Network/loadBalancers/backendAddressPools/join/action
+Microsoft.Network/loadBalancers/inboundNatPools/join/action
+Microsoft.Network/loadBalancers/probes/join/action
+Microsoft.Network/networkInterfaces/join/action
+Microsoft.Network/networkSecurityGroups/join/action
+Microsoft.Network/publicIPPrefixes/join/action
+Microsoft.Network/virtualNetworks/subnets/join/action
 </pre>
 </details>
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

I admit I don't fully understand Azure permissions. I think that when the CSI driver patches a VM to attach a disk, Azure evaluates *all* fields of the VM and not only the changed ones. Azure then evaluates all "link"/"action" permissions of anything that is linked to the VM - load balancers, security groups, network interfaces etc, even though the CSI driver never modifies these VM properties.

I'm adding the permissions found in an internal audit. However, I don't know _what else_ can be linked to a VM. The list may be quite incomplete. And it's not very future proof, as Azure may link other objects to the VMs in the future and we will need to update the driver permissions. It would be great if the permissions could say that the driver is allowed to modify only the disks attached to the VM + needs permissions for them, ignoring all other linked objects.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
