### PR TITLE
fix: typo in the required permissions

### DIFF
--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -17,8 +17,8 @@ Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read
 Microsoft.Compute/virtualMachineScaleSets/read
 Microsoft.Compute/locations/operations/read
 Microsoft.Compute/locations/DiskOperations/read
-Microsoft.Resources/subscriptions/resourceGroups/Microsoft.Compute/read
-Microsoft.Resources/subscriptions/resourceGroups/Microsoft.Compute/*/read
+Microsoft.Resources/subscriptions/resourceGroups/read
+Microsoft.Resources/subscriptions/resourceGroups/*/read
 # Those are needed only when the virtualMachine or virtualMachineScaleSets have these additional resources configured:
 Microsoft.Compute/disks/beginGetAccess/action
 Microsoft.KeyVault/vaults/deploy/action


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind documentation

**What this PR does / why we need it**:
Permission `Microsoft.Resources/subscriptions/resourceGroups/Microsoft.Compute/read` does not exists and it looks like a typo. Change it to `Microsoft.Resources/subscriptions/resourceGroups/read`.

Still, please double check, my Azure knowledge is limited.

**Which issue(s) this PR fixes**:
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Release note**:
```
none
```
