### PR TITLE
feat: notify user using events on sku migration complete

### DIFF
--- a/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
+++ b/charts/latest/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
@@ -76,7 +76,11 @@ spec:
           image: "{{ .Values.image.csiProvisioner.repository }}:{{ .Values.image.csiProvisioner.tag }}"
 {{- end }}
           args:
+{{- if .Values.feature.modifyVolume }}
+            - "--feature-gates=Topology=true,HonorPVReclaimPolicy=true,VolumeAttributesClass=true"
+{{- else }}
             - "--feature-gates=Topology=true,HonorPVReclaimPolicy=true"
+{{- end }}
             - "--csi-address=$(ADDRESS)"
             - "--v=2"
             - "--timeout=30s"
@@ -163,7 +167,11 @@ spec:
             - "-leader-election"
             - "--leader-election-namespace={{ .Release.Namespace }}"
             - '-handle-volume-inuse-error=false'
-            - '-feature-gates=RecoverVolumeExpansionFailure=true'
+{{- if .Values.feature.modifyVolume }}
+            - "-feature-gates=RecoverVolumeExpansionFailure=true,VolumeAttributesClass=true"
+{{- else }}
+            - "-feature-gates=RecoverVolumeExpansionFailure=true"
+{{- end }}
             - "-timeout=240s"
             - "--retry-interval-max=30m"
           env:

--- a/charts/latest/azuredisk-csi-driver/values.yaml
+++ b/charts/latest/azuredisk-csi-driver/values.yaml
@@ -169,6 +169,7 @@ snapshot:
 
 feature:
   enableFSGroupPolicy: true
+  modifyVolume: false
 
 driver:
   name: disk.csi.azure.com

--- a/pkg/azuredisk/azuredisk.go
+++ b/pkg/azuredisk/azuredisk.go
@@ -40,6 +40,9 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
 	"k8s.io/mount-utils"
@@ -96,6 +99,8 @@ type Driver struct {
 	cloud                        *azure.Cloud
 	clientFactory                azclient.ClientFactory
 	diskController               *ManagedDiskController
+	eventRecorder                record.EventRecorder
+	migrationMonitor             *MigrationProgressMonitor
 	mounter                      *mount.SafeFormatAndMount
 	deviceHelper                 optimization.Interface
 	nodeInfo                     *optimization.NodeInfo
@@ -263,6 +268,27 @@ func NewDriver(options *DriverOptions) *Driver {
 		driver.diskController.ForceDetachBackoff = driver.forceDetachBackoff
 		driver.diskController.WaitForDetach = driver.waitForDetach
 		driver.diskController.CheckDiskCountForBatching = driver.checkDiskCountForBatching
+
+		if kubeClient != nil {
+			eventBroadcaster := record.NewBroadcaster()
+			eventBroadcaster.StartStructuredLogging(0)
+			eventBroadcaster.StartRecordingToSink(&clientcorev1.EventSinkImpl{
+				Interface: kubeClient.CoreV1().Events(""),
+			})
+			eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{
+				Component: driver.Name,
+			})
+			driver.eventRecorder = eventRecorder
+			driver.migrationMonitor = NewMigrationProgressMonitor(kubeClient, eventRecorder, driver.diskController)
+
+			// Recover any ongoing migrations after restart
+			go func() {
+				time.Sleep(30 * time.Second) // Wait for controller to fully start
+				if err := driver.recoverMigrationMonitorsFromAnnotations(context.Background()); err != nil {
+					klog.Errorf("Failed to recover migration monitors: %v", err)
+				}
+			}()
+		}
 	}
 
 	driver.deviceHelper = optimization.NewSafeDeviceHelper()
