### PR TITLE
fix: detach call should not use the full context deadline and should leave an active context for force detach on timeout

### DIFF
--- a/pkg/azuredisk/azure_controller_common.go
+++ b/pkg/azuredisk/azure_controller_common.go
@@ -61,6 +61,9 @@ const (
 	// default initial delay in milliseconds for batch disk attach/detach
 	defaultAttachDetachInitialDelayInMs = 1000
 
+	// default detach operation timeout
+	defaultDetachOperationMinTimeoutInSeconds = 240
+
 	// WriteAcceleratorEnabled support for Azure Write Accelerator on Azure Disks
 	// https://docs.microsoft.com/azure/virtual-machines/windows/how-to-enable-write-accelerator
 	WriteAcceleratorEnabled = "writeacceleratorenabled"
@@ -90,6 +93,8 @@ type controllerCommon struct {
 	detachDiskMap sync.Map
 	// DisableDiskLunCheck whether disable disk lun check after disk attach/detach
 	DisableDiskLunCheck bool
+	// DetachOperationMinTimeoutInSeconds determines timeout for waiting on detach operation before a force detach
+	DetachOperationMinTimeoutInSeconds int
 	// AttachDetachInitialDelayInMs determines initial delay in milliseconds for batch disk attach/detach
 	AttachDetachInitialDelayInMs int
 	ForceDetachBackoff           bool
@@ -394,6 +399,8 @@ func (c *controllerCommon) DetachDisk(ctx context.Context, diskName, diskURI str
 
 	if len(diskMap) == 0 {
 		// disk was already processed in the batch, return the result
+		// returns success when the disk has toBeDetached flag set to true
+		// we could consider issuing a force detach if the disk is stuck in ToBeDetached state for too long
 		return c.verifyDetach(ctx, diskName, diskURI, nodeName)
 	}
 
@@ -401,7 +408,20 @@ func (c *controllerCommon) DetachDisk(ctx context.Context, diskName, diskURI str
 	c.diskStateMap.Store(formattedDiskURI, "detaching")
 	defer c.diskStateMap.Delete(formattedDiskURI)
 
-	if err = vmset.DetachDisk(ctx, nodeName, diskMap, false); err != nil {
+	// Calculate timeout for regular detach operation, if operation fails or times out,
+	// we need to have an active context to issue a force detach
+	detachContextTimeout := time.Duration(c.DetachOperationMinTimeoutInSeconds) * time.Second
+	if deadline, ok := ctx.Deadline(); ok {
+		remaining := time.Until(deadline)
+		halfRemaining := remaining / 2
+		if halfRemaining > detachContextTimeout {
+			detachContextTimeout = halfRemaining
+		}
+	}
+	detachCtx, cancel := context.WithTimeout(ctx, detachContextTimeout)
+	defer cancel()
+
+	if err = vmset.DetachDisk(detachCtx, nodeName, diskMap, false); err != nil {
 		if isInstanceNotFoundError(err) {
 			// if host doesn't exist, no need to detach
 			klog.Warningf("azureDisk - got InstanceNotFoundError(%v), DetachDisk(%s) will assume disk is already detached",

--- a/pkg/azuredisk/azure_managedDiskController.go
+++ b/pkg/azuredisk/azure_managedDiskController.go
@@ -49,10 +49,11 @@ type ManagedDiskController struct {
 
 func NewManagedDiskController(provider *provider.Cloud) *ManagedDiskController {
 	common := &controllerCommon{
-		cloud:                        provider,
-		lockMap:                      newLockMap(),
-		AttachDetachInitialDelayInMs: defaultAttachDetachInitialDelayInMs,
-		clientFactory:                provider.ComputeClientFactory,
+		cloud:                              provider,
+		lockMap:                            newLockMap(),
+		AttachDetachInitialDelayInMs:       defaultAttachDetachInitialDelayInMs,
+		DetachOperationMinTimeoutInSeconds: defaultDetachOperationMinTimeoutInSeconds,
+		clientFactory:                      provider.ComputeClientFactory,
 	}
 	getter := func(_ context.Context, _ string) (interface{}, error) { return nil, nil }
 	common.hitMaxDataDiskCountCache, _ = azcache.NewTimedCache(5*time.Minute, getter, false)

--- a/pkg/azuredisk/azure_managedDiskController_test.go
+++ b/pkg/azuredisk/azure_managedDiskController_test.go
@@ -265,10 +265,11 @@ func TestCreateManagedDisk(t *testing.T) {
 		testCloud := provider.GetTestCloud(ctrl)
 
 		common := &controllerCommon{
-			cloud:                        testCloud,
-			lockMap:                      newLockMap(),
-			AttachDetachInitialDelayInMs: defaultAttachDetachInitialDelayInMs,
-			clientFactory:                testCloud.ComputeClientFactory,
+			cloud:                              testCloud,
+			lockMap:                            newLockMap(),
+			AttachDetachInitialDelayInMs:       defaultAttachDetachInitialDelayInMs,
+			DetachOperationMinTimeoutInSeconds: defaultDetachOperationMinTimeoutInSeconds,
+			clientFactory:                      testCloud.ComputeClientFactory,
 		}
 
 		managedDiskController := &ManagedDiskController{common}
@@ -330,10 +331,11 @@ func TestCreateManagedDiskWithExtendedLocation(t *testing.T) {
 	}
 
 	common := &controllerCommon{
-		cloud:                        testCloud,
-		lockMap:                      newLockMap(),
-		AttachDetachInitialDelayInMs: defaultAttachDetachInitialDelayInMs,
-		clientFactory:                testCloud.ComputeClientFactory,
+		cloud:                              testCloud,
+		lockMap:                            newLockMap(),
+		AttachDetachInitialDelayInMs:       defaultAttachDetachInitialDelayInMs,
+		DetachOperationMinTimeoutInSeconds: defaultDetachOperationMinTimeoutInSeconds,
+		clientFactory:                      testCloud.ComputeClientFactory,
 	}
 
 	managedDiskController := &ManagedDiskController{common}
@@ -397,10 +399,11 @@ func TestDeleteManagedDisk(t *testing.T) {
 		testCloud := provider.GetTestCloud(ctrl)
 
 		common := &controllerCommon{
-			cloud:                        testCloud,
-			lockMap:                      newLockMap(),
-			AttachDetachInitialDelayInMs: defaultAttachDetachInitialDelayInMs,
-			clientFactory:                testCloud.ComputeClientFactory,
+			cloud:                              testCloud,
+			lockMap:                            newLockMap(),
+			AttachDetachInitialDelayInMs:       defaultAttachDetachInitialDelayInMs,
+			DetachOperationMinTimeoutInSeconds: defaultDetachOperationMinTimeoutInSeconds,
+			clientFactory:                      testCloud.ComputeClientFactory,
 		}
 
 		managedDiskController := &ManagedDiskController{common}

--- a/pkg/azuredisk/azuredisk.go
+++ b/pkg/azuredisk/azuredisk.go
@@ -91,51 +91,52 @@ type Driver struct {
 	csi.UnimplementedIdentityServer
 	csi.UnimplementedNodeServer
 
-	perfOptimizationEnabled      bool
-	cloudConfigSecretName        string
-	cloudConfigSecretNamespace   string
-	customUserAgent              string
-	userAgentSuffix              string
-	cloud                        *azure.Cloud
-	clientFactory                azclient.ClientFactory
-	diskController               *ManagedDiskController
-	eventRecorder                record.EventRecorder
-	migrationMonitor             *MigrationProgressMonitor
-	mounter                      *mount.SafeFormatAndMount
-	deviceHelper                 optimization.Interface
-	nodeInfo                     *optimization.NodeInfo
-	ioHandler                    azureutils.IOHandler
-	hostUtil                     hostUtil
-	useCSIProxyGAInterface       bool
-	enableDiskOnlineResize       bool
-	allowEmptyCloudConfig        bool
-	enableListVolumes            bool
-	enableListSnapshots          bool
-	supportZone                  bool
-	getNodeInfoFromLabels        bool
-	enableDiskCapacityCheck      bool
-	enableTrafficManager         bool
-	trafficManagerPort           int64
-	vmssCacheTTLInSeconds        int64
-	listVMSSWithInstanceView     bool
-	volStatsCacheExpireInMinutes int64
-	attachDetachInitialDelayInMs int64
-	getDiskTimeoutInSeconds      int64
-	vmType                       string
-	enableWindowsHostProcess     bool
-	useWinCIMAPI                 bool
-	getNodeIDFromIMDS            bool
-	enableOtelTracing            bool
-	shouldWaitForSnapshotReady   bool
-	checkDiskLUNCollision        bool
-	checkDiskCountForBatching    bool
-	forceDetachBackoff           bool
-	waitForDetach                bool
-	endpoint                     string
-	disableAVSetNodes            bool
-	removeNotReadyTaint          bool
-	neverStopTaintRemoval        bool
-	kubeClient                   clientset.Interface
+	perfOptimizationEnabled            bool
+	cloudConfigSecretName              string
+	cloudConfigSecretNamespace         string
+	customUserAgent                    string
+	userAgentSuffix                    string
+	cloud                              *azure.Cloud
+	clientFactory                      azclient.ClientFactory
+	diskController                     *ManagedDiskController
+	eventRecorder                      record.EventRecorder
+	migrationMonitor                   *MigrationProgressMonitor
+	mounter                            *mount.SafeFormatAndMount
+	deviceHelper                       optimization.Interface
+	nodeInfo                           *optimization.NodeInfo
+	ioHandler                          azureutils.IOHandler
+	hostUtil                           hostUtil
+	useCSIProxyGAInterface             bool
+	enableDiskOnlineResize             bool
+	allowEmptyCloudConfig              bool
+	enableListVolumes                  bool
+	enableListSnapshots                bool
+	supportZone                        bool
+	getNodeInfoFromLabels              bool
+	enableDiskCapacityCheck            bool
+	enableTrafficManager               bool
+	trafficManagerPort                 int64
+	vmssCacheTTLInSeconds              int64
+	listVMSSWithInstanceView           bool
+	volStatsCacheExpireInMinutes       int64
+	attachDetachInitialDelayInMs       int64
+	DetachOperationMinTimeoutInSeconds int64
+	getDiskTimeoutInSeconds            int64
+	vmType                             string
+	enableWindowsHostProcess           bool
+	useWinCIMAPI                       bool
+	getNodeIDFromIMDS                  bool
+	enableOtelTracing                  bool
+	shouldWaitForSnapshotReady         bool
+	checkDiskLUNCollision              bool
+	checkDiskCountForBatching          bool
+	forceDetachBackoff                 bool
+	waitForDetach                      bool
+	endpoint                           string
+	disableAVSetNodes                  bool
+	removeNotReadyTaint                bool
+	neverStopTaintRemoval              bool
+	kubeClient                         clientset.Interface
 	// a timed cache storing volume stats <volumeID, volumeStats>
 	volStatsCache           azcache.Resource
 	maxConcurrentFormat     int64
@@ -172,6 +173,7 @@ func NewDriver(options *DriverOptions) *Driver {
 	driver.getNodeInfoFromLabels = options.GetNodeInfoFromLabels
 	driver.enableDiskCapacityCheck = options.EnableDiskCapacityCheck
 	driver.attachDetachInitialDelayInMs = options.AttachDetachInitialDelayInMs
+	driver.DetachOperationMinTimeoutInSeconds = options.DetachOperationMinTimeoutInSeconds
 	driver.enableTrafficManager = options.EnableTrafficManager
 	driver.trafficManagerPort = options.TrafficManagerPort
 	driver.vmssCacheTTLInSeconds = options.VMSSCacheTTLInSeconds
@@ -278,6 +280,12 @@ func NewDriver(options *DriverOptions) *Driver {
 		driver.diskController.ForceDetachBackoff = driver.forceDetachBackoff
 		driver.diskController.WaitForDetach = driver.waitForDetach
 		driver.diskController.CheckDiskCountForBatching = driver.checkDiskCountForBatching
+		driver.diskController.DetachOperationMinTimeoutInSeconds = int(driver.DetachOperationMinTimeoutInSeconds)
+		klog.V(2).Infof("set DetachOperationMinTimeoutInSeconds as %d", driver.diskController.DetachOperationMinTimeoutInSeconds)
+		if driver.diskController.DetachOperationMinTimeoutInSeconds <= 0 {
+			klog.V(2).Infof("reset DetachOperationMinTimeoutInSeconds as %d", defaultDetachOperationMinTimeoutInSeconds)
+			driver.diskController.DetachOperationMinTimeoutInSeconds = defaultDetachOperationMinTimeoutInSeconds
+		}
 
 		if kubeClient != nil && driver.NodeID == "" && driver.enableMigrationMonitor {
 			eventBroadcaster := record.NewBroadcaster()

--- a/pkg/azuredisk/azuredisk_option.go
+++ b/pkg/azuredisk/azuredisk_option.go
@@ -39,39 +39,40 @@ type DriverOptions struct {
 	EnableMinimumRetryAfter    bool
 
 	//only used in v1
-	EnableDiskOnlineResize            bool
-	AllowEmptyCloudConfig             bool
-	EnableListVolumes                 bool
-	EnableListSnapshots               bool
-	SupportZone                       bool
-	GetNodeInfoFromLabels             bool
-	EnableDiskCapacityCheck           bool
-	EnableTrafficManager              bool
-	TrafficManagerPort                int64
-	AttachDetachInitialDelayInMs      int64
-	VMSSCacheTTLInSeconds             int64
-	ListVMSSWithInstanceView          bool
-	VolStatsCacheExpireInMinutes      int64
-	GetDiskTimeoutInSeconds           int64
-	VMType                            string
-	EnableWindowsHostProcess          bool
-	UseWinCIMAPI                      bool
-	GetNodeIDFromIMDS                 bool
-	WaitForSnapshotReady              bool
-	CheckDiskLUNCollision             bool
-	ForceDetachBackoff                bool
-	CheckDiskCountForBatching         bool
-	WaitForDetach                     bool
-	Kubeconfig                        string
-	Endpoint                          string
-	DisableAVSetNodes                 bool
-	RemoveNotReadyTaint               bool
-	NeverStopTaintRemoval             bool
-	TaintRemovalInitialDelayInSeconds int64
-	MaxConcurrentFormat               int64
-	ConcurrentFormatTimeout           int64
-	GoMaxProcs                        int64
-	EnableMigrationMonitor            bool
+	EnableDiskOnlineResize             bool
+	AllowEmptyCloudConfig              bool
+	EnableListVolumes                  bool
+	EnableListSnapshots                bool
+	SupportZone                        bool
+	GetNodeInfoFromLabels              bool
+	EnableDiskCapacityCheck            bool
+	EnableTrafficManager               bool
+	TrafficManagerPort                 int64
+	AttachDetachInitialDelayInMs       int64
+	DetachOperationMinTimeoutInSeconds int64
+	VMSSCacheTTLInSeconds              int64
+	ListVMSSWithInstanceView           bool
+	VolStatsCacheExpireInMinutes       int64
+	GetDiskTimeoutInSeconds            int64
+	VMType                             string
+	EnableWindowsHostProcess           bool
+	UseWinCIMAPI                       bool
+	GetNodeIDFromIMDS                  bool
+	WaitForSnapshotReady               bool
+	CheckDiskLUNCollision              bool
+	ForceDetachBackoff                 bool
+	CheckDiskCountForBatching          bool
+	WaitForDetach                      bool
+	Kubeconfig                         string
+	Endpoint                           string
+	DisableAVSetNodes                  bool
+	RemoveNotReadyTaint                bool
+	NeverStopTaintRemoval              bool
+	TaintRemovalInitialDelayInSeconds  int64
+	MaxConcurrentFormat                int64
+	ConcurrentFormatTimeout            int64
+	GoMaxProcs                         int64
+	EnableMigrationMonitor             bool
 }
 
 func (o *DriverOptions) AddFlags() *flag.FlagSet {
@@ -102,6 +103,7 @@ func (o *DriverOptions) AddFlags() *flag.FlagSet {
 	fs.BoolVar(&o.EnableTrafficManager, "enable-traffic-manager", false, "boolean flag to enable traffic manager")
 	fs.Int64Var(&o.TrafficManagerPort, "traffic-manager-port", 7788, "default traffic manager port")
 	fs.Int64Var(&o.AttachDetachInitialDelayInMs, "attach-detach-initial-delay-ms", 1000, "initial delay in milliseconds for batch disk attach/detach")
+	fs.Int64Var(&o.DetachOperationMinTimeoutInSeconds, "detach-operation-min-timeout-seconds", 240, "minimum detach operation timeout in seconds")
 	fs.Int64Var(&o.VMSSCacheTTLInSeconds, "vmss-cache-ttl-seconds", -1, "vmss cache TTL in seconds (600 by default)")
 	fs.BoolVar(&o.ListVMSSWithInstanceView, "list-vmss-with-instance-view", false, "boolean flag to enable vmss cache with instance view")
 	fs.Int64Var(&o.VolStatsCacheExpireInMinutes, "vol-stats-cache-expire-in-minutes", 10, "The cache expire time in minutes for volume stats cache")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
When Detach call times out, it currently uses the full context deadline to wait for a timeout from the platform. This blocks CSI from being able to issue a Force Detach call on timeouts. Detach call should not use the full context deadline for the operation and should leave an active context for force detach. 

This PR allows to define a min context timeout a Detach call should use, if the context has a longer timeout, then the operation would use half of the context's deadline and leave the half for Force Detach, otherwise it will use it's min timeout. 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
