### PR TITLE
chore: bump Go version to 1.25.10 in trivy workflow

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: 1.25.9
+          go-version: 1.25.10
         id: go
 
       - name: Checkout code


### PR DESCRIPTION
## What this PR does

Bumps the Go version from 1.25.9 to 1.25.10 in the trivy security scan workflow.

/kind cleanup