### PR TITLE
fix: create volume failure when requested pvc size is smaller than snapshot disk size

### DIFF
--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -49,10 +49,11 @@ import (
 )
 
 const (
-	waitForSnapshotReadyInterval = 5 * time.Second
-	waitForSnapshotReadyTimeout  = 10 * time.Minute
-	maxErrMsgLength              = 990
-	checkDiskLunThrottleLatency  = 1 * time.Second
+	waitForSnapshotReadyInterval     = 5 * time.Second
+	waitForSnapshotReadyTimeout      = 10 * time.Minute
+	maxErrMsgLength                  = 990
+	checkDiskLunThrottleLatency      = 1 * time.Second
+	maxSnapshotSizeDifferenceAllowed = 50 // in GiB
 )
 
 // listVolumeStatus explains the return status of `listVolumesByResourceGroup`
@@ -196,6 +197,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 
 	capacityBytes := req.GetCapacityRange().GetRequiredBytes()
 	volSizeBytes := int64(capacityBytes)
+	requestSizeToBeSupplied := true
 	requestGiB := int(volumehelper.RoundUpGiB(volSizeBytes))
 
 	if diskParams.PerformancePlus != nil && *diskParams.PerformancePlus && requestGiB < consts.PerformancePlusMinimumDiskSizeGiB {
@@ -314,11 +316,31 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 					},
 				},
 			}
-			// if migration monitoring is enabled and if target SKU is PremiumV2LRS, get the snapshot SKU
-			// the snapshot SKU is marked as source SKU
-			if skuName == armcompute.DiskStorageAccountTypesPremiumV2LRS && d.migrationMonitor != nil {
-				sourceSKU, _ = d.getSnapshotSKU(ctx, sourceID)
+
+			// Get snapshot once and extract both SKU and disk size info
+			snapshot, err := d.getSnapshot(ctx, sourceID)
+			if err == nil {
+				// fetch snapshot info and compare size with requested size
+				// when snapshot size is larger than requested size, do not supply the size in the request
+				// to allow Azure to create a disk with exact snapshot size in bytes.
+				diskSizeInBytes, err := getDiskSizeInBytesFromSnapshot(snapshot)
+				if err == nil {
+					requestedGiBfromSnapshot := int(volumehelper.RoundUpGiB(diskSizeInBytes))
+					differenceSize := requestedGiBfromSnapshot - requestGiB
+					if requestedGiBfromSnapshot > requestGiB && differenceSize <= maxSnapshotSizeDifferenceAllowed {
+						klog.V(4).Infof("snapshot size (%d GiB) is larger than requested size (%d GiB) but difference (%d GiB) is within the allowed limit (%d GiB), will not supply the size in the create disk request", requestedGiBfromSnapshot, requestGiB, differenceSize, maxSnapshotSizeDifferenceAllowed)
+						requestSizeToBeSupplied = false
+					}
+				}
+
+				// Get SKU if migration monitoring is enabled and target SKU is PremiumV2LRS
+				if skuName == armcompute.DiskStorageAccountTypesPremiumV2LRS && d.migrationMonitor != nil {
+					sourceSKU, _ = getSnapshotSKUFromSnapshot(snapshot)
+				}
+			} else {
+				return nil, status.Errorf(codes.NotFound, "%v", err)
 			}
+
 			metricsRequest = "controller_create_volume_from_snapshot"
 		} else {
 			sourceID = content.GetVolume().GetVolumeId()
@@ -392,6 +414,11 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	}
 
 	diskParams.VolumeContext[consts.RequestedSizeGib] = strconv.Itoa(requestGiB)
