### PR TITLE
chore: provide flags for converting ReadWrite cachingMode for in-tree PV

### DIFF
--- a/pkg/azuredisk/azuredisk.go
+++ b/pkg/azuredisk/azuredisk.go
@@ -148,6 +148,8 @@ type Driver struct {
 	// a timed cache for disk lun collision check throttling
 	checkDiskLunThrottlingCache azcache.Resource
 	enableMigrationMonitor      bool
+	// whether to convert ReadWrite cachingMode to ReadOnly for intree PVs to avoid issues
+	convertRWCachingModeForIntreePV bool
 }
 
 // NewDriver Creates a NewCSIDriver object. Assumes vendor version is equal to driver version &
@@ -201,6 +203,7 @@ func NewDriver(options *DriverOptions) *Driver {
 	driver.ioHandler = azureutils.NewOSIOHandler()
 	driver.hostUtil = hostutil.NewHostUtil()
 	driver.enableMigrationMonitor = options.EnableMigrationMonitor
+	driver.convertRWCachingModeForIntreePV = options.ConvertRWCachingModeForIntreePV
 
 	if driver.NodeID == "" {
 		// nodeid is not needed in controller component

--- a/pkg/azuredisk/azuredisk_option.go
+++ b/pkg/azuredisk/azuredisk_option.go
@@ -73,6 +73,7 @@ type DriverOptions struct {
 	ConcurrentFormatTimeout            int64
 	GoMaxProcs                         int64
 	EnableMigrationMonitor             bool
+	ConvertRWCachingModeForIntreePV    bool
 }
 
 func (o *DriverOptions) AddFlags() *flag.FlagSet {
@@ -127,5 +128,6 @@ func (o *DriverOptions) AddFlags() *flag.FlagSet {
 	fs.Int64Var(&o.ConcurrentFormatTimeout, "concurrent-format-timeout", 300, "maximum time in seconds duration of a format operation before its concurrency token is released")
 	fs.Int64Var(&o.GoMaxProcs, "max-procs", 2, "maximum number of CPUs that can be executing simultaneously in golang runtime")
 	fs.BoolVar(&o.EnableMigrationMonitor, "enable-migration-monitor", true, "enable migration monitor for Azure Disk CSI Driver")
+	fs.BoolVar(&o.ConvertRWCachingModeForIntreePV, "convert-rw-caching-mode-for-intree-pv", false, "convert ReadWrite cachingMode to ReadOnly for intree PVs to avoid issues")
 	return fs
 }

--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -695,6 +695,13 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 			return nil, status.Errorf(codes.Internal, "%v", err)
 		}
 
+		if d.convertRWCachingModeForIntreePV && cachingMode == armcompute.CachingTypesReadWrite {
+			if strings.EqualFold(volumeContext[consts.KindField], string(v1.AzureManagedDisk)) {
+				klog.V(2).Infof("converting RWCachingMode to ReadOnly for intree PV volume %s", diskURI)
+				cachingMode = armcompute.CachingTypesReadOnly
+			}
+		}
+
 		occupiedLuns := d.getOccupiedLunsFromNode(ctx, nodeName, diskURI)
 		klog.V(2).Infof("Trying to attach volume %s to node %s", diskURI, nodeName)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
chore: provide flags for converting ReadWrite cachingMode for in-tree PV

the in-tree PV has ReadWrite cachingMode by default that may have cache sync issue, ideally users need to migrate to CSI PV which has ReadOnly cachingMode by default, this PR provides a flag for specific users who still want to keep in-tree PV for a period of time and do the cachingMode convension using `--convert-rw-caching-mode-for-intree-pv=true` in the disk driver controller setting as a workaround.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
