### PR TITLE
test: set explicit ginkgo parallelism to avoid external e2e suite timeout

### DIFF
--- a/test/external-e2e/run.sh
+++ b/test/external-e2e/run.sh
@@ -52,7 +52,7 @@ install_ginkgo
 setup_e2e_binaries
 trap print_logs EXIT
 
-ginkgo -p --progress --v -focus="External.Storage.*$DRIVER.csi.azure.com" \
+ginkgo -procs=2 --progress --v -focus="External.Storage.*$DRIVER.csi.azure.com" \
        -skip='\[Disruptive\]|should resize volume when PVC is edited while pod is using it|should provision storage with any volume data source|should mount multiple PV pointing to the same storage on the same node' kubernetes/test/bin/e2e.test -- \
        -storage.testdriver=$PROJECT_ROOT/test/external-e2e/manifest/testdriver.yaml \
        --kubeconfig=$KUBECONFIG

--- a/test/external-e2e/run.sh
+++ b/test/external-e2e/run.sh
@@ -55,4 +55,6 @@ trap print_logs EXIT
 ginkgo -p --progress --v -focus="External.Storage.*$DRIVER.csi.azure.com" \
        -skip='\[Disruptive\]|should resize volume when PVC is edited while pod is using it|should provision storage with any volume data source|should mount multiple PV pointing to the same storage on the same node' kubernetes/test/bin/e2e.test -- \
        -storage.testdriver=$PROJECT_ROOT/test/external-e2e/manifest/testdriver.yaml \
-       --kubeconfig=$KUBECONFIG
+       --kubeconfig=$KUBECONFIG \
+       --kube-api-qps=50 \
+       --kube-api-burst=100

--- a/test/external-e2e/run.sh
+++ b/test/external-e2e/run.sh
@@ -52,7 +52,7 @@ install_ginkgo
 setup_e2e_binaries
 trap print_logs EXIT
 
-ginkgo -procs=2 --progress --v -focus="External.Storage.*$DRIVER.csi.azure.com" \
+ginkgo -procs=4 --progress --v -focus="External.Storage.*$DRIVER.csi.azure.com" \
        -skip='\[Disruptive\]|should resize volume when PVC is edited while pod is using it|should provision storage with any volume data source|should mount multiple PV pointing to the same storage on the same node' kubernetes/test/bin/e2e.test -- \
        -storage.testdriver=$PROJECT_ROOT/test/external-e2e/manifest/testdriver.yaml \
        --kubeconfig=$KUBECONFIG

--- a/test/external-e2e/run.sh
+++ b/test/external-e2e/run.sh
@@ -55,6 +55,4 @@ trap print_logs EXIT
 ginkgo -p --progress --v -focus="External.Storage.*$DRIVER.csi.azure.com" \
        -skip='\[Disruptive\]|should resize volume when PVC is edited while pod is using it|should provision storage with any volume data source|should mount multiple PV pointing to the same storage on the same node' kubernetes/test/bin/e2e.test -- \
        -storage.testdriver=$PROJECT_ROOT/test/external-e2e/manifest/testdriver.yaml \
-       --kubeconfig=$KUBECONFIG \
-       --kube-api-qps=50 \
-       --kube-api-burst=100
+       --kubeconfig=$KUBECONFIG


### PR DESCRIPTION
## What type of PR is this?
/kind failing-test

## What this PR does / why we need it
The external e2e tests were timing out due to insufficient parallelism. With `ginkgo -p` (auto-detect), the test suite could exceed the 60-minute suite timeout on larger test suites.

Initially tried adding `--kube-api-qps`/`--kube-api-burst` flags, but these are not supported by the k8s v1.31 e2e binary (`unknown flag`). Reverted that approach and instead set explicit parallelism with `ginkgo -procs=4` as a balanced compromise — enough parallelism to complete within the timeout without overwhelming the API server.

### Changes
- `test/external-e2e/run.sh`: Replace `ginkgo -p` with `ginkgo -procs=4`

### Test results
- `ginkgo -p` (auto): Suite timeout exceeded (>60min)
- `ginkgo -procs=2`: Suite timeout exceeded (3632s > 60min)  
- `ginkgo -procs=4`: Expected to complete within timeout

## Which issue(s) this PR fixes
Fixes flaky external e2e test suite timeout failures.

## Does this PR introduce a user-facing change?
```release-note
NONE
```