### PR TITLE
fix: ASH static provision segmentation fault

### DIFF
--- a/pkg/azureutils/azure_disk_utils.go
+++ b/pkg/azureutils/azure_disk_utils.go
@@ -746,7 +746,7 @@ func checkDiskName(diskName string) bool {
 	return true
 }
 
-// InsertProperties: insert disk properties to map
+// InsertDiskProperties inserts disk properties to map
 func InsertDiskProperties(disk *armcompute.Disk, publishConext map[string]string) {
 	if disk == nil || publishConext == nil {
 		return
@@ -757,7 +757,10 @@ func InsertDiskProperties(disk *armcompute.Disk, publishConext map[string]string
 	}
 	prop := disk.Properties
 	if prop != nil {
-		publishConext[consts.NetworkAccessPolicyField] = string(*prop.NetworkAccessPolicy)
+		// Azure stack hub does not have NetworkAccessPolicy property, so the prop.NetworkAccessPolicy will always be nil
+		if prop.NetworkAccessPolicy != nil {
+			publishConext[consts.NetworkAccessPolicyField] = string(*prop.NetworkAccessPolicy)
+		}
 		if prop.DiskIOPSReadWrite != nil {
 			publishConext[consts.DiskIOPSReadWriteField] = strconv.Itoa(int(*prop.DiskIOPSReadWrite))
 		}

--- a/pkg/azureutils/azure_disk_utils_test.go
+++ b/pkg/azureutils/azure_disk_utils_test.go
@@ -1637,6 +1637,28 @@ func TestInsertDiskProperties(t *testing.T) {
 				consts.MaxSharesField:           "3",
 			},
 		},
+		{
+			// Azure Stack does not support NetworkAccessPolicy property
+			desc: "DiskProperties with nil NetworkAccessPolicy",
+			disk: &armcompute.Disk{
+				SKU: &armcompute.DiskSKU{Name: to.Ptr(armcompute.DiskStorageAccountTypesStandardSSDLRS)},
+				Properties: &armcompute.DiskProperties{
+					NetworkAccessPolicy: nil,
+					DiskIOPSReadWrite:   ptr.To(int64(6400)),
+					DiskMBpsReadWrite:   ptr.To(int64(100)),
+					CreationData: &armcompute.CreationData{
+						LogicalSectorSize: ptr.To(int32(512)),
+					},
+				},
+			},
+			inputMap: map[string]string{},
+			expectedMap: map[string]string{
+				consts.SkuNameField:           string(armcompute.DiskStorageAccountTypesStandardSSDLRS),
+				consts.DiskIOPSReadWriteField: "6400",
+				consts.DiskMBPSReadWriteField: "100",
+				consts.LogicalSectorSizeField: "512",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
- fix: ASH static provision segmentation fault issue, in ASH the `NetworkAccessPolicy` does not support so it will always nil while in static provision we need the `InsertDiskProperties ` which does not take it into consideration.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/azuredisk-csi-driver/issues/3448

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
