### PR TITLE
fix: allow `.` in Azure tags

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -99,8 +99,8 @@ func ConvertTagsToMap(tags string, tagsDelimiter string) (map[string]string, err
 		if key == "" {
 			return nil, fmt.Errorf("tags '%s' are invalid, the format should like: 'key1=value1%skey2=value2'", tags, tagsDelimiter)
 		}
-		// <>%&?/. are not allowed in tag key
-		if strings.ContainsAny(key, "<>%&?/.") {
+		// <>%&?\/ are not allowed in Azure tag keys: https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources#limitations
+		if strings.ContainsAny(key, "<>%&?\\/") {
 			return nil, fmt.Errorf("tag key '%s' contains invalid characters", key)
 		}
 		value := strings.TrimSpace(kv[1])

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -124,6 +124,16 @@ func TestConvertTagsToMap(t *testing.T) {
 			expectedError:  true,
 		},
 		{
+			desc:          "should return success for keys containing '.'",
+			tags:          "key.1=value1,key2=value2",
+			tagsDelimiter: ",",
+			expectedOutput: map[string]string{
+				"key.1": "value1",
+				"key2":  "value2",
+			},
+			expectedError: false,
+		},
+		{
 			desc:           "should return success for special characters in value",
 			tags:           "key1=value1,key2=<>%&?/.",
 			tagsDelimiter:  ",",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Currently, configuring a storage class to add tags containing a `.` will fail due to validation in the CSI driver. However, the current validation logic does not match [Azure's requirements for tags](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources#limitations), which state:

> Tag names can't contain these characters: <, >, %, &, \, ?, /

**Which issue(s) this PR fixes**:
Fixes #3276 

**Requirements**:
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
Docs and testing upgrades didn't seem to be needed here, but do note that after upgrading, storage classes that add keys containing `\` will now fail validation. Since creating the tag in Azure would also fail, those storage classes already had broken prior to the upgrade.

**Release note**:
```
Fixed tag validation to match [Azure's tagging requirements].
```
