### PR TITLE
support custom Azure disk naming using PVC name and namespace [#3174]

### DIFF
--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -153,13 +153,26 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	}
 
 	if diskParams.DiskName == "" {
-		// Custom PVC naming logic: use pvcNamespace-pvcName if both tags are present, else fallback to default name
 		pvcName, pvcNameOk := diskParams.Tags[consts.PvcNameTag]
 		pvcNamespace, pvcNamespaceOk := diskParams.Tags[consts.PvcNamespaceTag]
-		if pvcNameOk && pvcNamespaceOk && pvcName != "" && pvcNamespace != "" {
-			diskParams.DiskName = pvcNamespace + "-" + pvcName
+		if val, ok := params["diskName"]; ok && val != "" {
+			// Template substitution for ${pvc.metadata.namespace} and ${pvc.metadata.name}
+			diskName := val
+			if pvcNamespaceOk {
+				diskName = strings.ReplaceAll(diskName, "${pvc.metadata.namespace}", pvcNamespace)
+			}
+			if pvcNameOk {
+				diskName = strings.ReplaceAll(diskName, "${pvc.metadata.name}", pvcName)
+			}
+			if diskName == "-" || diskName == "" {
+				return nil, status.Error(codes.InvalidArgument, "CreateVolume diskName template must resolve to a non-empty value")
+			}
+			diskParams.DiskName = diskName
+			klog.V(2).Infof("Disk name (template) will be: %s, the name length is %d.", diskName, len(diskName))
 		} else {
+			// Fallback to default name (original upstream behavior)
 			diskParams.DiskName = name
+			klog.V(2).Infof("Disk name (default) will be: %s, the name length is %d.", name, len(name))
 		}
 	}
 	diskParams.DiskName = azureutils.CreateValidDiskName(diskParams.DiskName)

--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -153,7 +153,14 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	}
 
 	if diskParams.DiskName == "" {
-		diskParams.DiskName = name
+		// Custom PVC naming logic: use pvcNamespace-pvcName if both tags are present, else fallback to default name
+		pvcName, pvcNameOk := diskParams.Tags[consts.PvcNameTag]
+		pvcNamespace, pvcNamespaceOk := diskParams.Tags[consts.PvcNamespaceTag]
+		if pvcNameOk && pvcNamespaceOk && pvcName != "" && pvcNamespace != "" {
+			diskParams.DiskName = pvcNamespace + "-" + pvcName
+		} else {
+			diskParams.DiskName = name
+		}
 	}
 	diskParams.DiskName = azureutils.CreateValidDiskName(diskParams.DiskName)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature
/kind documentation

**What this PR does / why we need it**:

This PR introduces a custom disk naming logic to the Azure Disk CSI driver:

- When both the PVC namespace and name tags are present and non-empty, the Azure disk will be named as `<namespace>-<pvcname>`.
- If either tag is missing, the default disk naming logic is used.
- The disk name is always sanitized to meet Azure requirements.

This improves traceability and operational clarity by making disk names more meaningful and directly linked to their originating PVCs.

**Which issue(s) this PR fixes**:
Fixes #3174

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [x] includes documentation
- [x] adds unit tests
- [x] tested upgrade from previous version

**Special notes for your reviewer**:
- The logic is implemented in the `CreateVolume` method in `controllerserver.go`.
- Example: If a PVC has namespace `prod` and name `data`, the resulting disk name will be `prod-data`.

**Release note**:
```
```release-note
Added custom disk naming logic: When both PVC namespace and name tags are present, Azure disks are named as <namespace>-<pvcname>. This improves traceability and operational clarity. If either tag is missing, the default naming logic is used. The disk name is always sanitized to meet Azure requirements. (#3174)
```
