### PR TITLE
test: add ModifyVolume sanity test with storage account type change

### DIFF
--- a/test/sanity/modify-volume-params.yaml
+++ b/test/sanity/modify-volume-params.yaml
@@ -1,0 +1,1 @@
+skuName: Premium_LRS

--- a/test/sanity/run-test.sh
+++ b/test/sanity/run-test.sh
@@ -43,4 +43,4 @@ sleep 1
 
 echo 'Begin to run sanity test...'
 readonly CSI_SANITY_BIN='csi-sanity'
-"$CSI_SANITY_BIN" --ginkgo.v --csi.endpoint="$endpoint" --ginkgo.skip='should work|should fail when volume does not exist on the specified path|should be idempotent|pagination should detect volumes added between pages and accept tokens when the last volume from a page is deleted|should remove target path|should return appropriate capabilities'
+"$CSI_SANITY_BIN" --ginkgo.v --csi.endpoint="$endpoint" --csi.testvolumemutableparameters="test/sanity/modify-volume-params.yaml" --ginkgo.skip='should work|should fail when volume does not exist on the specified path|should be idempotent|pagination should detect volumes added between pages and accept tokens when the last volume from a page is deleted|should remove target path|should return appropriate capabilities'


### PR DESCRIPTION
## What type of PR is this?
/kind cleanup

## What this PR does / why we need it:
The existing csi-sanity `ModifyVolume` test runs with empty mutable parameters, making `ControllerModifyVolume` effectively a no-op. This PR adds a `modify-volume-params.yaml` with `skuName: Premium_LRS` and passes `--csi.testvolumemutableparameters` to `csi-sanity`, so the ModifyVolume tests exercise the real SKU change code path (`ParseDiskParameters` → `NormalizeStorageAccountType` → `ModifyDisk` → `diskClient.Patch`).

Uses `Premium_LRS` instead of `StandardSSD_LRS` since `StandardSSD_LRS` is the default SKU for CreateVolume, which would result in a no-op.

## Which issue(s) this PR fixes:
None

## Special notes for your reviewer:
Two files changed:
- `test/sanity/modify-volume-params.yaml` — new file with `skuName: Premium_LRS`
- `test/sanity/run-test.sh` — added `--csi.testvolumemutableparameters` flag