### PR TITLE
fix: xfs mount failure on Azure Linux 3.0 node

### DIFF
--- a/pkg/azuredisk/azure_common_linux.go
+++ b/pkg/azuredisk/azure_common_linux.go
@@ -124,10 +124,6 @@ func formatAndMount(source, target, fstype string, options []string, m *mount.Sa
 		klog.V(2).Infof("formatAndMount - skip format for %s, old options: %v, new options: %v", target, options, newOptions)
 		return m.Mount(source, target, fstype, newOptions)
 	}
-	if fstype == "xfs" {
-		klog.V(2).Infof("use crc=0 rmapbt=0 option for xfs filesystem on %s", target)
-		return m.FormatAndMountSensitiveWithFormatOptions(source, target, fstype, options, nil, []string{"-m", "crc=0,rmapbt=0"})
-	}
 	return m.FormatAndMount(source, target, fstype, options)
 }
 

--- a/pkg/azurediskplugin/Dockerfile
+++ b/pkg/azurediskplugin/Dockerfile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.20.6
-RUN apk upgrade --available --no-cache && \
-    apk add --no-cache util-linux e2fsprogs e2fsprogs-extra ca-certificates udev xfsprogs xfsprogs-extra btrfs-progs btrfs-progs-extra
+FROM registry.k8s.io/build-image/debian-base:bookworm-v1.0.5
+
+RUN apt update && apt upgrade -y && apt-mark unhold libcap2 && clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs btrfs-progs
 
 LABEL maintainers="andyzhangx"
 LABEL description="Azure Disk CSI Driver"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: xfs mount failure on Azure Linux 3.0 node

refer to https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/3156/files#r2173108626 for more details, the debian-base image works on both Ubuntu and AzureLinux node:
```
statefulset-azuredisk-0    1/1     Running   0          9m41s   10.244.1.23    aks-ubt-36798378-vmss000000          <none>           <none>
statefulset-azuredisk-1    1/1     Running   0          9m40s   10.244.1.15    aks-ubt-36798378-vmss000000          <none>           <none>
statefulset-azuredisk2-0   1/1     Running   0          10m     10.244.2.214   aks-azurelinux-36798378-vmss000000   <none>           <none>
statefulset-azuredisk2-1   1/1     Running   0          9m36s   10.244.1.138   aks-ubt-36798378-vmss000000          <none>           <none>
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: xfs mount failure on Azure Linux 3.0 node
```