+
+	if !requestSizeToBeSupplied && sourceType == consts.SourceSnapshot {
+		requestGiB = 0
+	}
+
 	volumeOptions := &ManagedDiskOptions{
 		AvailabilityZone:    diskZone,
 		BurstingEnabled:     diskParams.EnableBursting,
@@ -1441,26 +1468,48 @@ func (d *Driver) GetSourceDiskSize(ctx context.Context, subsID, resourceGroup, d
 	return (*result.Properties).DiskSizeGB, result, nil
 }
 
-// getSnapshotSKU retrieves the SKU of the snapshot and returns the SKU or if any error occurs
-func (d *Driver) getSnapshotSKU(ctx context.Context, sourceID string) (string, error) {
+// getSnapshot retrieves the Snapshot and returns the Snapshot or the error if any error occurs
+func (d *Driver) getSnapshot(ctx context.Context, sourceID string) (*armcompute.Snapshot, error) {
 	subsID, resourceGroup, snapshotName, err := azureutils.GetInfoFromURI(sourceID)
 	if err != nil {
 		klog.Warningf("could not get subscription id, resource group from snapshot uri (%s) with error(%v)", sourceID, err)
-		return "", err
+		return nil, err
 	}
 	snapClient, err := d.clientFactory.GetSnapshotClientForSub(subsID)
 	if err != nil {
 		klog.Warningf("could not get snapshot client for subscription(%s) with error(%v)", subsID, err)
-		return "", err
+		return nil, err
 	}
-	result, err := snapClient.Get(ctx, resourceGroup, snapshotName)
+	snapshotRetrieved, err := snapClient.Get(ctx, resourceGroup, snapshotName)
 	if err != nil {
 		klog.Warningf("get snapshot %s from rg(%s) error: %v", snapshotName, resourceGroup, err)
-		return "", err
+		return nil, err
 	}
-	if result == nil || result.SKU == nil || result.SKU.Name == nil {
-		klog.Warningf("Snapshot or Snapshot property not found for snapshot (%s) in resource group (%s)", snapshotName, resourceGroup)
-		return "", status.Error(codes.NotFound, fmt.Sprintf("Snapshot or Snapshot property not found for snapshot (%s) in resource group (%s)", snapshotName, resourceGroup))
+	return snapshotRetrieved, nil
+}
+
+// getSnapshotSKU retrieves the SKU of the snapshot and returns the SKU or if any error occurs
+func getSnapshotSKUFromSnapshot(computeSnapshot *armcompute.Snapshot) (string, error) {
+	if computeSnapshot == nil {
+		klog.Warningf("Snapshot is nil")
+		return "", status.Error(codes.NotFound, "Snapshot is nil")
 	}
-	return string(*result.SKU.Name), nil
+	if computeSnapshot.SKU == nil || computeSnapshot.SKU.Name == nil {
+		klog.Warningf("Snapshot or Snapshot Properties SKU not found for snapshot")
+		return "", status.Error(codes.NotFound, "Snapshot SKU property not found")
+	}
+	return string(*computeSnapshot.SKU.Name), nil
+}
+
+// getDiskSizeInBytes retrieves the size of the disk and returns the size or if any error occurs
+func getDiskSizeInBytesFromSnapshot(computeSnapshot *armcompute.Snapshot) (int64, error) {
+	if computeSnapshot == nil {
+		klog.Warningf("Snapshot is nil")
+		return 0, status.Error(codes.NotFound, "Snapshot is nil")
+	}
+	if computeSnapshot.Properties == nil || computeSnapshot.Properties.DiskSizeBytes == nil {
+		klog.Warningf("Snapshot or Snapshot Properties.DiskSizeBytes not found for snapshot")
+		return 0, status.Error(codes.NotFound, "Snapshot size not found")
+	}
+	return *computeSnapshot.Properties.DiskSizeBytes, nil
 }

--- a/pkg/azuredisk/fake_azuredisk.go
+++ b/pkg/azuredisk/fake_azuredisk.go
@@ -96,7 +96,7 @@ type FakeDriver interface {
 	checkDiskExists(ctx context.Context, diskURI string) (*armcompute.Disk, error)
 	waitForSnapshotReady(context.Context, string, string, string, time.Duration, time.Duration) error
 	getSnapshotByID(context.Context, string, string, string, string) (*csi.Snapshot, error)
-	getSnapshotSKU(context.Context, string) (string, error)
+	getSnapshot(context.Context, string) (*armcompute.Snapshot, error)
 	ensureMountPoint(string) (bool, error)
 	ensureBlockTargetFile(string) error
 	getDevicePathWithLUN(lunStr string) (string, error)


### PR DESCRIPTION
In cases where the requested size is lesser than snapshot size, we want the Disk RP to handle the size automatically from snapshot.
This is the process we use in our backend which has worked seamlessly for years. We want to integrate the same behavior here.

/kind bug

**What this PR does / why we need it**:
Currently if the snapshot size is more than the requested size in PVC it causes failure to provision the Disk, this change will help to check if snapshot size is larger than requested size in PVC, provision disk based on that size.

Example:
```
PVC.YAML:
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: pv2-pvc-restored
spec:
  accessModes:
    - ReadWriteOnce
  storageClassName: managed-csi-premium-v2
  resources:
    requests:
      storage: 1024Gi
  dataSource:
    name: pv2-restore-vs
    kind: VolumeSnapshot
    apiGroup: snapshot.storage.k8s.io
```

Here the Volume Snapshot referred if has size of 1024.25Gi we would need a disk of exactly 1024.25Gi, instead current flow fails to do so as it tries to provision it for 1024Gi.

Adding refernece to the 256MiB Increment Behaviour.

<img width="818" height="342" alt="image" src="https://github.com/user-attachments/assets/a33c9476-339f-4fe0-8a3f-0324de222458" />

https://learn.microsoft.com/en-us/azure/virtual-machines/windows/disks-upload-vhd-to-managed-disk-powershell#create-an-empty-managed-disk


- [ ] includes documentation
- [X] adds unit tests
- [X] tested upgrade from previous version


**Release note**:
```
none
```
