### PR TITLE
perf: rely on readyToUse flag to monitor snapshot progress instead of waiting in for loop

### DIFF
--- a/pkg/azuredisk/azuredisk_option.go
+++ b/pkg/azuredisk/azuredisk_option.go
@@ -106,7 +106,7 @@ func (o *DriverOptions) AddFlags() *flag.FlagSet {
 	fs.BoolVar(&o.EnableWindowsHostProcess, "enable-windows-host-process", false, "enable windows host process")
 	fs.BoolVar(&o.UseWinCIMAPI, "use-win-cim-api", true, "whether perform disk operations using CIM API or Powershell command on Windows node")
 	fs.BoolVar(&o.GetNodeIDFromIMDS, "get-nodeid-from-imds", false, "boolean flag to get NodeID from IMDS")
-	fs.BoolVar(&o.WaitForSnapshotReady, "wait-for-snapshot-ready", true, "boolean flag to wait for snapshot ready when creating snapshot in same region")
+	fs.BoolVar(&o.WaitForSnapshotReady, "wait-for-snapshot-ready", false, "boolean flag to wait for snapshot ready when creating snapshot in same region")
 	fs.BoolVar(&o.CheckDiskLUNCollision, "check-disk-lun-collision", true, "boolean flag to check disk lun collisio before attaching disk")
 	fs.BoolVar(&o.CheckDiskCountForBatching, "check-disk-count-for-batching", true, "boolean flag to check disk count before creating a batch for disk attach")
 	fs.BoolVar(&o.ForceDetachBackoff, "force-detach-backoff", true, "boolean flag to force detach in disk detach backoff")

--- a/pkg/azuredisk/fake_azuredisk.go
+++ b/pkg/azuredisk/fake_azuredisk.go
@@ -68,6 +68,8 @@ type FakeDriver interface {
 	CSIDriver
 
 	GetSourceDiskSize(ctx context.Context, subsID, resourceGroup, diskName string, curDepth, maxDepth int) (*int32, *armcompute.Disk, error)
+	SetWaitForSnapshotReady(bool)
+	GetWaitForSnapshotReady() bool
 
 	setNextCommandOutputScripts(scripts ...testingexec.FakeAction)
 
@@ -189,4 +191,12 @@ func createVolumeCapability(accessMode csi.VolumeCapability_AccessMode_Mode) *cs
 			Mode: accessMode,
 		},
 	}
+}
+
+func (d *fakeDriver) SetWaitForSnapshotReady(shouldWait bool) {
+	d.shouldWaitForSnapshotReady = shouldWait
+}
+
+func (d *fakeDriver) GetWaitForSnapshotReady() bool {
+	return d.shouldWaitForSnapshotReady
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [x] tested upgrade from previous version

**Special notes for your reviewer**:
Today we wait for snapshot to be completed in the create snapshot CSI handler itself. Instead, we can use ready to use flag in CreateVolumeSnapshotResponse which will let the side car to retry until it we set it to true later when snapshot in backend completes. This will help any utilities to know the progress and updates immediately.

Please refer the sidecar code that wait for ready to use flag to become true https://github.com/kubernetes-csi/external-snapshotter//commit/8a29bf5b21ff9019e8c96aa46acd4991fc6d94c8

This is part of the CSI spec https://github.com/container-storage-interface/spec/blob/master/spec.md#the-ready_to_use-parameter

```
The ready_to_use parameter provides guidance to the CO on when it can "thaw" the application in the process of snapshotting. If the cloud provider or storage system needs to process the snapshot after the snapshot is cut, the ready_to_use parameter returned by CreateSnapshot SHALL be false. CO MAY continue to call CreateSnapshot while waiting for the process to complete until ready_to_use becomes true. Note that CreateSnapshot no longer blocks after the snapshot is cut.
```
One more reference https://github.com/container-storage-interface/spec/blob/master/spec.md#createsnapshot

```
For plugins that supports snapshot post processing such as uploading, CreateSnapshot SHOULD return 0 OK and ready_to_use SHOULD be set to false after the snapshot is cut but still being processed. CO SHOULD then reissue the same CreateSnapshotRequest periodically until boolean ready_to_use flips to true indicating the snapshot has been "processed" and is ready to use to create new volumes. If an error occurs during the process, CreateSnapshot SHOULD return a corresponding gRPC error code that reflects the error condition.
```

**Release note**:
```
none
```