### PR TITLE
test: fix TestConcurrentDetachDisk ut failure on Windows

### DIFF
--- a/pkg/azuredisk/azure_controller_common_test.go
+++ b/pkg/azuredisk/azure_controller_common_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1032,6 +1033,9 @@ func TestVerifyDetach(t *testing.T) {
 }
 
 func TestConcurrentDetachDisk(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skip test case on Windows")
+	}
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
test: fix TestConcurrentDetachDisk ut failure on Windows

```
2025-07-25T08:04:41.1772565Z === RUN   TestConcurrentDetachDisk
2025-07-25T08:04:41.1774656Z I0725 08:03:46.399330    1828 azure_controller_common_test.go:1092] Calling DetachDisk for non-batched disk detach[{0xc0007c28f0 <nil> <nil> <nil> <nil> 0xc0002421c0 map[] [] <nil> 0xc0002748f0 <nil> 0xc0002748e0 [] <nil>}]
2025-07-25T08:04:41.1778973Z W0725 08:03:46.399330    1828 azure_controller_standard.go:172] detach azure disk on node(vm1): disk list(map[/subscriptions/subscription/resourcegroups/rg/providers/microsoft.compute/disks/disk-batched-0:disk-batched-0 /subscriptions/subscription/resourcegroups/rg/providers/microsoft.compute/disks/disk-batched-1:disk-batched-1 /subscriptions/subscription/resourcegroups/rg/providers/microsoft.compute/disks/disk-not-batched:disk-not-batched]) not found
2025-07-25T08:04:41.1783937Z I0725 08:03:46.399330    1828 azure_controller_common_test.go:1065] First call to CreateOrUpdate succeededVM Name:vm1Params:{0xc0007c28f0 <nil> <nil> <nil> <nil> 0xc0001180e0 map[] [] <nil> <nil> <nil> <nil> [] <nil>}
2025-07-25T08:04:41.1786447Z I0725 08:03:46.651156    1828 azure_controller_common_test.go:1103] No error received from detach disk requests
2025-07-25T08:04:41.1787406Z     azure_controller_common_test.go:1106: 
2025-07-25T08:04:41.1788867Z         	Error Trace:	D:/a/azuredisk-csi-driver/azuredisk-csi-driver/pkg/azuredisk/azure_controller_common_test.go:1106
2025-07-25T08:04:41.1790073Z         	Error:      	An error is expected but got nil.
2025-07-25T08:04:41.1790758Z         	Test:       	TestConcurrentDetachDisk
2025-07-25T08:04:41.1792489Z         	Messages:   	DetachDisk should return an error for the non-batched disk detach
2025-07-25T08:04:41.1793119Z --- FAIL: TestConcurrentDetachDisk (1.48s)
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
