### PR TITLE
[WIP] feat: support changing cachingMode through VolumeAttributeClass

### DIFF
--- a/pkg/azuredisk/azure_managedDiskController.go
+++ b/pkg/azuredisk/azure_managedDiskController.go
@@ -111,6 +111,9 @@ type ManagedDiskOptions struct {
 	Location string
 	// PerformancePlus - Set this flag to true to get a boost on the performance target of the disk deployed
 	PerformancePlus *bool
+	// CachingMode - The caching mode of the disk when attached to a VM.
+	// This is a VM-level property stored in the PV volumeAttributes, applied on next ControllerPublishVolume.
+	CachingMode armcompute.CachingTypes
 }
 
 // CreateManagedDisk: create managed disk
@@ -443,7 +446,7 @@ func (c *ManagedDiskController) ResizeDisk(ctx context.Context, diskURI string, 
 
 // ModifyDisk: modify disk
 func (c *ManagedDiskController) ModifyDisk(ctx context.Context, options *ManagedDiskOptions) error {
-	klog.V(4).Infof("azureDisk - modifying managed disk URI:%s, StorageAccountType:%s, DiskIOPSReadWrite:%s, DiskMBpsReadWrite:%s", options.SourceResourceID, options.StorageAccountType, options.DiskIOPSReadWrite, options.DiskMBpsReadWrite)
+	klog.V(4).Infof("azureDisk - modifying managed disk URI:%s, StorageAccountType:%s, DiskIOPSReadWrite:%s, DiskMBpsReadWrite:%s, CachingMode:%s", options.SourceResourceID, options.StorageAccountType, options.DiskIOPSReadWrite, options.DiskMBpsReadWrite, options.CachingMode)
 
 	subsID, rg, diskName, err := azureutils.GetInfoFromURI(options.SourceResourceID)
 	if err != nil {
@@ -508,8 +511,12 @@ func (c *ManagedDiskController) ModifyDisk(ctx context.Context, options *Managed
 		if _, err := diskClient.Patch(ctx, rg, diskName, model); err != nil {
 			return err
 		}
-	} else {
+	} else if options.CachingMode == "" {
 		klog.V(4).Infof("azureDisk - no modification needed for disk(%s)", diskName)
+	}
+
+	if options.CachingMode != "" {
+		klog.V(2).Infof("azureDisk - cachingMode(%s) updated for disk(%s), will take effect on next attach", options.CachingMode, diskName)
 	}
 	return nil
 }

--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -549,6 +549,30 @@ func (d *Driver) ControllerModifyVolume(ctx context.Context, req *csi.Controller
 		return nil, status.Errorf(codes.InvalidArgument, "Failed parsing disk parameters: %v", err)
 	}
 
+	// Validate and apply cachingMode if specified in mutable parameters.
+	var cachingMode armcompute.CachingTypes
+	if diskParams.CachingMode != "" {
+		normalizedCachingMode, err := azureutils.NormalizeCachingMode(diskParams.CachingMode)
+		if err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+		cachingMode = armcompute.CachingTypes(normalizedCachingMode)
+
+		// Enforce caching limits: disks >= 4 TiB only support None
+		if currentDisk != nil && currentDisk.Properties != nil &&
+			currentDisk.Properties.DiskSizeGB != nil && *currentDisk.Properties.DiskSizeGB >= 4096 &&
+			cachingMode != armcompute.CachingTypesNone {
+			return nil, status.Errorf(codes.InvalidArgument, "cachingMode %s is not supported for disks >= 4 TiB, only None is allowed", cachingMode)
+		}
+
+		// PremiumV2_LRS only supports None caching
+		if currentDisk != nil && currentDisk.SKU != nil && currentDisk.SKU.Name != nil &&
+			*currentDisk.SKU.Name == armcompute.DiskStorageAccountTypesPremiumV2LRS &&
+			cachingMode != armcompute.CachingTypesNone {
+			return nil, status.Errorf(codes.InvalidArgument, "cachingMode %s is not supported for PremiumV2_LRS disks, only None is allowed", cachingMode)
+		}
+	}
+
 	// normalize values
 	skuName, err := azureutils.NormalizeStorageAccountType(diskParams.AccountType, d.cloud.Config.Cloud, d.cloud.Config.DisableAzureStackCloud)
 	if err != nil {
@@ -588,6 +612,7 @@ func (d *Driver) ControllerModifyVolume(ctx context.Context, req *csi.Controller
 		StorageAccountType: skuName,
 		SourceResourceID:   diskURI,
 		SourceType:         consts.SourceVolume,
+		CachingMode:        cachingMode,
 	}
 
 	mc := csiMetrics.NewCSIMetricContext("controller_modify_volume").WithBasicVolumeInfo(d.cloud.ResourceGroup, d.cloud.SubscriptionID, d.Name)

--- a/pkg/azuredisk/controllerserver_test.go
+++ b/pkg/azuredisk/controllerserver_test.go
@@ -1312,6 +1312,54 @@ func TestControllerModifyVolume(t *testing.T) {
 			multipleMigrationsToRecover:             true,
 			simulateMigrationCompletionAfterRestart: true,
 		},
+		{
+			desc: "success with valid cachingMode ReadOnly",
+			req: &csi.ControllerModifyVolumeRequest{
+				VolumeId: testVolumeID,
+				MutableParameters: map[string]string{
+					consts.CachingModeField: "ReadOnly",
+				},
+			},
+			oldSKU:                 to.Ptr(armcompute.DiskStorageAccountTypesPremiumLRS),
+			expectedResp:           &csi.ControllerModifyVolumeResponse{},
+			expectMigrationStarted: false,
+		},
+		{
+			desc: "success with valid cachingMode None",
+			req: &csi.ControllerModifyVolumeRequest{
+				VolumeId: testVolumeID,
+				MutableParameters: map[string]string{
+					consts.CachingModeField: "None",
+				},
+			},
+			oldSKU:                 to.Ptr(armcompute.DiskStorageAccountTypesPremiumLRS),
+			expectedResp:           &csi.ControllerModifyVolumeResponse{},
+			expectMigrationStarted: false,
+		},
+		{
+			desc: "success with valid cachingMode ReadWrite",
+			req: &csi.ControllerModifyVolumeRequest{
+				VolumeId: testVolumeID,
+				MutableParameters: map[string]string{
+					consts.CachingModeField: "ReadWrite",
+				},
+			},
+			oldSKU:                 to.Ptr(armcompute.DiskStorageAccountTypesPremiumLRS),
+			expectedResp:           &csi.ControllerModifyVolumeResponse{},
+			expectMigrationStarted: false,
+		},
+		{
+			desc: "fail with invalid cachingMode",
+			req: &csi.ControllerModifyVolumeRequest{
+				VolumeId: testVolumeID,
+				MutableParameters: map[string]string{
+					consts.CachingModeField: "WriteOnly",
+				},
+			},
+			expectedResp:           nil,
+			expectedErrCode:        codes.InvalidArgument,
+			expectMigrationStarted: false,
+		},
 	}
 
 	for _, test := range tests {

--- a/test/sanity/modify-volume-params.yaml
+++ b/test/sanity/modify-volume-params.yaml
@@ -1,0 +1,1 @@
+cachingmode: ReadOnly

--- a/test/sanity/run-test.sh
+++ b/test/sanity/run-test.sh
@@ -43,4 +43,4 @@ sleep 1
 
 echo 'Begin to run sanity test...'
 readonly CSI_SANITY_BIN='csi-sanity'
-"$CSI_SANITY_BIN" --ginkgo.v --csi.endpoint="$endpoint" --ginkgo.skip='should work|should fail when volume does not exist on the specified path|should be idempotent|pagination should detect volumes added between pages and accept tokens when the last volume from a page is deleted|should remove target path|should return appropriate capabilities'
+"$CSI_SANITY_BIN" --ginkgo.v --csi.endpoint="$endpoint" --csi.testvolumemutableparameters="test/sanity/modify-volume-params.yaml" --ginkgo.skip='should work|should fail when volume does not exist on the specified path|should be idempotent|pagination should detect volumes added between pages and accept tokens when the last volume from a page is deleted|should remove target path|should return appropriate capabilities'


### PR DESCRIPTION
## What type of PR is this?
/kind feature

## What this PR does / why we need it:
Adds support for changing `cachingMode` via `VolumeAttributeClass` by validating the parameter in `ControllerModifyVolume` and updating the disk's caching mode on the VM in-place.

### How it works

`cachingMode` is a VM-level data disk attachment property. When modified via VolumeAttributeClass:

1. `ControllerModifyVolume` validates the new cachingMode value
2. Enforces constraints: disks >= 4 TiB only support `None`; PremiumV2_LRS only supports `None`
3. If the disk is currently attached to a VM, calls `UpdateDiskCachingMode` which:
   - Finds the node the disk is attached to via `disk.ManagedBy`
   - Gets the disk's current LUN
   - Issues an `AttachDisk` call with the existing LUN and new cachingMode to update the VM
4. If the disk is not attached, the update is a no-op — the new cachingMode will be applied on next attach via PV `volumeAttributes`

### Changes

- **`azure_controller_common.go`**: Added `UpdateDiskCachingMode` method on `controllerCommon`
- **`controllerserver.go`**: Added cachingMode validation and update logic in `ControllerModifyVolume`
- **`controllerserver_test.go`**: Added 4 unit test cases (3 valid modes + 1 invalid)

### Example VolumeAttributeClass

```yaml
apiVersion: storage.k8s.io/v1beta1
kind: VolumeAttributesClass
metadata:
  name: caching-readonly
driverName: disk.csi.azure.com
parameters:
  cachingMode: ReadOnly
```

## Which issue(s) this PR fixes:
Fixes #3471

## Special notes for your reviewer:
- Supported cachingMode values: `None`, `ReadOnly`, `ReadWrite`
- For attached disks, the change is applied in-place via VM update (no pod restart required)
- For unattached disks, the new cachingMode takes effect on next attach