@@ -356,6 +382,12 @@ func (d *Driver) Run(ctx context.Context) error {
 	go func() {
 		//graceful shutdown
 		<-ctx.Done()
+
+		// Stop migration monitor if it exists
+		if d.migrationMonitor != nil {
+			d.migrationMonitor.Stop()
+		}
+
 		s.GracefulStop()
 	}()
 	// Driver d act as IdentityServer, ControllerServer and NodeServer

--- a/pkg/azuredisk/fake_azuredisk.go
+++ b/pkg/azuredisk/fake_azuredisk.go
@@ -70,6 +70,10 @@ type FakeDriver interface {
 	GetSourceDiskSize(ctx context.Context, subsID, resourceGroup, diskName string, curDepth, maxDepth int) (*int32, *armcompute.Disk, error)
 	SetWaitForSnapshotReady(bool)
 	GetWaitForSnapshotReady() bool
+	GetDiskController() *ManagedDiskController
+	GetMigrationMonitor() *MigrationProgressMonitor
+	SetMigrationMonitor(*MigrationProgressMonitor)
+	RecoverMigrationMonitor(ctx context.Context) error
 
 	setNextCommandOutputScripts(scripts ...testingexec.FakeAction)
 
@@ -199,4 +203,30 @@ func (d *fakeDriver) SetWaitForSnapshotReady(shouldWait bool) {
 
 func (d *fakeDriver) GetWaitForSnapshotReady() bool {
 	return d.shouldWaitForSnapshotReady
+}
+
+func (d *fakeDriver) GetDiskController() *ManagedDiskController {
+	if d.diskController == nil {
+		d.diskController = NewManagedDiskController(d.cloud)
+	}
+	return d.diskController
+}
+
+func (d *fakeDriver) GetMigrationMonitor() *MigrationProgressMonitor {
+	if d.migrationMonitor == nil {
+		d.migrationMonitor = NewMigrationProgressMonitor(d.kubeClient, d.eventRecorder, d.GetDiskController())
+	}
+	return d.migrationMonitor
+}
+
+func (d *fakeDriver) SetMigrationMonitor(monitor *MigrationProgressMonitor) {
+	if monitor == nil {
+		d.migrationMonitor = NewMigrationProgressMonitor(d.kubeClient, d.eventRecorder, d.GetDiskController())
+	} else {
+		d.migrationMonitor = monitor
+	}
+}
+
+func (d *fakeDriver) RecoverMigrationMonitor(ctx context.Context) error {
+	return d.recoverMigrationMonitorsFromAnnotations(ctx)
 }

--- a/pkg/azuredisk/migration_monitor.go
+++ b/pkg/azuredisk/migration_monitor.go
@@ -1,0 +1,364 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azuredisk
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// Migration monitoring constants
+	migrationCheckInterval     = 30 * time.Second
+	migrationTimeout           = 24 * time.Hour
+	progressReportingThreshold = 20 // Report every 20% completion
+
+	// Event types and reasons
+	EventTypeNormal  = "Normal"
+	EventTypeWarning = "Warning"
+
+	ReasonSKUMigrationStarted   = "SKUMigrationStarted"
+	ReasonSKUMigrationProgress  = "SKUMigrationProgress"
+	ReasonSKUMigrationCompleted = "SKUMigrationCompleted"
+	ReasonSKUMigrationFailed    = "SKUMigrationFailed"
+	ReasonSKUMigrationTimeout   = "SKUMigrationTimeout"
+
+	// Annotations for migration status
+	AnnotationMigrationStatus = "disk.csi.azure.com/migration-status"
+	AnnotationMigrationFrom   = "disk.csi.azure.com/migration-from-sku"
+	AnnotationMigrationTo     = "disk.csi.azure.com/migration-to-sku"
+	AnnotationMigrationStart  = "disk.csi.azure.com/migration-start-time"
+)
+
+// MigrationTask represents an active disk migration monitoring task
+type MigrationTask struct {
+	DiskURI              string
+	PVName               string
+	FromSKU              armcompute.DiskStorageAccountTypes
+	ToSKU                armcompute.DiskStorageAccountTypes
+	StartTime            time.Time
+	LastReportedProgress float32
+	Context              context.Context
+	CancelFunc           context.CancelFunc
+}
+
+// MigrationProgressMonitor monitors disk migration progress
+type MigrationProgressMonitor struct {
+	kubeClient     kubernetes.Interface
+	eventRecorder  record.EventRecorder
+	diskController *ManagedDiskController
+	activeTasks    map[string]*MigrationTask
+	mutex          sync.RWMutex
+}
+
+// NewMigrationProgressMonitor creates a new migration progress monitor
+func NewMigrationProgressMonitor(kubeClient kubernetes.Interface, eventRecorder record.EventRecorder, diskController *ManagedDiskController) *MigrationProgressMonitor {
+	return &MigrationProgressMonitor{
+		kubeClient:     kubeClient,
+		eventRecorder:  eventRecorder,
+		diskController: diskController,
+		activeTasks:    make(map[string]*MigrationTask),
+	}
+}
+
+// StartMigrationMonitoring starts monitoring a disk migration with progress updates
+func (m *MigrationProgressMonitor) StartMigrationMonitoring(ctx context.Context, diskURI, pvName string, fromSKU, toSKU armcompute.DiskStorageAccountTypes) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	// Check if already monitoring this disk
+	if _, exists := m.activeTasks[diskURI]; exists {
+		klog.V(2).Infof("Migration monitoring already active for disk %s", diskURI)
+		return nil
+	}
+
+	// Create task context with timeout
+	taskCtx, cancelFunc := context.WithTimeout(context.Background(), migrationTimeout)
+
+	task := &MigrationTask{
+		DiskURI:              diskURI,
+		PVName:               pvName,
+		FromSKU:              fromSKU,
+		ToSKU:                toSKU,
+		StartTime:            time.Now(),
+		LastReportedProgress: 0,
+		Context:              taskCtx,
+		CancelFunc:           cancelFunc,
+	}
+
+	m.activeTasks[diskURI] = task
+
+	// Start async monitoring
+	go m.monitorMigrationProgress(task)
+
+	// Add annotations to PV to track migration state and check if they were already present
+	annotationsExisted, err := m.addMigrationAnnotationsIfNotExists(ctx, pvName, fromSKU, toSKU)
+	if err != nil {
+		klog.Warningf("Failed to add migration annotations to PV %s: %v", pvName, err)
+	}
+
+	// Only emit start event if annotations were not already present (new migration)
+	if !annotationsExisted {
+		_ = m.emitMigrationEvent(task, EventTypeNormal, ReasonSKUMigrationStarted,
+			fmt.Sprintf("Started SKU migration from %s to %s for volume %s", fromSKU, toSKU, pvName))
+		klog.V(2).Infof("Started migration monitoring for disk %s (%s -> %s)", pvName, fromSKU, toSKU)
+	} else {
+		klog.V(2).Infof("Resumed migration monitoring for disk %s (%s -> %s)", pvName, fromSKU, toSKU)
+	}
+
+	return nil
+}
+
+// monitorMigrationProgress monitors the progress of a disk migration
+func (m *MigrationProgressMonitor) monitorMigrationProgress(task *MigrationTask) {
+	defer func() {
+		m.mutex.Lock()
+		delete(m.activeTasks, task.DiskURI)
+		m.mutex.Unlock()
+		task.CancelFunc()
+	}()
+
+	ticker := time.NewTicker(migrationCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-task.Context.Done():
+			if task.Context.Err() == context.DeadlineExceeded {
+				_ = m.emitMigrationEvent(task, EventTypeWarning, ReasonSKUMigrationTimeout,
+					fmt.Sprintf("Migration timeout after %v for volume %s", migrationTimeout, task.PVName))
+				klog.Warningf("Migration timeout for disk %s after %v", task.DiskURI, migrationTimeout)
+			}
+			return
+
+		case <-ticker.C:
+			completed, err := m.checkMigrationProgress(task)
+			if err != nil {
+				klog.V(4).Infof("Progress check error for disk %s (will retry): %v", task.DiskURI, err)
+				continue
+			}
+
+			if completed {
+				if m.emitMigrationEvent(task, EventTypeNormal, ReasonSKUMigrationCompleted,
+					fmt.Sprintf("Successfully completed SKU migration from %s to %s for volume %s (duration: %v)",
+						task.FromSKU, task.ToSKU, task.PVName, time.Since(task.StartTime))) != nil {
+					klog.Errorf("Failed to emit completion event for disk %s: %v", task.DiskURI, err)
+					return
+				}
+				klog.V(2).Infof("Migration completed for disk %s in %v", task.DiskURI, time.Since(task.StartTime))
+
+				// Remove annotations when migration completes
+				if err := m.removeMigrationAnnotations(task.Context, task.PVName); err != nil {
+					klog.Warningf("Failed to remove migration annotations from PV %s: %v", task.PVName, err)
+				}
+				return
+			}
+		}
+	}
+}
+
+// checkMigrationProgress checks the current progress of a disk migration
+func (m *MigrationProgressMonitor) checkMigrationProgress(task *MigrationTask) (bool, error) {
+	// Get current disk state
+	disk, err := m.diskController.GetDiskByURI(task.Context, task.DiskURI)
+	if err != nil {
+		return false, fmt.Errorf("failed to get disk %s: %v", task.DiskURI, err)
+	}
+
+	// Check completion percentage if available
+	var completionPercent float32
+	if disk.Properties != nil && disk.Properties.CompletionPercent != nil {
+		completionPercent = *disk.Properties.CompletionPercent
+	}
+
+	// Report progress if significant milestone reached
+	if m.shouldReportProgress(completionPercent, task.LastReportedProgress) {
+		_ = m.emitMigrationEvent(task, EventTypeNormal, ReasonSKUMigrationProgress,
+			fmt.Sprintf("Migration progress: %.1f%% complete for volume %s (elapsed: %v)",
+				completionPercent, task.PVName, time.Since(task.StartTime)))
+		task.LastReportedProgress = completionPercent
+		klog.V(2).Infof("Migration progress for disk %s: %.1f%% complete", task.DiskURI, completionPercent)
+	}
+
+	return completionPercent >= 100, nil
+}
+
+// shouldReportProgress determines if progress should be reported based on milestones
+func (m *MigrationProgressMonitor) shouldReportProgress(current, last float32) bool {
+	// Report at every 20% milestone
+	currentMilestone := int(current/progressReportingThreshold) * progressReportingThreshold
+	lastMilestone := int(last/progressReportingThreshold) * progressReportingThreshold
+
+	return current < 100 && (currentMilestone > lastMilestone && currentMilestone > 0)
+}
+
+// emitMigrationEvent emits a Kubernetes event for the PersistentVolume
+func (m *MigrationProgressMonitor) emitMigrationEvent(task *MigrationTask, eventType, reason, message string) error {
+	if m.eventRecorder == nil || m.kubeClient == nil {
+		klog.Warningf("Event recorder or kube client not available, skipping event: %s", message)
+		return fmt.Errorf("event recorder or kube client not available")
+	}
+
+	// Get PersistentVolume object
+	pv, err := m.kubeClient.CoreV1().PersistentVolumes().Get(context.TODO(), task.PVName, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("Failed to get PersistentVolume %s for event emission: %v", task.PVName, err)
+		// if error is not found, lets exit the migration go routine
+		if apierrors.IsNotFound(err) {
+			return err
+		}
+		return nil
+	}
+
+	// Emit event on the PersistentVolume
+	m.eventRecorder.Event(pv, eventType, reason, message)
+	klog.V(4).Infof("Emitted event for PV %s: %s - %s", task.PVName, reason, message)
+	return nil
+}
+
+// addMigrationAnnotationsIfNotExists adds migration-related annotations to the PersistentVolume if they don't already exist
+// Returns true if annotations already existed, false if they were newly added
+func (m *MigrationProgressMonitor) addMigrationAnnotationsIfNotExists(ctx context.Context, pvName string, fromSKU, toSKU armcompute.DiskStorageAccountTypes) (bool, error) {
+	pv, err := m.kubeClient.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	// Check if migration annotations already exist
+	if pv.Annotations != nil {
+		if status, exists := pv.Annotations[AnnotationMigrationStatus]; exists && status == "in-progress" {
+			// Verify that the SKU annotations match what we expect
+			existingFromSKU := pv.Annotations[AnnotationMigrationFrom]
+			existingToSKU := pv.Annotations[AnnotationMigrationTo]
+
+			if existingFromSKU == string(fromSKU) && existingToSKU == string(toSKU) {
+				klog.V(2).Infof("Migration annotations already exist for PV %s (%s -> %s)", pvName, fromSKU, toSKU)
+				return true, nil
+			}
+		}
+	}
+
+	// Annotations don't exist or don't match, add them
+	if pv.Annotations == nil {
+		pv.Annotations = make(map[string]string)
+	}
+
+	pv.Annotations[AnnotationMigrationStatus] = "in-progress"
+	pv.Annotations[AnnotationMigrationFrom] = string(fromSKU)
+	pv.Annotations[AnnotationMigrationTo] = string(toSKU)
+	pv.Annotations[AnnotationMigrationStart] = time.Now().Format(time.RFC3339)
+
+	_, err = m.kubeClient.CoreV1().PersistentVolumes().Update(ctx, pv, metav1.UpdateOptions{})
+	return false, err
+}
+
+// removeMigrationAnnotations removes migration-related annotations from the PersistentVolume
+func (m *MigrationProgressMonitor) removeMigrationAnnotations(ctx context.Context, pvName string) error {
+	pv, err := m.kubeClient.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if pv.Annotations != nil {
+		delete(pv.Annotations, AnnotationMigrationStatus)
+		delete(pv.Annotations, AnnotationMigrationFrom)
+		delete(pv.Annotations, AnnotationMigrationTo)
+		delete(pv.Annotations, AnnotationMigrationStart)
+	}
+
+	_, err = m.kubeClient.CoreV1().PersistentVolumes().Update(ctx, pv, metav1.UpdateOptions{})
+	return err
+}
+
+// GetActiveMigrations returns currently active migration tasks
+func (m *MigrationProgressMonitor) GetActiveMigrations() map[string]*MigrationTask {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	result := make(map[string]*MigrationTask)
+	for k, v := range m.activeTasks {
+		taskCopy := *v
+		result[k] = &taskCopy
+	}
+	return result
+}
+
+// IsMigrationActive checks if migration is currently being monitored for a disk
+func (m *MigrationProgressMonitor) IsMigrationActive(diskURI string) bool {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	_, exists := m.activeTasks[diskURI]
+	return exists
+}
+
+// Stop stops all active migration monitoring tasks
+func (m *MigrationProgressMonitor) Stop() {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	for _, task := range m.activeTasks {
+		if task.CancelFunc != nil {
+			task.CancelFunc()
+		}
+	}
+
+	klog.V(2).Infof("Migration progress monitor stopped, cancelled %d active tasks", len(m.activeTasks))
+}
+
+// Recovery function using annotations
+func (d *Driver) recoverMigrationMonitorsFromAnnotations(ctx context.Context) error {
+	pvList, err := d.cloud.KubeClient.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	recoveredCount := 0
+	for _, pv := range pvList.Items {
+		if pv.Spec.CSI != nil && pv.Spec.CSI.Driver == d.Name {
+			if status, exists := pv.Annotations[AnnotationMigrationStatus]; exists && status == "in-progress" {
+				fromSKU := pv.Annotations[AnnotationMigrationFrom]
+				toSKU := pv.Annotations[AnnotationMigrationTo]
+				diskURI := pv.Spec.CSI.VolumeHandle
+
+				if fromSKU != "" && toSKU != "" {
+					klog.V(2).Infof("Recovering migration monitor for PV %s (%s -> %s)", pv.Name, fromSKU, toSKU)
+
+					if err := d.migrationMonitor.StartMigrationMonitoring(ctx, diskURI, pv.Name,
+						armcompute.DiskStorageAccountTypes(fromSKU),
+						armcompute.DiskStorageAccountTypes(toSKU)); err != nil {
+						klog.Errorf("Failed to recover migration for PV %s: %v", pv.Name, err)
+					} else {
+						recoveredCount++
+					}
+				}
+			}
+		}
+	}
+
+	klog.V(2).Infof("Recovered %d migration monitors from annotations", recoveredCount)
+	return nil
+}

