### PR TITLE
[WIP] fix: retry with backoff when zone label is empty during NodeGetInfo

### DIFF
--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -36,6 +36,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
@@ -370,6 +371,11 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 					klog.Warningf("GetNodeInfoFromLabels on node(%s) failed: %v, will retry", d.NodeID, err)
 					err = nil // don't fail immediately — fall through to retry
 				}
+			} else if failureDomainFromLabels == "" {
+				// GetNodeInfoFromLabels succeeded but zone label is not populated yet
+				// (CCM hasn't set topology.kubernetes.io/zone). Mark as transient so
+				// the retry loop below waits for the label to appear.
+				zoneLookupFailed = true
 			}
 		} else {
 			if runtime.GOOS == "windows" && (!d.cloud.UseInstanceMetadata || d.cloud.Metadata == nil) {
@@ -407,6 +413,11 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 			retryErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
 				node, nodeErr := d.cloud.KubeClient.CoreV1().Nodes().Get(ctx, d.NodeID, metav1.GetOptions{})
 				if nodeErr != nil {
+					// Permanent errors: stop retrying and surface the error.
+					if apierrors.IsForbidden(nodeErr) || apierrors.IsNotFound(nodeErr) {
+						klog.Warningf("NodeGetInfo: permanent error getting node(%s): %v", d.NodeID, nodeErr)
+						return false, nodeErr
+					}
 					klog.V(4).Infof("NodeGetInfo: retry get node(%s) failed: %v", d.NodeID, nodeErr)
 					return false, nil
 				}
@@ -434,6 +445,8 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 			if retryErr != nil {
 				if ctx.Err() != nil {
 					klog.Warningf("NodeGetInfo: context canceled while waiting for zone label on node %s: %v", d.NodeID, ctx.Err())
+				} else if apierrors.IsForbidden(retryErr) || apierrors.IsNotFound(retryErr) {
+					return nil, status.Error(codes.Internal, fmt.Sprintf("NodeGetInfo: permanent error getting node(%s): %v", d.NodeID, retryErr))
 				} else {
 					klog.Warningf("NodeGetInfo: timed out waiting for zone label on node %s after 2m", d.NodeID)
 				}

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -500,6 +500,11 @@ func GetMaxDataDiskCount(instanceType string) (int64, bool) {
 // to avoid an unnecessary retry.
 func (d *Driver) handleZoneLookupResult(ctx context.Context, failureDomain string, lookupErr error) (bool, error) {
 	if lookupErr != nil {
+		// Permanent errors should not be retried — surface them immediately.
+		if apierrors.IsForbidden(lookupErr) || apierrors.IsNotFound(lookupErr) ||
+			apierrors.IsUnauthorized(lookupErr) {
+			return false, lookupErr
+		}
 		if d.cloud.KubeClient != nil {
 			klog.Warningf("GetNodeInfoFromLabels on node(%s) failed: %v, will retry", d.NodeID, lookupErr)
 			return true, nil // zoneLookupFailed=true, clear error for retry
@@ -542,27 +547,23 @@ func (d *Driver) waitForZoneLabel(ctx context.Context) (string, string, error) {
 
 	var zoneFD, instanceType string
 	retryErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
-		node, nodeErr := d.cloud.KubeClient.CoreV1().Nodes().Get(ctx, d.NodeID, metav1.GetOptions{})
-		if nodeErr != nil {
-			if apierrors.IsForbidden(nodeErr) || apierrors.IsNotFound(nodeErr) {
-				klog.Warningf("NodeGetInfo: permanent error getting node(%s): %v", d.NodeID, nodeErr)
-				return false, nodeErr
+		fd, it, err := GetNodeInfoFromLabels(ctx, d.NodeID, d.cloud.KubeClient)
+		if err != nil {
+			if apierrors.IsForbidden(err) || apierrors.IsNotFound(err) || apierrors.IsUnauthorized(err) {
+				klog.Warningf("NodeGetInfo: permanent error getting node(%s): %v", d.NodeID, err)
+				return false, err
 			}
-			klog.V(4).Infof("NodeGetInfo: retry get node(%s) failed: %v", d.NodeID, nodeErr)
+			klog.V(4).Infof("NodeGetInfo: retry GetNodeInfoFromLabels on node(%s) failed: %v", d.NodeID, err)
 			return false, nil
 		}
-		if len(node.Labels) == 0 {
-			klog.V(4).Infof("NodeGetInfo: node %s has no labels yet, retrying...", d.NodeID)
-			return false, nil
-		}
-		if fd := node.Labels[consts.WellKnownTopologyKey]; fd != "" {
+		if fd != "" {
 			zoneFD = fd
-			instanceType = node.Labels[consts.InstanceTypeKey]
+			instanceType = it
 			return true, nil
 		}
-		// Region label present but no zone label → non-zonal node.
-		if region := node.Labels["topology.kubernetes.io/region"]; region != "" {
-			klog.V(2).Infof("NodeGetInfo: node %s has region label (%s) but no zone label, non-zonal — stopping retry", d.NodeID, region)
+		// Zone still empty — check if region-only (non-zonal) node.
+		if d.isRegionOnlyNode(ctx) {
+			instanceType = it
 			return true, nil
 		}
 		klog.V(4).Infof("NodeGetInfo: zone label still empty on node %s, retrying...", d.NodeID)

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -387,12 +387,14 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 		// joined node before CNI is ready), retry with backoff to wait for
 		// cloud-controller-manager to populate the zone label.
 		// We only retry when:
-		// - zoneLookupFailed is true (initial cloud zone query returned an error)
-		// - cloud.Location is set (cloud config was loaded, so zone info should
-		//   eventually be available; if Location is empty, the driver truly has no
-		//   cloud config and the zone label will never appear)
+		// - zoneLookupFailed is true (initial cloud zone query returned an error,
+		//   distinguishing transient failures from legitimately non-zonal nodes)
 		// - KubeClient is available (to read node labels)
-		if zone.FailureDomain == "" && zoneLookupFailed && d.cloud.Location != "" && d.cloud.KubeClient != nil {
+		// Note: we intentionally do NOT gate on allowEmptyCloudConfig or
+		// cloud.Location — during the startup race, cloud config may fail to load
+		// (Location="") even though the node IS in a zone. The zoneLookupFailed
+		// flag already ensures we only retry when a transient error occurred.
+		if zone.FailureDomain == "" && zoneLookupFailed && d.cloud.KubeClient != nil {
 			klog.Warningf("NodeGetInfo: zone is empty for node %s after transient lookup failure, retrying with backoff to wait for node labels", d.NodeID)
 			retryErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
 				fd, it, labelErr := GetNodeInfoFromLabels(ctx, d.NodeID, d.cloud.KubeClient)

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -386,11 +386,15 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 		// (e.g., cloud config unavailable because apiserver was unreachable on a newly
 		// joined node before CNI is ready), retry with backoff to wait for
 		// cloud-controller-manager to populate the zone label.
-		// We only retry when zoneLookupFailed is true to avoid blocking for 2 minutes
-		// on non-zonal nodes that legitimately have no zone label.
-		if zone.FailureDomain == "" && zoneLookupFailed && d.cloud.KubeClient != nil {
+		// We only retry when:
+		// - zoneLookupFailed is true (initial cloud zone query returned an error)
+		// - allowEmptyCloudConfig is false (cloud config absence is NOT intentional;
+		//   when true, the driver is deployed without cloud config on purpose and
+		//   the zone label may legitimately never appear)
+		// - KubeClient is available (to read node labels)
+		if zone.FailureDomain == "" && zoneLookupFailed && !d.allowEmptyCloudConfig && d.cloud.KubeClient != nil {
 			klog.Warningf("NodeGetInfo: zone is empty for node %s after transient lookup failure, retrying with backoff to wait for node labels", d.NodeID)
-			retryErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+			retryErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
 				fd, it, labelErr := GetNodeInfoFromLabels(ctx, d.NodeID, d.cloud.KubeClient)
 				if labelErr != nil {
 					klog.V(4).Infof("NodeGetInfo: retry GetNodeInfoFromLabels on node(%s) failed: %v", d.NodeID, labelErr)
@@ -407,7 +411,11 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 				return false, nil
 			})
 			if retryErr != nil {
-				klog.Warningf("NodeGetInfo: timed out waiting for zone label on node %s: %v", d.NodeID, retryErr)
+				if ctx.Err() != nil {
+					klog.Warningf("NodeGetInfo: context canceled while waiting for zone label on node %s: %v", d.NodeID, ctx.Err())
+				} else {
+					klog.Warningf("NodeGetInfo: timed out waiting for zone label on node %s after 2m", d.NodeID)
+				}
 			}
 		}
 

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -380,6 +380,32 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 			zone.FailureDomain = failureDomainFromLabels
 		}
 
+		// When zone is still empty (e.g., cloud config unavailable and node labels not yet
+		// populated by cloud-controller-manager on a newly joined node), retry with backoff
+		// to wait for the labels to appear rather than returning an empty topology.
+		if zone.FailureDomain == "" && d.cloud.KubeClient != nil {
+			klog.Warningf("NodeGetInfo: zone is empty for node %s, retrying with backoff to wait for node labels", d.NodeID)
+			retryErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+				fd, it, labelErr := GetNodeInfoFromLabels(ctx, d.NodeID, d.cloud.KubeClient)
+				if labelErr != nil {
+					klog.V(4).Infof("NodeGetInfo: retry GetNodeInfoFromLabels on node(%s) failed: %v", d.NodeID, labelErr)
+					return false, nil
+				}
+				if fd != "" {
+					zone.FailureDomain = fd
+					if instanceTypeFromLabels == "" {
+						instanceTypeFromLabels = it
+					}
+					return true, nil
+				}
+				klog.V(4).Infof("NodeGetInfo: zone label still empty on node %s, retrying...", d.NodeID)
+				return false, nil
+			})
+			if retryErr != nil {
+				klog.Warningf("NodeGetInfo: timed out waiting for zone label on node %s: %v", d.NodeID, retryErr)
+			}
+		}
+
 		klog.V(2).Infof("NodeGetInfo, nodeName: %s, failureDomain: %s", d.NodeID, zone.FailureDomain)
 		if azureutils.IsValidAvailabilityZone(zone.FailureDomain, d.cloud.Location) {
 			topology.Segments[topologyKey] = zone.FailureDomain

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -388,11 +388,11 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 		// cloud-controller-manager to populate the zone label.
 		// We only retry when:
 		// - zoneLookupFailed is true (initial cloud zone query returned an error)
-		// - allowEmptyCloudConfig is false (cloud config absence is NOT intentional;
-		//   when true, the driver is deployed without cloud config on purpose and
-		//   the zone label may legitimately never appear)
+		// - cloud.Location is set (cloud config was loaded, so zone info should
+		//   eventually be available; if Location is empty, the driver truly has no
+		//   cloud config and the zone label will never appear)
 		// - KubeClient is available (to read node labels)
-		if zone.FailureDomain == "" && zoneLookupFailed && !d.allowEmptyCloudConfig && d.cloud.KubeClient != nil {
+		if zone.FailureDomain == "" && zoneLookupFailed && d.cloud.Location != "" && d.cloud.KubeClient != nil {
 			klog.Warningf("NodeGetInfo: zone is empty for node %s after transient lookup failure, retrying with backoff to wait for node labels", d.NodeID)
 			retryErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
 				fd, it, labelErr := GetNodeInfoFromLabels(ctx, d.NodeID, d.cloud.KubeClient)

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -372,10 +372,15 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 					err = nil // don't fail immediately — fall through to retry
 				}
 			} else if failureDomainFromLabels == "" {
-				// GetNodeInfoFromLabels succeeded but zone label is not populated yet
-				// (CCM hasn't set topology.kubernetes.io/zone). Mark as transient so
-				// the retry loop below waits for the label to appear.
-				zoneLookupFailed = true
+				// Zone label not populated yet. Check if the node is region-only
+				// (has region label but no zone label) to avoid unnecessary retry delay.
+				node, nodeErr := d.cloud.KubeClient.CoreV1().Nodes().Get(ctx, d.NodeID, metav1.GetOptions{})
+				if nodeErr == nil && node.Labels["topology.kubernetes.io/region"] != "" {
+					klog.V(2).Infof("NodeGetInfo: node %s has region label but no zone label via getNodeInfoFromLabels, non-zonal node", d.NodeID)
+					// Non-zonal node — no need to retry.
+				} else {
+					zoneLookupFailed = true
+				}
 			}
 		} else {
 			if runtime.GOOS == "windows" && (!d.cloud.UseInstanceMetadata || d.cloud.Metadata == nil) {
@@ -391,6 +396,14 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 					if d.cloud.KubeClient != nil {
 						klog.Warningf("GetNodeInfoFromLabels fallback on node(%s) also failed: %v, will retry", d.NodeID, err)
 						err = nil // don't fail immediately — fall through to retry
+					}
+				} else if failureDomainFromLabels == "" {
+					// Fallback succeeded but zone is empty. Check if region-only node
+					// to avoid unnecessary 5s delay before first poll iteration.
+					node, nodeErr := d.cloud.KubeClient.CoreV1().Nodes().Get(ctx, d.NodeID, metav1.GetOptions{})
+					if nodeErr == nil && node.Labels["topology.kubernetes.io/region"] != "" {
+						klog.V(2).Infof("NodeGetInfo: node %s has region label but no zone label in fallback path, non-zonal node", d.NodeID)
+						zoneLookupFailed = false // no need to retry
 					}
 				}
 			}
@@ -444,7 +457,7 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 			})
 			if retryErr != nil {
 				if ctx.Err() != nil {
-					klog.Warningf("NodeGetInfo: context canceled while waiting for zone label on node %s: %v", d.NodeID, ctx.Err())
+					return nil, status.Error(codes.Aborted, fmt.Sprintf("NodeGetInfo: context canceled while waiting for zone label on node %s: %v", d.NodeID, ctx.Err()))
 				} else if apierrors.IsForbidden(retryErr) || apierrors.IsNotFound(retryErr) {
 					return nil, status.Error(codes.Internal, fmt.Sprintf("NodeGetInfo: permanent error getting node(%s): %v", d.NodeID, retryErr))
 				} else {

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -360,6 +360,7 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 
 	if d.supportZone {
 		var zone cloudprovider.Zone
+		var zoneLookupFailed bool // tracks whether initial zone lookup hit a transient error
 		if d.getNodeInfoFromLabels {
 			failureDomainFromLabels, instanceTypeFromLabels, err = GetNodeInfoFromLabels(ctx, d.NodeID, d.cloud.KubeClient)
 		} else {
@@ -369,6 +370,7 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 				zone, err = d.cloud.GetZone(ctx)
 			}
 			if err != nil {
+				zoneLookupFailed = true
 				klog.Warningf("get zone(%s) failed with: %v, fall back to get zone from node labels", d.NodeID, err)
 				failureDomainFromLabels, instanceTypeFromLabels, err = GetNodeInfoFromLabels(ctx, d.NodeID, d.cloud.KubeClient)
 			}
@@ -380,11 +382,14 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 			zone.FailureDomain = failureDomainFromLabels
 		}
 
-		// When zone is still empty (e.g., cloud config unavailable and node labels not yet
-		// populated by cloud-controller-manager on a newly joined node), retry with backoff
-		// to wait for the labels to appear rather than returning an empty topology.
-		if zone.FailureDomain == "" && d.cloud.KubeClient != nil {
-			klog.Warningf("NodeGetInfo: zone is empty for node %s, retrying with backoff to wait for node labels", d.NodeID)
+		// When zone is still empty AND the initial zone lookup failed with an error
+		// (e.g., cloud config unavailable because apiserver was unreachable on a newly
+		// joined node before CNI is ready), retry with backoff to wait for
+		// cloud-controller-manager to populate the zone label.
+		// We only retry when zoneLookupFailed is true to avoid blocking for 2 minutes
+		// on non-zonal nodes that legitimately have no zone label.
+		if zone.FailureDomain == "" && zoneLookupFailed && d.cloud.KubeClient != nil {
+			klog.Warningf("NodeGetInfo: zone is empty for node %s after transient lookup failure, retrying with backoff to wait for node labels", d.NodeID)
 			retryErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 				fd, it, labelErr := GetNodeInfoFromLabels(ctx, d.NodeID, d.cloud.KubeClient)
 				if labelErr != nil {

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -365,23 +365,7 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 		var zoneLookupFailed bool // tracks whether zone lookup hit a transient error
 		if d.getNodeInfoFromLabels {
 			failureDomainFromLabels, instanceTypeFromLabels, err = GetNodeInfoFromLabels(ctx, d.NodeID, d.cloud.KubeClient)
-			if err != nil {
-				if d.cloud.KubeClient != nil {
-					zoneLookupFailed = true
-					klog.Warningf("GetNodeInfoFromLabels on node(%s) failed: %v, will retry", d.NodeID, err)
-					err = nil // don't fail immediately — fall through to retry
-				}
-			} else if failureDomainFromLabels == "" {
-				// Zone label not populated yet. Check if the node is region-only
-				// (has region label but no zone label) to avoid unnecessary retry delay.
-				node, nodeErr := d.cloud.KubeClient.CoreV1().Nodes().Get(ctx, d.NodeID, metav1.GetOptions{})
-				if nodeErr == nil && node.Labels["topology.kubernetes.io/region"] != "" {
-					klog.V(2).Infof("NodeGetInfo: node %s has region label but no zone label via getNodeInfoFromLabels, non-zonal node", d.NodeID)
-					// Non-zonal node — no need to retry.
-				} else {
-					zoneLookupFailed = true
-				}
-			}
+			zoneLookupFailed, err = d.handleZoneLookupResult(ctx, failureDomainFromLabels, err)
 		} else {
 			if runtime.GOOS == "windows" && (!d.cloud.UseInstanceMetadata || d.cloud.Metadata == nil) {
 				zone, err = d.cloud.VMSet.GetZoneByNodeName(ctx, d.NodeID)
@@ -392,20 +376,7 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 				zoneLookupFailed = true
 				klog.Warningf("get zone(%s) failed with: %v, fall back to get zone from node labels", d.NodeID, err)
 				failureDomainFromLabels, instanceTypeFromLabels, err = GetNodeInfoFromLabels(ctx, d.NodeID, d.cloud.KubeClient)
-				if err != nil {
-					if d.cloud.KubeClient != nil {
-						klog.Warningf("GetNodeInfoFromLabels fallback on node(%s) also failed: %v, will retry", d.NodeID, err)
-						err = nil // don't fail immediately — fall through to retry
-					}
-				} else if failureDomainFromLabels == "" {
-					// Fallback succeeded but zone is empty. Check if region-only node
-					// to avoid unnecessary 5s delay before first poll iteration.
-					node, nodeErr := d.cloud.KubeClient.CoreV1().Nodes().Get(ctx, d.NodeID, metav1.GetOptions{})
-					if nodeErr == nil && node.Labels["topology.kubernetes.io/region"] != "" {
-						klog.V(2).Infof("NodeGetInfo: node %s has region label but no zone label in fallback path, non-zonal node", d.NodeID)
-						zoneLookupFailed = false // no need to retry
-					}
-				}
+				zoneLookupFailed, err = d.handleZoneLookupResult(ctx, failureDomainFromLabels, err)
 			}
 		}
 		if err != nil {
@@ -415,54 +386,17 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 			zone.FailureDomain = failureDomainFromLabels
 		}
 
-		// When zone is still empty AND zone lookup hit a transient error,
-		// retry with backoff to wait for cloud-controller-manager to populate
-		// the zone label. This handles the startup race where CSI starts before
-		// CNI is ready (apiserver unreachable / cloud config not loaded yet).
-		// Inside the retry loop, if CCM has set the region label but NOT the
-		// zone label, the node is confirmed non-zonal and we stop early.
 		if zone.FailureDomain == "" && zoneLookupFailed && d.cloud.KubeClient != nil {
-			klog.Warningf("NodeGetInfo: zone is empty for node %s after transient lookup failure, retrying with backoff to wait for node labels", d.NodeID)
-			retryErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
-				node, nodeErr := d.cloud.KubeClient.CoreV1().Nodes().Get(ctx, d.NodeID, metav1.GetOptions{})
-				if nodeErr != nil {
-					// Permanent errors: stop retrying and surface the error.
-					if apierrors.IsForbidden(nodeErr) || apierrors.IsNotFound(nodeErr) {
-						klog.Warningf("NodeGetInfo: permanent error getting node(%s): %v", d.NodeID, nodeErr)
-						return false, nodeErr
-					}
-					klog.V(4).Infof("NodeGetInfo: retry get node(%s) failed: %v", d.NodeID, nodeErr)
-					return false, nil
-				}
-				if len(node.Labels) == 0 {
-					klog.V(4).Infof("NodeGetInfo: node %s has no labels yet, retrying...", d.NodeID)
-					return false, nil
-				}
-				fd := node.Labels[consts.WellKnownTopologyKey]
-				if fd != "" {
-					zone.FailureDomain = fd
-					if instanceTypeFromLabels == "" {
-						instanceTypeFromLabels = node.Labels[consts.InstanceTypeKey]
-					}
-					return true, nil
-				}
-				// If CCM has set the region label but not the zone label,
-				// this node is in a non-zonal region — stop retrying.
-				if region := node.Labels["topology.kubernetes.io/region"]; region != "" {
-					klog.V(2).Infof("NodeGetInfo: node %s has region label (%s) but no zone label, non-zonal node — stopping retry", d.NodeID, region)
-					return true, nil
-				}
-				klog.V(4).Infof("NodeGetInfo: zone label still empty on node %s, retrying...", d.NodeID)
-				return false, nil
-			})
-			if retryErr != nil {
-				if ctx.Err() != nil {
-					return nil, status.Error(codes.Aborted, fmt.Sprintf("NodeGetInfo: context canceled while waiting for zone label on node %s: %v", d.NodeID, ctx.Err()))
-				}
-				if apierrors.IsForbidden(retryErr) || apierrors.IsNotFound(retryErr) {
-					return nil, status.Error(codes.Internal, fmt.Sprintf("NodeGetInfo: permanent error getting node(%s): %v", d.NodeID, retryErr))
-				}
-				klog.Warningf("NodeGetInfo: timed out waiting for zone label on node %s after 2m", d.NodeID)
+			var retryZone, retryInstanceType string
+			retryZone, retryInstanceType, err = d.waitForZoneLabel(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if retryZone != "" {
+				zone.FailureDomain = retryZone
+			}
+			if instanceTypeFromLabels == "" {
+				instanceTypeFromLabels = retryInstanceType
 			}
 		}
 
@@ -558,6 +492,93 @@ func GetMaxDataDiskCount(instanceType string) (int64, bool) {
 
 	klog.V(5).Infof("not found a matching size in getMaxDataDiskCount, VM Size: %s, use default volume limit: %d", vmsize, defaultAzureVolumeLimit)
 	return defaultAzureVolumeLimit, false
+}
+
+// handleZoneLookupResult processes the result of a zone label lookup (GetNodeInfoFromLabels).
+// It returns (zoneLookupFailed, err). When the lookup failed transiently and KubeClient is
+// available, err is cleared so the caller falls through to the retry loop. When the lookup
+// succeeded but the zone is empty, it checks whether the node is region-only (non-zonal)
+// to avoid an unnecessary retry.
+func (d *Driver) handleZoneLookupResult(ctx context.Context, failureDomain string, lookupErr error) (bool, error) {
+	if lookupErr != nil {
+		if d.cloud.KubeClient != nil {
+			klog.Warningf("GetNodeInfoFromLabels on node(%s) failed: %v, will retry", d.NodeID, lookupErr)
+			return true, nil // zoneLookupFailed=true, clear error for retry
+		}
+		return false, lookupErr // no KubeClient, can't retry — propagate error
+	}
+	if failureDomain == "" {
+		// Zone empty — check if this is a region-only (non-zonal) node.
+		if d.isRegionOnlyNode(ctx) {
+			return false, nil // non-zonal, no retry needed
+		}
+		return true, nil // zoneLookupFailed=true, need retry
+	}
+	return false, nil // zone found, no retry needed
+}
+
+// isRegionOnlyNode checks whether the node has a region label but no zone label,
+// indicating it is in a non-zonal region and should not wait for a zone label.
+func (d *Driver) isRegionOnlyNode(ctx context.Context) bool {
+	if d.cloud.KubeClient == nil {
+		return false
+	}
+	node, err := d.cloud.KubeClient.CoreV1().Nodes().Get(ctx, d.NodeID, metav1.GetOptions{})
+	if err != nil {
+		return false
+	}
+	if region := node.Labels["topology.kubernetes.io/region"]; region != "" {
+		klog.V(2).Infof("NodeGetInfo: node %s has region label (%s) but no zone label, non-zonal node", d.NodeID, region)
+		return true
+	}
+	return false
+}
+
+// waitForZoneLabel polls node labels with backoff until the zone label appears,
+// the node is confirmed non-zonal (region-only), or the timeout (2min) expires.
+// Returns (failureDomain, instanceType, error). A non-nil error means the caller
+// should return it directly (context cancellation or permanent API error).
+func (d *Driver) waitForZoneLabel(ctx context.Context) (string, string, error) {
+	klog.Warningf("NodeGetInfo: zone is empty for node %s after transient lookup failure, retrying with backoff", d.NodeID)
+
+	var zoneFD, instanceType string
+	retryErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
+		node, nodeErr := d.cloud.KubeClient.CoreV1().Nodes().Get(ctx, d.NodeID, metav1.GetOptions{})
+		if nodeErr != nil {
+			if apierrors.IsForbidden(nodeErr) || apierrors.IsNotFound(nodeErr) {
+				klog.Warningf("NodeGetInfo: permanent error getting node(%s): %v", d.NodeID, nodeErr)
+				return false, nodeErr
+			}
+			klog.V(4).Infof("NodeGetInfo: retry get node(%s) failed: %v", d.NodeID, nodeErr)
+			return false, nil
+		}
+		if len(node.Labels) == 0 {
+			klog.V(4).Infof("NodeGetInfo: node %s has no labels yet, retrying...", d.NodeID)
+			return false, nil
+		}
+		if fd := node.Labels[consts.WellKnownTopologyKey]; fd != "" {
+			zoneFD = fd
+			instanceType = node.Labels[consts.InstanceTypeKey]
+			return true, nil
+		}
+		// Region label present but no zone label → non-zonal node.
+		if region := node.Labels["topology.kubernetes.io/region"]; region != "" {
+			klog.V(2).Infof("NodeGetInfo: node %s has region label (%s) but no zone label, non-zonal — stopping retry", d.NodeID, region)
+			return true, nil
+		}
+		klog.V(4).Infof("NodeGetInfo: zone label still empty on node %s, retrying...", d.NodeID)
+		return false, nil
+	})
+	if retryErr != nil {
+		if ctx.Err() != nil {
+			return "", "", status.Error(codes.Aborted, fmt.Sprintf("NodeGetInfo: context canceled while waiting for zone label on node %s: %v", d.NodeID, ctx.Err()))
+		}
+		if apierrors.IsForbidden(retryErr) || apierrors.IsNotFound(retryErr) {
+			return "", "", status.Error(codes.Internal, fmt.Sprintf("NodeGetInfo: permanent error getting node(%s): %v", d.NodeID, retryErr))
+		}
+		klog.Warningf("NodeGetInfo: timed out waiting for zone label on node %s after 2m", d.NodeID)
+	}
+	return zoneFD, instanceType, nil
 }
 
 func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -35,8 +35,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -373,7 +373,6 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 				zone, err = d.cloud.GetZone(ctx)
 			}
 			if err != nil {
-				zoneLookupFailed = true
 				klog.Warningf("get zone(%s) failed with: %v, fall back to get zone from node labels", d.NodeID, err)
 				failureDomainFromLabels, instanceTypeFromLabels, err = GetNodeInfoFromLabels(ctx, d.NodeID, d.cloud.KubeClient)
 				zoneLookupFailed, err = d.handleZoneLookupResult(ctx, failureDomainFromLabels, err)

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -35,6 +35,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
@@ -390,23 +391,33 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 		// - zoneLookupFailed is true (initial cloud zone query returned an error,
 		//   distinguishing transient failures from legitimately non-zonal nodes)
 		// - KubeClient is available (to read node labels)
-		// Note: we intentionally do NOT gate on allowEmptyCloudConfig or
-		// cloud.Location — during the startup race, cloud config may fail to load
-		// (Location="") even though the node IS in a zone. The zoneLookupFailed
-		// flag already ensures we only retry when a transient error occurred.
+		// Inside the retry loop, we also check the region label
+		// (topology.kubernetes.io/region): if CCM has added the region label but
+		// NOT the zone label, the node is in a non-zonal region and we stop early.
 		if zone.FailureDomain == "" && zoneLookupFailed && d.cloud.KubeClient != nil {
 			klog.Warningf("NodeGetInfo: zone is empty for node %s after transient lookup failure, retrying with backoff to wait for node labels", d.NodeID)
 			retryErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
-				fd, it, labelErr := GetNodeInfoFromLabels(ctx, d.NodeID, d.cloud.KubeClient)
-				if labelErr != nil {
-					klog.V(4).Infof("NodeGetInfo: retry GetNodeInfoFromLabels on node(%s) failed: %v", d.NodeID, labelErr)
+				node, nodeErr := d.cloud.KubeClient.CoreV1().Nodes().Get(ctx, d.NodeID, metav1.GetOptions{})
+				if nodeErr != nil {
+					klog.V(4).Infof("NodeGetInfo: retry get node(%s) failed: %v", d.NodeID, nodeErr)
 					return false, nil
 				}
+				if len(node.Labels) == 0 {
+					klog.V(4).Infof("NodeGetInfo: node %s has no labels yet, retrying...", d.NodeID)
+					return false, nil
+				}
+				fd := node.Labels[consts.WellKnownTopologyKey]
 				if fd != "" {
 					zone.FailureDomain = fd
 					if instanceTypeFromLabels == "" {
-						instanceTypeFromLabels = it
+						instanceTypeFromLabels = node.Labels[consts.InstanceTypeKey]
 					}
+					return true, nil
+				}
+				// If CCM has set the region label but not the zone label,
+				// this node is in a non-zonal region — stop retrying.
+				if region := node.Labels["topology.kubernetes.io/region"]; region != "" {
+					klog.V(2).Infof("NodeGetInfo: node %s has region label (%s) but no zone label, non-zonal node — stopping retry", d.NodeID, region)
 					return true, nil
 				}
 				klog.V(4).Infof("NodeGetInfo: zone label still empty on node %s, retrying...", d.NodeID)

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -458,11 +458,11 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 			if retryErr != nil {
 				if ctx.Err() != nil {
 					return nil, status.Error(codes.Aborted, fmt.Sprintf("NodeGetInfo: context canceled while waiting for zone label on node %s: %v", d.NodeID, ctx.Err()))
-				} else if apierrors.IsForbidden(retryErr) || apierrors.IsNotFound(retryErr) {
-					return nil, status.Error(codes.Internal, fmt.Sprintf("NodeGetInfo: permanent error getting node(%s): %v", d.NodeID, retryErr))
-				} else {
-					klog.Warningf("NodeGetInfo: timed out waiting for zone label on node %s after 2m", d.NodeID)
 				}
+				if apierrors.IsForbidden(retryErr) || apierrors.IsNotFound(retryErr) {
+					return nil, status.Error(codes.Internal, fmt.Sprintf("NodeGetInfo: permanent error getting node(%s): %v", d.NodeID, retryErr))
+				}
+				klog.Warningf("NodeGetInfo: timed out waiting for zone label on node %s after 2m", d.NodeID)
 			}
 		}
 

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -361,9 +361,14 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 
 	if d.supportZone {
 		var zone cloudprovider.Zone
-		var zoneLookupFailed bool // tracks whether initial zone lookup hit a transient error
+		var zoneLookupFailed bool // tracks whether zone lookup hit a transient error
 		if d.getNodeInfoFromLabels {
 			failureDomainFromLabels, instanceTypeFromLabels, err = GetNodeInfoFromLabels(ctx, d.NodeID, d.cloud.KubeClient)
+			if err != nil {
+				zoneLookupFailed = true
+				klog.Warningf("GetNodeInfoFromLabels on node(%s) failed: %v, will retry", d.NodeID, err)
+				err = nil // don't fail immediately — fall through to retry
+			}
 		} else {
 			if runtime.GOOS == "windows" && (!d.cloud.UseInstanceMetadata || d.cloud.Metadata == nil) {
 				zone, err = d.cloud.VMSet.GetZoneByNodeName(ctx, d.NodeID)
@@ -374,26 +379,22 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 				zoneLookupFailed = true
 				klog.Warningf("get zone(%s) failed with: %v, fall back to get zone from node labels", d.NodeID, err)
 				failureDomainFromLabels, instanceTypeFromLabels, err = GetNodeInfoFromLabels(ctx, d.NodeID, d.cloud.KubeClient)
+				if err != nil {
+					klog.Warningf("GetNodeInfoFromLabels fallback on node(%s) also failed: %v, will retry", d.NodeID, err)
+					err = nil // don't fail immediately — fall through to retry
+				}
 			}
-		}
-		if err != nil {
-			return nil, status.Error(codes.Internal, fmt.Sprintf("GetNodeInfoFromLabels on node(%s) failed with %v", d.NodeID, err))
 		}
 		if zone.FailureDomain == "" {
 			zone.FailureDomain = failureDomainFromLabels
 		}
 
-		// When zone is still empty AND the initial zone lookup failed with an error
-		// (e.g., cloud config unavailable because apiserver was unreachable on a newly
-		// joined node before CNI is ready), retry with backoff to wait for
-		// cloud-controller-manager to populate the zone label.
-		// We only retry when:
-		// - zoneLookupFailed is true (initial cloud zone query returned an error,
-		//   distinguishing transient failures from legitimately non-zonal nodes)
-		// - KubeClient is available (to read node labels)
-		// Inside the retry loop, we also check the region label
-		// (topology.kubernetes.io/region): if CCM has added the region label but
-		// NOT the zone label, the node is in a non-zonal region and we stop early.
+		// When zone is still empty AND zone lookup hit a transient error,
+		// retry with backoff to wait for cloud-controller-manager to populate
+		// the zone label. This handles the startup race where CSI starts before
+		// CNI is ready (apiserver unreachable / cloud config not loaded yet).
+		// Inside the retry loop, if CCM has set the region label but NOT the
+		// zone label, the node is confirmed non-zonal and we stop early.
 		if zone.FailureDomain == "" && zoneLookupFailed && d.cloud.KubeClient != nil {
 			klog.Warningf("NodeGetInfo: zone is empty for node %s after transient lookup failure, retrying with backoff to wait for node labels", d.NodeID)
 			retryErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -365,9 +365,11 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 		if d.getNodeInfoFromLabels {
 			failureDomainFromLabels, instanceTypeFromLabels, err = GetNodeInfoFromLabels(ctx, d.NodeID, d.cloud.KubeClient)
 			if err != nil {
-				zoneLookupFailed = true
-				klog.Warningf("GetNodeInfoFromLabels on node(%s) failed: %v, will retry", d.NodeID, err)
-				err = nil // don't fail immediately — fall through to retry
+				if d.cloud.KubeClient != nil {
+					zoneLookupFailed = true
+					klog.Warningf("GetNodeInfoFromLabels on node(%s) failed: %v, will retry", d.NodeID, err)
+					err = nil // don't fail immediately — fall through to retry
+				}
 			}
 		} else {
 			if runtime.GOOS == "windows" && (!d.cloud.UseInstanceMetadata || d.cloud.Metadata == nil) {
@@ -380,10 +382,15 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 				klog.Warningf("get zone(%s) failed with: %v, fall back to get zone from node labels", d.NodeID, err)
 				failureDomainFromLabels, instanceTypeFromLabels, err = GetNodeInfoFromLabels(ctx, d.NodeID, d.cloud.KubeClient)
 				if err != nil {
-					klog.Warningf("GetNodeInfoFromLabels fallback on node(%s) also failed: %v, will retry", d.NodeID, err)
-					err = nil // don't fail immediately — fall through to retry
+					if d.cloud.KubeClient != nil {
+						klog.Warningf("GetNodeInfoFromLabels fallback on node(%s) also failed: %v, will retry", d.NodeID, err)
+						err = nil // don't fail immediately — fall through to retry
+					}
 				}
 			}
+		}
+		if err != nil {
+			return nil, status.Error(codes.Internal, fmt.Sprintf("GetNodeInfoFromLabels on node(%s) failed with %v", d.NodeID, err))
 		}
 		if zone.FailureDomain == "" {
 			zone.FailureDomain = failureDomainFromLabels


### PR DESCRIPTION
## What this PR does

Adds a retry loop with backoff (5s interval, 2min timeout) in `NodeGetInfo` when the zone/failure domain is empty after the initial attempt.

## Why

On newly joined nodes, the azuredisk CSI driver node pod can start before CNI is ready because the DaemonSet uses `hostNetwork: true`, which causes kubelet to add a `NetworkUnavailable` toleration. This creates a race condition:

1. CSI driver pod starts → tries to read `azure-cloud-provider` secret via kube-apiserver ClusterIP (`10.43.0.1`)
2. CNI not ready → ClusterIP unreachable → secret read times out
3. No cloud config → falls back to reading zone from node labels
4. Cloud-controller-manager has not yet labeled the node → empty zone label
5. Node gets `topology.disk.csi.azure.com/zone=""` permanently

This is particularly impactful for clusters with autoscaler where manual intervention (restarting the DaemonSet) is not acceptable.

## How it works

After the initial zone lookup fails to produce a non-empty failure domain, the code now enters a `wait.PollUntilContextTimeout` loop that retries `GetNodeInfoFromLabels` every 5 seconds for up to 2 minutes. This gives cloud-controller-manager time to populate the `topology.kubernetes.io/zone` label.

The retry only triggers when:
- Zone is empty after initial lookup
- KubeClient is available (to read node labels)

If the timeout expires, the behavior is the same as before (empty zone).

Fixes #3400

/kind bug