### PR TITLE
fix: removing crc from mount option for xfs.

### DIFF
--- a/pkg/azuredisk/azure_common_linux.go
+++ b/pkg/azuredisk/azure_common_linux.go
@@ -124,10 +124,6 @@ func formatAndMount(source, target, fstype string, options []string, m *mount.Sa
 		klog.V(2).Infof("formatAndMount - skip format for %s, old options: %v, new options: %v", target, options, newOptions)
 		return m.Mount(source, target, fstype, newOptions)
 	}
-	if fstype == "xfs" {
-		klog.V(2).Infof("use crc=0 rmapbt=0 option for xfs filesystem on %s", target)
-		return m.FormatAndMountSensitiveWithFormatOptions(source, target, fstype, options, nil, []string{"-m", "crc=0,rmapbt=0"})
-	}
 	return m.FormatAndMount(source, target, fstype, options)
 }
 

--- a/pkg/azurediskplugin/Dockerfile
+++ b/pkg/azurediskplugin/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.20.6
+FROM alpine:3.18.12
 RUN apk upgrade --available --no-cache && \
     apk add --no-cache util-linux e2fsprogs e2fsprogs-extra ca-certificates udev xfsprogs xfsprogs-extra btrfs-progs btrfs-progs-extra
 
@@ -23,5 +23,4 @@ ARG ARCH=amd64
 ARG PLUGIN_NAME=azurediskplugin
 ARG binary=./_output/${ARCH}/${PLUGIN_NAME}
 COPY ${binary} /azurediskplugin
-
 ENTRYPOINT ["/azurediskplugin"]


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind regression

**What this PR does / why we need it**:

AzureLinuxV3 does not support crc option and causing the failure while mounting the device.
    
Dmesg error :
Deprecated V4 format (crc=0) not supported by kernel.

**Which issue(s) this PR fixes**:

https://portal.microsofticm.com/imp/v5/incidents/details/647022560

Fixes #

https://portal.microsofticm.com/imp/v5/incidents/details/647022560

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

https://github.com/microsoft/azurelinux/commit/a1cef2314400f4f22926386d25f26244cf7dc388