--- a/pkg/azuredisk/migration_monitor_test.go
+++ b/pkg/azuredisk/migration_monitor_test.go
@@ -1,0 +1,852 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azuredisk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+
+	"sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk/mockcorev1"
+	"sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk/mockkubeclient"
+	"sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk/mockpersistentvolume"
+	azure "sigs.k8s.io/cloud-provider-azure/pkg/provider"
+)
+
+func TestNewMigrationProgressMonitor(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockKubeClient := mockkubeclient.NewMockInterface(ctrl)
+	mockEventRecorder := record.NewFakeRecorder(10)
+	mockDiskController := &ManagedDiskController{}
+
+	monitor := NewMigrationProgressMonitor(mockKubeClient, mockEventRecorder, mockDiskController)
+
+	assert.NotNil(t, monitor)
+	assert.Equal(t, mockKubeClient, monitor.kubeClient)
+	assert.Equal(t, mockEventRecorder, monitor.eventRecorder)
+	assert.Equal(t, mockDiskController, monitor.diskController)
+	assert.NotNil(t, monitor.activeTasks)
+	assert.Equal(t, 0, len(monitor.activeTasks))
+}
+
+func TestStartMigrationMonitoring(t *testing.T) {
+	tests := []struct {
+		name        string
+		diskURI     string
+		pvName      string
+		fromSKU     armcompute.DiskStorageAccountTypes
+		toSKU       armcompute.DiskStorageAccountTypes
+		expectError bool
+	}{
+		{
+			name:        "successful start Premium_LRS to PremiumV2_LRS",
+			diskURI:     "/subscriptions/test/resourceGroups/rg/providers/Microsoft.Compute/disks/test-disk",
+			pvName:      "test-pv",
+			fromSKU:     armcompute.DiskStorageAccountTypesPremiumLRS,
+			toSKU:       armcompute.DiskStorageAccountTypesPremiumV2LRS,
+			expectError: false,
+		},
+		{
+			name:        "successful start Standard_LRS to Premium_LRS",
+			diskURI:     "/subscriptions/test/resourceGroups/rg/providers/Microsoft.Compute/disks/test-disk-2",
+			pvName:      "test-pv-2",
+			fromSKU:     armcompute.DiskStorageAccountTypesStandardLRS,
+			toSKU:       armcompute.DiskStorageAccountTypesPremiumLRS,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockKubeClient := mockkubeclient.NewMockInterface(ctrl)
+			mockCoreV1 := mockcorev1.NewMockInterface(ctrl)
+			mockPVInterface := mockpersistentvolume.NewMockInterface(ctrl)
+			mockEventRecorder := record.NewFakeRecorder(10)
+			mockDiskController := &ManagedDiskController{}
+
+			// Create test PV for the event emission and annotation updates
+			testPV := &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tt.pvName,
+				},
+			}
+
+			// Set up mock expectations for both event emission and annotation updates
+			mockKubeClient.EXPECT().CoreV1().Return(mockCoreV1).AnyTimes()
+			mockCoreV1.EXPECT().PersistentVolumes().Return(mockPVInterface).AnyTimes()
+
+			// Expect Get calls for both event emission and addMigrationAnnotationsIfNotExists
+			mockPVInterface.EXPECT().Get(gomock.Any(), tt.pvName, gomock.Any()).Return(testPV, nil).AnyTimes()
+
+			// Expect Update call for addMigrationAnnotationsIfNotExists
+			mockPVInterface.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, pv *v1.PersistentVolume, _ metav1.UpdateOptions) (*v1.PersistentVolume, error) {
+					// Verify annotations were added correctly
+					assert.Equal(t, "in-progress", pv.Annotations[AnnotationMigrationStatus])
+					assert.Equal(t, string(tt.fromSKU), pv.Annotations[AnnotationMigrationFrom])
+					assert.Equal(t, string(tt.toSKU), pv.Annotations[AnnotationMigrationTo])
+					assert.NotEmpty(t, pv.Annotations[AnnotationMigrationStart])
+					return pv, nil
+				}).Times(1)
+
+			monitor := NewMigrationProgressMonitor(mockKubeClient, mockEventRecorder, mockDiskController)
+
+			ctx := context.Background()
+			err := monitor.StartMigrationMonitoring(ctx, tt.diskURI, tt.pvName, tt.fromSKU, tt.toSKU)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.True(t, monitor.IsMigrationActive(tt.diskURI))
+
+				// Verify task was created correctly
+				activeTasks := monitor.GetActiveMigrations()
+				assert.Equal(t, 1, len(activeTasks))
+
+				task, exists := activeTasks[tt.diskURI]
+				assert.True(t, exists)
+				assert.Equal(t, tt.diskURI, task.DiskURI)
+				assert.Equal(t, tt.pvName, task.PVName)
+				assert.Equal(t, tt.fromSKU, task.FromSKU)
+				assert.Equal(t, tt.toSKU, task.ToSKU)
+				assert.NotNil(t, task.CancelFunc)
+				assert.NotNil(t, task.Context)
+
+				// Verify migration started event was recorded
+				select {
+				case event := <-mockEventRecorder.Events:
+					assert.Contains(t, event, "Normal")
+					assert.Contains(t, event, ReasonSKUMigrationStarted)
+					assert.Contains(t, event, tt.pvName)
+				case <-time.After(100 * time.Millisecond):
+					t.Error("Expected migration started event was not recorded")
+				}
+
+				// Stop monitoring to clean up
+				monitor.Stop()
+			}
+		})
+	}
+}
+
+func TestIsMigrationActive(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockKubeClient := mockkubeclient.NewMockInterface(ctrl)
+	mockCoreV1 := mockcorev1.NewMockInterface(ctrl)
+	mockPVInterface := mockpersistentvolume.NewMockInterface(ctrl)
+	mockEventRecorder := record.NewFakeRecorder(10)
+	mockDiskController := &ManagedDiskController{}
+
+	// Create test PV for the event emission
+	testPV := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pv",
+		},
+	}
+
+	// Set up mock expectations for event emission and annotation updates
+	mockKubeClient.EXPECT().CoreV1().Return(mockCoreV1).AnyTimes()
+	mockCoreV1.EXPECT().PersistentVolumes().Return(mockPVInterface).AnyTimes()
+	mockPVInterface.EXPECT().Get(gomock.Any(), "test-pv", gomock.Any()).Return(testPV, nil).AnyTimes()
+
+	// Add the missing Update expectation for addMigrationAnnotationsIfNotExists
+	mockPVInterface.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, pv *v1.PersistentVolume, _ metav1.UpdateOptions) (*v1.PersistentVolume, error) {
+			// Verify annotations were added correctly
+			assert.Equal(t, "in-progress", pv.Annotations[AnnotationMigrationStatus])
+			assert.Equal(t, string(armcompute.DiskStorageAccountTypesPremiumLRS), pv.Annotations[AnnotationMigrationFrom])
+			assert.Equal(t, string(armcompute.DiskStorageAccountTypesPremiumV2LRS), pv.Annotations[AnnotationMigrationTo])
+			assert.NotEmpty(t, pv.Annotations[AnnotationMigrationStart])
+			return pv, nil
+		}).Times(1)
+
+	monitor := NewMigrationProgressMonitor(mockKubeClient, mockEventRecorder, mockDiskController)
+
+	diskURI := "/subscriptions/test/resourceGroups/rg/providers/Microsoft.Compute/disks/test-disk"
+	nonExistentDiskURI := "/subscriptions/test/resourceGroups/rg/providers/Microsoft.Compute/disks/non-existent"
+
+	// Initially no migration should be active
+	assert.False(t, monitor.IsMigrationActive(diskURI))
+	assert.False(t, monitor.IsMigrationActive(nonExistentDiskURI))
+
+	// Start monitoring
+	ctx := context.Background()
+	err := monitor.StartMigrationMonitoring(ctx, diskURI, "test-pv",
+		armcompute.DiskStorageAccountTypesPremiumLRS,
+		armcompute.DiskStorageAccountTypesPremiumV2LRS)
+	assert.NoError(t, err)
+
+	// Now should be active
+	assert.True(t, monitor.IsMigrationActive(diskURI))
+	assert.False(t, monitor.IsMigrationActive(nonExistentDiskURI))
+
+	monitor.Stop()
+
+	// After stop, should not be active anymore
+	time.Sleep(100 * time.Millisecond) // Allow goroutines to finish
+	assert.False(t, monitor.IsMigrationActive(diskURI))
+}
+
+func TestMigrationShouldReportProgress(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockKubeClient := mockkubeclient.NewMockInterface(ctrl)
+	mockEventRecorder := record.NewFakeRecorder(10)
+	mockDiskController := &ManagedDiskController{}
+
+	monitor := NewMigrationProgressMonitor(mockKubeClient, mockEventRecorder, mockDiskController)
+
+	tests := []struct {
+		name     string
+		current  float32
+		last     float32
+		expected bool
+	}{
+		{"initial progress", 15.0, 0.0, false},
+		{"reach 20% milestone", 20.0, 15.0, true},
+		{"within same milestone", 25.0, 20.0, false},
+		{"reach 40% milestone", 40.0, 25.0, true},
+		{"reach 60% milestone", 60.0, 45.0, true},
+		{"reach 80% milestone", 80.0, 65.0, true},
+		{"completion", 100.0, 85.0, false},
+		{"regression", 75.0, 80.0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := monitor.shouldReportProgress(tt.current, tt.last)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestEmitMigrationEvent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockKubeClient := mockkubeclient.NewMockInterface(ctrl)
+	mockCoreV1 := mockcorev1.NewMockInterface(ctrl)
+	mockPVInterface := mockpersistentvolume.NewMockInterface(ctrl)
+	mockEventRecorder := record.NewFakeRecorder(10)
+	mockDiskController := &ManagedDiskController{}
+
+	monitor := NewMigrationProgressMonitor(mockKubeClient, mockEventRecorder, mockDiskController)
+
+	// Create test PV
+	testPV := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pv",
+		},
+	}
+
+	// Create test task
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	task := &MigrationTask{
+		DiskURI:    "/subscriptions/test/resourceGroups/rg/providers/Microsoft.Compute/disks/test-disk",
+		PVName:     "test-pv",
+		FromSKU:    armcompute.DiskStorageAccountTypesPremiumLRS,
+		ToSKU:      armcompute.DiskStorageAccountTypesPremiumV2LRS,
+		StartTime:  time.Now(),
+		Context:    ctx,
+		CancelFunc: cancel,
+	}
+
+	// Set up mocks
+	mockKubeClient.EXPECT().CoreV1().Return(mockCoreV1)
+	mockCoreV1.EXPECT().PersistentVolumes().Return(mockPVInterface)
+	mockPVInterface.EXPECT().Get(gomock.Any(), "test-pv", gomock.Any()).Return(testPV, nil)
+
+	// Test successful event emission
+	assert.NoError(t, monitor.emitMigrationEvent(task, EventTypeNormal, ReasonSKUMigrationStarted, "Test migration started"))
+
+	// Verify event was recorded
+	select {
+	case event := <-mockEventRecorder.Events:
+		assert.Contains(t, event, "Normal")
+		assert.Contains(t, event, ReasonSKUMigrationStarted)
+		assert.Contains(t, event, "Test migration started")
+	default:
+		t.Error("Expected event was not recorded")
+	}
+}
+
+func TestEmitMigrationEvent_PVNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockKubeClient := mockkubeclient.NewMockInterface(ctrl)
+	mockCoreV1 := mockcorev1.NewMockInterface(ctrl)
+	mockPVInterface := mockpersistentvolume.NewMockInterface(ctrl)
+	mockEventRecorder := record.NewFakeRecorder(10)
+	mockDiskController := &ManagedDiskController{}
+
+	monitor := NewMigrationProgressMonitor(mockKubeClient, mockEventRecorder, mockDiskController)
+
+	// Create test task
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	task := &MigrationTask{
+		DiskURI:    "/subscriptions/test/resourceGroups/rg/providers/Microsoft.Compute/disks/test-disk",
+		PVName:     "non-existent-pv",
+		FromSKU:    armcompute.DiskStorageAccountTypesPremiumLRS,
+		ToSKU:      armcompute.DiskStorageAccountTypesPremiumV2LRS,
+		StartTime:  time.Now(),
+		Context:    ctx,
+		CancelFunc: cancel,
+	}
+
+	// Set up mocks to return error
+	mockKubeClient.EXPECT().CoreV1().Return(mockCoreV1)
+	mockCoreV1.EXPECT().PersistentVolumes().Return(mockPVInterface)
+	mockPVInterface.EXPECT().Get(gomock.Any(), "non-existent-pv", gomock.Any()).Return(nil, errors.New("not found"))
+
+	// Test event emission with PV not found - should not panic
+	assert.NoError(t, monitor.emitMigrationEvent(task, EventTypeNormal, ReasonSKUMigrationStarted, "Test migration started"))
+
+	// Verify no event was recorded
+	select {
+	case <-mockEventRecorder.Events:
+		t.Error("No event should have been recorded when PV is not found")
+	default:
+		// Expected - no event should be recorded
+	}
+}
+
+func TestMigrationStop(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockKubeClient := mockkubeclient.NewMockInterface(ctrl)
+	mockCoreV1 := mockcorev1.NewMockInterface(ctrl)
+	mockPVInterface := mockpersistentvolume.NewMockInterface(ctrl)
+	mockEventRecorder := record.NewFakeRecorder(10)
+	mockDiskController := &ManagedDiskController{}
+
+	// Create test PVs for the event emission
+	testPVs := []*v1.PersistentVolume{
+		{ObjectMeta: metav1.ObjectMeta{Name: "pv-1"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "pv-2"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "pv-3"}},
+	}
+
+	// Set up mock expectations for event emission and annotation updates
+	mockKubeClient.EXPECT().CoreV1().Return(mockCoreV1).AnyTimes()
+	mockCoreV1.EXPECT().PersistentVolumes().Return(mockPVInterface).AnyTimes()
+
+	// Set up expectations for each PV (Get calls for both event emission and addMigrationAnnotationsIfNotExists)
+	for i, pv := range testPVs {
+		pvName := fmt.Sprintf("pv-%d", i+1)
+		mockPVInterface.EXPECT().Get(gomock.Any(), pvName, gomock.Any()).Return(pv, nil).AnyTimes()
+	}
+
+	// Add Update expectations for addMigrationAnnotationsIfNotExists (3 calls for 3 migrations)
+	mockPVInterface.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, pv *v1.PersistentVolume, _ metav1.UpdateOptions) (*v1.PersistentVolume, error) {
+			// Verify annotations were added correctly
+			assert.Equal(t, "in-progress", pv.Annotations[AnnotationMigrationStatus])
+			assert.Equal(t, string(armcompute.DiskStorageAccountTypesPremiumLRS), pv.Annotations[AnnotationMigrationFrom])
+			assert.Equal(t, string(armcompute.DiskStorageAccountTypesPremiumV2LRS), pv.Annotations[AnnotationMigrationTo])
+			assert.NotEmpty(t, pv.Annotations[AnnotationMigrationStart])
+			return pv, nil
+		}).Times(3)
+
+	monitor := NewMigrationProgressMonitor(mockKubeClient, mockEventRecorder, mockDiskController)
+
+	// Start multiple migrations
+	ctx := context.Background()
+	diskURIs := []string{
+		"/subscriptions/test/resourceGroups/rg/providers/Microsoft.Compute/disks/disk1",
+		"/subscriptions/test/resourceGroups/rg/providers/Microsoft.Compute/disks/disk2",
+		"/subscriptions/test/resourceGroups/rg/providers/Microsoft.Compute/disks/disk3",
+	}
+
+	for i, diskURI := range diskURIs {
+		err := monitor.StartMigrationMonitoring(ctx, diskURI, fmt.Sprintf("pv-%d", i+1),
+			armcompute.DiskStorageAccountTypesPremiumLRS,
+			armcompute.DiskStorageAccountTypesPremiumV2LRS)
+		assert.NoError(t, err)
+	}
+
+	// Verify migrations are active
+	activeTasks := monitor.GetActiveMigrations()
+	assert.Equal(t, 3, len(activeTasks))
+
+	// Stop all migrations
+	monitor.Stop()
+
+	// Allow some time for goroutines to finish
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify all migrations are stopped
+	for _, diskURI := range diskURIs {
+		assert.False(t, monitor.IsMigrationActive(diskURI))
+	}
+
+	activeTasks = monitor.GetActiveMigrations()
+	assert.Equal(t, 0, len(activeTasks))
+}
+
+func TestRecoverMigrationMonitorsFromAnnotations(t *testing.T) {
+	tests := []struct {
+		name          string
+		existingPVs   []*v1.PersistentVolume
+		expectedCount int
+		expectError   bool
+	}{
+		{
+			name: "recover single ongoing migration",
+			existingPVs: []*v1.PersistentVolume{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-with-migration",
+						Annotations: map[string]string{
+							AnnotationMigrationStatus: "in-progress",
+							AnnotationMigrationFrom:   string(armcompute.DiskStorageAccountTypesPremiumLRS),
+							AnnotationMigrationTo:     string(armcompute.DiskStorageAccountTypesPremiumV2LRS),
+							AnnotationMigrationStart:  time.Now().Format(time.RFC3339),
+						},
+					},
+					Spec: v1.PersistentVolumeSpec{
+						PersistentVolumeSource: v1.PersistentVolumeSource{
+							CSI: &v1.CSIPersistentVolumeSource{
+								Driver:       "disk.csi.azure.com",
+								VolumeHandle: "/subscriptions/test/resourceGroups/rg/providers/Microsoft.Compute/disks/test-disk",
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 1,
+			expectError:   false,
+		},
+		{
+			name: "recover multiple ongoing migrations",
+			existingPVs: []*v1.PersistentVolume{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-migration-1",
+						Annotations: map[string]string{
+							AnnotationMigrationStatus: "in-progress",
+							AnnotationMigrationFrom:   string(armcompute.DiskStorageAccountTypesPremiumLRS),
+							AnnotationMigrationTo:     string(armcompute.DiskStorageAccountTypesPremiumV2LRS),
+						},
+					},
+					Spec: v1.PersistentVolumeSpec{
+						PersistentVolumeSource: v1.PersistentVolumeSource{
+							CSI: &v1.CSIPersistentVolumeSource{
+								Driver:       "disk.csi.azure.com",
+								VolumeHandle: "/subscriptions/test/resourceGroups/rg/providers/Microsoft.Compute/disks/disk-1",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-migration-2",
+						Annotations: map[string]string{
+							AnnotationMigrationStatus: "in-progress",
+							AnnotationMigrationFrom:   string(armcompute.DiskStorageAccountTypesStandardLRS),
+							AnnotationMigrationTo:     string(armcompute.DiskStorageAccountTypesPremiumLRS),
+						},
+					},
+					Spec: v1.PersistentVolumeSpec{
+						PersistentVolumeSource: v1.PersistentVolumeSource{
+							CSI: &v1.CSIPersistentVolumeSource{
+								Driver:       "disk.csi.azure.com",
+								VolumeHandle: "/subscriptions/test/resourceGroups/rg/providers/Microsoft.Compute/disks/disk-2",
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 2,
+			expectError:   false,
+		},
+		{
+			name: "skip PVs without migration annotations",
+			existingPVs: []*v1.PersistentVolume{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-no-migration",
+					},
+					Spec: v1.PersistentVolumeSpec{
+						PersistentVolumeSource: v1.PersistentVolumeSource{
+							CSI: &v1.CSIPersistentVolumeSource{
+								Driver:       "disk.csi.azure.com",
+								VolumeHandle: "/subscriptions/test/resourceGroups/rg/providers/Microsoft.Compute/disks/no-migration",
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 0,
+			expectError:   false,
+		},
+		{
+			name: "skip non-Azure disk PVs",
+			existingPVs: []*v1.PersistentVolume{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-other-driver",
+						Annotations: map[string]string{
+							AnnotationMigrationStatus: "in-progress",
+							AnnotationMigrationFrom:   string(armcompute.DiskStorageAccountTypesPremiumLRS),
+							AnnotationMigrationTo:     string(armcompute.DiskStorageAccountTypesPremiumV2LRS),
+						},
+					},
+					Spec: v1.PersistentVolumeSpec{
+						PersistentVolumeSource: v1.PersistentVolumeSource{
+							CSI: &v1.CSIPersistentVolumeSource{
+								Driver:       "other.csi.driver",
+								VolumeHandle: "/some/other/volume",
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 0,
+			expectError:   false,
+		},
+		{
+			name: "skip completed migrations",
+			existingPVs: []*v1.PersistentVolume{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-completed-migration",
+						Annotations: map[string]string{
+							AnnotationMigrationStatus: "completed",
+							AnnotationMigrationFrom:   string(armcompute.DiskStorageAccountTypesPremiumLRS),
+							AnnotationMigrationTo:     string(armcompute.DiskStorageAccountTypesPremiumV2LRS),
+						},
+					},
+					Spec: v1.PersistentVolumeSpec{
+						PersistentVolumeSource: v1.PersistentVolumeSource{
+							CSI: &v1.CSIPersistentVolumeSource{
+								Driver:       "disk.csi.azure.com",
+								VolumeHandle: "/subscriptions/test/resourceGroups/rg/providers/Microsoft.Compute/disks/completed-disk",
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 0,
+			expectError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			// Setup mocks
+			mockKubeClient := mockkubeclient.NewMockInterface(ctrl)
+			mockCoreV1 := mockcorev1.NewMockInterface(ctrl)
+			mockPVInterface := mockpersistentvolume.NewMockInterface(ctrl)
+			mockEventRecorder := record.NewFakeRecorder(10)
+
+			// Create Driver using the proper initialization pattern
+			driver := &Driver{}
+			driver.Name = "disk.csi.azure.com" // Set the driver name directly
+			driver.cloud = &azure.Cloud{
+				KubeClient: mockKubeClient,
+			}
+			driver.migrationMonitor = NewMigrationProgressMonitor(mockKubeClient, mockEventRecorder, &ManagedDiskController{})
+
+			// Setup mock expectations for listing PVs
+			pvList := &v1.PersistentVolumeList{Items: make([]v1.PersistentVolume, len(tt.existingPVs))}
+			for i, pv := range tt.existingPVs {
+				pvList.Items[i] = *pv
+			}
+
+			mockKubeClient.EXPECT().CoreV1().Return(mockCoreV1).AnyTimes()
+			mockCoreV1.EXPECT().PersistentVolumes().Return(mockPVInterface).AnyTimes()
+			mockPVInterface.EXPECT().List(gomock.Any(), gomock.Any()).Return(pvList, nil)
+
+			// Setup expectations for each PV that should be recovered
+			for _, pv := range tt.existingPVs {
+				if pv.Spec.CSI != nil && pv.Spec.CSI.Driver == "disk.csi.azure.com" {
+					if status, exists := pv.Annotations[AnnotationMigrationStatus]; exists && status == "in-progress" {
+						if pv.Annotations[AnnotationMigrationFrom] != "" && pv.Annotations[AnnotationMigrationTo] != "" {
+							// This PV should be recovered - setup Get expectation for StartMigrationMonitoring
+							mockPVInterface.EXPECT().Get(gomock.Any(), pv.Name, gomock.Any()).Return(pv, nil).AnyTimes()
+
+							// StartMigrationMonitoring calls addMigrationAnnotationsIfNotExists which needs Update expectation
+							mockPVInterface.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+								func(_ context.Context, updatedPV *v1.PersistentVolume, _ metav1.UpdateOptions) (*v1.PersistentVolume, error) {
+									// Just return the updated PV - the annotations are already set
+									return updatedPV, nil
+								}).AnyTimes()
+						}
+					}
+				}
+			}
+
+			// Execute recovery
+			ctx := context.Background()
+			err := driver.recoverMigrationMonitorsFromAnnotations(ctx)
+
+			// Verify results
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+
+				// Verify correct number of migrations were recovered
+				activeTasks := driver.migrationMonitor.GetActiveMigrations()
+				assert.Equal(t, tt.expectedCount, len(activeTasks))
+
+				// Verify each recovered migration is properly configured
+				for _, pv := range tt.existingPVs {
+					if pv.Spec.CSI != nil && pv.Spec.CSI.Driver == "disk.csi.azure.com" {
+						if status, exists := pv.Annotations[AnnotationMigrationStatus]; exists && status == "in-progress" {
+							if pv.Annotations[AnnotationMigrationFrom] != "" && pv.Annotations[AnnotationMigrationTo] != "" {
+								diskURI := pv.Spec.CSI.VolumeHandle
+								assert.True(t, driver.migrationMonitor.IsMigrationActive(diskURI))
+
+								task, exists := activeTasks[diskURI]
+								assert.True(t, exists)
+								assert.Equal(t, pv.Name, task.PVName)
+								assert.Equal(t, armcompute.DiskStorageAccountTypes(pv.Annotations[AnnotationMigrationFrom]), task.FromSKU)
+								assert.Equal(t, armcompute.DiskStorageAccountTypes(pv.Annotations[AnnotationMigrationTo]), task.ToSKU)
+							}
+						}
+					}
+				}
+			}
+
+			// Cleanup
+			driver.migrationMonitor.Stop()
+		})
+	}
+}
+
+func TestAddMigrationAnnotationsIfNotExists(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockKubeClient := mockkubeclient.NewMockInterface(ctrl)
+	mockCoreV1 := mockcorev1.NewMockInterface(ctrl)
+	mockPVInterface := mockpersistentvolume.NewMockInterface(ctrl)
+	mockEventRecorder := record.NewFakeRecorder(10)
+	mockDiskController := &ManagedDiskController{}
+
+	monitor := NewMigrationProgressMonitor(mockKubeClient, mockEventRecorder, mockDiskController)
+
+	// Create test PV without annotations
+	testPV := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pv",
+		},
+	}
+
+	// Setup mock expectations - need multiple calls to CoreV1() and PersistentVolumes()
+	mockKubeClient.EXPECT().CoreV1().Return(mockCoreV1).AnyTimes()
+	mockCoreV1.EXPECT().PersistentVolumes().Return(mockPVInterface).AnyTimes()
+	mockPVInterface.EXPECT().Get(gomock.Any(), "test-pv", gomock.Any()).Return(testPV, nil)
+	mockPVInterface.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, pv *v1.PersistentVolume, _ metav1.UpdateOptions) (*v1.PersistentVolume, error) {
+			// Verify annotations were added correctly
+			assert.Equal(t, "in-progress", pv.Annotations[AnnotationMigrationStatus])
+			assert.Equal(t, string(armcompute.DiskStorageAccountTypesPremiumLRS), pv.Annotations[AnnotationMigrationFrom])
+			assert.Equal(t, string(armcompute.DiskStorageAccountTypesPremiumV2LRS), pv.Annotations[AnnotationMigrationTo])
+			assert.NotEmpty(t, pv.Annotations[AnnotationMigrationStart])
+			return pv, nil
+		})
+
+	// Execute
+	ctx := context.Background()
+	exists, err := monitor.addMigrationAnnotationsIfNotExists(ctx, "test-pv",
+		armcompute.DiskStorageAccountTypesPremiumLRS,
+		armcompute.DiskStorageAccountTypesPremiumV2LRS)
+
+	assert.Equal(t, exists, false)
+	assert.NoError(t, err)
+}
+
+func TestRemoveMigrationAnnotations(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockKubeClient := mockkubeclient.NewMockInterface(ctrl)
+	mockCoreV1 := mockcorev1.NewMockInterface(ctrl)
+	mockPVInterface := mockpersistentvolume.NewMockInterface(ctrl)
+	mockEventRecorder := record.NewFakeRecorder(10)
+	mockDiskController := &ManagedDiskController{}
+
+	monitor := NewMigrationProgressMonitor(mockKubeClient, mockEventRecorder, mockDiskController)
+
+	// Create test PV with migration annotations
+	testPV := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pv",
+			Annotations: map[string]string{
+				AnnotationMigrationStatus: "in-progress",
+				AnnotationMigrationFrom:   string(armcompute.DiskStorageAccountTypesPremiumLRS),
+				AnnotationMigrationTo:     string(armcompute.DiskStorageAccountTypesPremiumV2LRS),
+				AnnotationMigrationStart:  time.Now().Format(time.RFC3339),
+				"other.annotation":        "should-remain",
+			},
+		},
+	}
+
+	// Setup mock expectations - need multiple calls to CoreV1() and PersistentVolumes()
+	mockKubeClient.EXPECT().CoreV1().Return(mockCoreV1).AnyTimes()
+	mockCoreV1.EXPECT().PersistentVolumes().Return(mockPVInterface).AnyTimes()
+	mockPVInterface.EXPECT().Get(gomock.Any(), "test-pv", gomock.Any()).Return(testPV, nil)
+	mockPVInterface.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, pv *v1.PersistentVolume, _ metav1.UpdateOptions) (*v1.PersistentVolume, error) {
+			// Verify migration annotations were removed but others remain
+			assert.NotContains(t, pv.Annotations, AnnotationMigrationStatus)
+			assert.NotContains(t, pv.Annotations, AnnotationMigrationFrom)
+			assert.NotContains(t, pv.Annotations, AnnotationMigrationTo)
+			assert.NotContains(t, pv.Annotations, AnnotationMigrationStart)
+			assert.Contains(t, pv.Annotations, "other.annotation")
+			assert.Equal(t, "should-remain", pv.Annotations["other.annotation"])
+			return pv, nil
+		})
+
+	// Execute
+	ctx := context.Background()
+	err := monitor.removeMigrationAnnotations(ctx, "test-pv")
+
+	assert.NoError(t, err)
+}
+
+func TestMigrationMonitorControllerRestart_EndToEnd(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockKubeClient := mockkubeclient.NewMockInterface(ctrl)
+	mockCoreV1 := mockcorev1.NewMockInterface(ctrl)
+	mockPVInterface := mockpersistentvolume.NewMockInterface(ctrl)
+	mockEventRecorder := record.NewFakeRecorder(10)
+	mockDiskController := &ManagedDiskController{}
+
+	// Simulate controller restart scenario
+	t.Run("full controller restart recovery scenario", func(t *testing.T) {
+		// Phase 1: Create initial monitor and start migration
+		monitor1 := NewMigrationProgressMonitor(mockKubeClient, mockEventRecorder, mockDiskController)
+
+		testPV := &v1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-pv",
+			},
+			Spec: v1.PersistentVolumeSpec{
+				PersistentVolumeSource: v1.PersistentVolumeSource{
+					CSI: &v1.CSIPersistentVolumeSource{
+						Driver:       "disk.csi.azure.com",
+						VolumeHandle: "/subscriptions/test/resourceGroups/rg/providers/Microsoft.Compute/disks/test-disk",
+					},
+				},
+			},
+		}
+
+		// Mock expectations for starting migration (adds annotations)
+		mockKubeClient.EXPECT().CoreV1().Return(mockCoreV1).AnyTimes()
+		mockCoreV1.EXPECT().PersistentVolumes().Return(mockPVInterface).AnyTimes()
+		mockPVInterface.EXPECT().Get(gomock.Any(), "test-pv", gomock.Any()).Return(testPV, nil).AnyTimes()
+		mockPVInterface.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, pv *v1.PersistentVolume, _ metav1.UpdateOptions) (*v1.PersistentVolume, error) {
+				// Simulate annotations being added
+				if pv.Annotations == nil {
+					pv.Annotations = make(map[string]string)
+				}
+				pv.Annotations[AnnotationMigrationStatus] = "in-progress"
+				pv.Annotations[AnnotationMigrationFrom] = string(armcompute.DiskStorageAccountTypesPremiumLRS)
+				pv.Annotations[AnnotationMigrationTo] = string(armcompute.DiskStorageAccountTypesPremiumV2LRS)
+				pv.Annotations[AnnotationMigrationStart] = time.Now().Format(time.RFC3339)
+				return pv, nil
+			}).AnyTimes()
+
+		// Start migration
+		ctx := context.Background()
+		diskURI := "/subscriptions/test/resourceGroups/rg/providers/Microsoft.Compute/disks/test-disk"
+		err := monitor1.StartMigrationMonitoring(ctx, diskURI, "test-pv",
+			armcompute.DiskStorageAccountTypesPremiumLRS,
+			armcompute.DiskStorageAccountTypesPremiumV2LRS)
+		assert.NoError(t, err)
+		assert.True(t, monitor1.IsMigrationActive(diskURI))
+
+		// Phase 2: Simulate controller restart by creating new monitor and driver
+		monitor1.Stop() // Old monitor stops
+
+		// Create new monitor (simulating restart)
+		monitor2 := NewMigrationProgressMonitor(mockKubeClient, mockEventRecorder, mockDiskController)
+
+		driver := &Driver{}
+		driver.Name = "disk.csi.azure.com"
+		driver.cloud = &azure.Cloud{
+			KubeClient: mockKubeClient,
+		}
+		driver.migrationMonitor = monitor2
+
+		// Update testPV to have the migration annotations (simulating persistence)
+		testPVWithAnnotations := testPV.DeepCopy()
+		testPVWithAnnotations.Annotations = map[string]string{
+			AnnotationMigrationStatus: "in-progress",
+			AnnotationMigrationFrom:   string(armcompute.DiskStorageAccountTypesPremiumLRS),
+			AnnotationMigrationTo:     string(armcompute.DiskStorageAccountTypesPremiumV2LRS),
+			AnnotationMigrationStart:  time.Now().Format(time.RFC3339),
+		}
+
+		// Mock expectations for recovery
+		pvList := &v1.PersistentVolumeList{
+			Items: []v1.PersistentVolume{*testPVWithAnnotations},
+		}
+		mockPVInterface.EXPECT().List(gomock.Any(), gomock.Any()).Return(pvList, nil)
+
+		// Phase 3: Recover migrations
+		err = driver.recoverMigrationMonitorsFromAnnotations(ctx)
+		assert.NoError(t, err)
+
+		// Verify migration was recovered
+		assert.True(t, monitor2.IsMigrationActive(diskURI))
+		activeTasks := monitor2.GetActiveMigrations()
+		assert.Equal(t, 1, len(activeTasks))
+
+		task, exists := activeTasks[diskURI]
+		assert.True(t, exists)
+		assert.Equal(t, "test-pv", task.PVName)
+		assert.Equal(t, armcompute.DiskStorageAccountTypesPremiumLRS, task.FromSKU)
+		assert.Equal(t, armcompute.DiskStorageAccountTypesPremiumV2LRS, task.ToSKU)
+
+		// Cleanup
+		monitor2.Stop()
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
In Azure when user modifies the PersistentVolume sku from Premium_LRS to PremiumV2_LRS, it takes time to change the effect though the SKU shows PremiumV2_LRS immediately in portal. The completionPercentage in disk properties indicate same. Though this window does not stop the user from attaching the PV but may see some performance drop. So, users may want to know how long this will take and may plan the maintenance window in a planned manner that would avoid any unforeseen/unnecessary disruption. Example, in order to reduce any impact or due to any restrictions, user wanted to plan to batch the volumes (> x10s of PVs) for using PremiumV2_LRS. Without this PR, users may to use other way to monitor the completionPercentage outside AKS. With this, user can wait for the events on PersitentVolume for completion event and batch next set of volumes.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
