### PR TITLE
fix: correct local uninstall command in v1.33.x install docs

### DIFF
--- a/docs/install-csi-driver-v1.33.0.md
+++ b/docs/install-csi-driver-v1.33.0.md
@@ -44,5 +44,5 @@ curl -skSL https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-drive
 git clone https://github.com/kubernetes-sigs/azuredisk-csi-driver.git
 cd azuredisk-csi-driver
 git checkout v1.33.0
-./deploy/install-driver.sh v1.33.0 local
+./deploy/uninstall-driver.sh v1.33.0 local
 ```

--- a/docs/install-csi-driver-v1.33.1.md
+++ b/docs/install-csi-driver-v1.33.1.md
@@ -44,5 +44,5 @@ curl -skSL https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-drive
 git clone https://github.com/kubernetes-sigs/azuredisk-csi-driver.git
 cd azuredisk-csi-driver
 git checkout v1.33.1
-./deploy/install-driver.sh v1.33.1 local
+./deploy/uninstall-driver.sh v1.33.1 local
 ```

--- a/docs/install-csi-driver-v1.33.2.md
+++ b/docs/install-csi-driver-v1.33.2.md
@@ -44,5 +44,5 @@ curl -skSL https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-drive
 git clone https://github.com/kubernetes-sigs/azuredisk-csi-driver.git
 cd azuredisk-csi-driver
 git checkout v1.33.2
-./deploy/install-driver.sh v1.33.2 local
+./deploy/uninstall-driver.sh v1.33.2 local
 ```

--- a/docs/install-csi-driver-v1.33.3.md
+++ b/docs/install-csi-driver-v1.33.3.md
@@ -44,5 +44,5 @@ curl -skSL https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-drive
 git clone https://github.com/kubernetes-sigs/azuredisk-csi-driver.git
 cd azuredisk-csi-driver
 git checkout v1.33.3
-./deploy/install-driver.sh v1.33.3 local
+./deploy/uninstall-driver.sh v1.33.3 local
 ```

--- a/docs/install-csi-driver-v1.33.4.md
+++ b/docs/install-csi-driver-v1.33.4.md
@@ -44,5 +44,5 @@ curl -skSL https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-drive
 git clone https://github.com/kubernetes-sigs/azuredisk-csi-driver.git
 cd azuredisk-csi-driver
 git checkout v1.33.4
-./deploy/install-driver.sh v1.33.4 local
+./deploy/uninstall-driver.sh v1.33.4 local
 ```

--- a/docs/install-csi-driver-v1.33.5.md
+++ b/docs/install-csi-driver-v1.33.5.md
@@ -44,5 +44,5 @@ curl -skSL https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-drive
 git clone https://github.com/kubernetes-sigs/azuredisk-csi-driver.git
 cd azuredisk-csi-driver
 git checkout v1.33.5
-./deploy/install-driver.sh v1.33.5 local
+./deploy/uninstall-driver.sh v1.33.5 local
 ```

--- a/docs/install-csi-driver-v1.33.6.md
+++ b/docs/install-csi-driver-v1.33.6.md
@@ -44,5 +44,5 @@ curl -skSL https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-drive
 git clone https://github.com/kubernetes-sigs/azuredisk-csi-driver.git
 cd azuredisk-csi-driver
 git checkout v1.33.6
-./deploy/install-driver.sh v1.33.6 local
+./deploy/uninstall-driver.sh v1.33.6 local
 ```

--- a/docs/install-csi-driver-v1.33.7.md
+++ b/docs/install-csi-driver-v1.33.7.md
@@ -44,5 +44,5 @@ curl -skSL https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-drive
 git clone https://github.com/kubernetes-sigs/azuredisk-csi-driver.git
 cd azuredisk-csi-driver
 git checkout v1.33.7
-./deploy/install-driver.sh v1.33.7 local
+./deploy/uninstall-driver.sh v1.33.7 local
 ```

--- a/docs/install-csi-driver-v1.33.8.md
+++ b/docs/install-csi-driver-v1.33.8.md
@@ -44,5 +44,5 @@ curl -skSL https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-drive
 git clone https://github.com/kubernetes-sigs/azuredisk-csi-driver.git
 cd azuredisk-csi-driver
 git checkout v1.33.8
-./deploy/install-driver.sh v1.33.8 local
+./deploy/uninstall-driver.sh v1.33.8 local
 ```

--- a/docs/install-csi-driver-v1.33.9.md
+++ b/docs/install-csi-driver-v1.33.9.md
@@ -44,5 +44,5 @@ curl -skSL https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-drive
 git clone https://github.com/kubernetes-sigs/azuredisk-csi-driver.git
 cd azuredisk-csi-driver
 git checkout v1.33.9
-./deploy/install-driver.sh v1.33.9 local
+./deploy/uninstall-driver.sh v1.33.9 local
 ```


### PR DESCRIPTION
Fix local uninstall example in all v1.33.x install docs (v1.33.0 through v1.33.9).

The "local uninstall" section incorrectly referenced `install-driver.sh` instead of `uninstall-driver.sh`, so following the doc would re-install the driver rather than remove it.

/kind bug
/kind documentation