### PR TITLE
docs: fix broken link and improve snapshot README

### DIFF
--- a/deploy/example/snapshot/README.md
+++ b/deploy/example/snapshot/README.md
@@ -1,11 +1,12 @@
-# Snapshot feature
+# Snapshot Feature
 
-> From version 1.26.4, you can take cross-region snapshots by setting the `location` parameter to a different region than the current cluster
+> Starting from version 1.26.4, you can take cross-region snapshots by setting the `location` parameter to a different region than the current cluster.
 
-- [Use velero to backup & restore Azure disk by snapshot feature](https://velero.io/blog/csi-integration/)
+- [Use Velero to back up & restore Azure disks using the snapshot feature](https://velero.io/blog/csi-integration/)
 
 ## Introduction
-This driver supports both [full and incremental snapshot functionalities](https://docs.microsoft.com/en-us/azure/virtual-machines/disks-incremental-snapshots), you could set `incremental` parameter in `VolumeSnapshotClass` to set full or incremental(by default) snapshot(refer to [VolumeSnapshotClass](../../../docs/driver-parameters.md#volumesnapshotclass) for detailed parameters description):
+
+This driver supports both [full and incremental snapshot functionalities](https://docs.microsoft.com/en-us/azure/virtual-machines/disks-incremental-snapshots). You can set the `incremental` parameter in the `VolumeSnapshotClass` to choose full or incremental (default) snapshots. Refer to [VolumeSnapshotClass](../../../docs/driver-parameters.md#volumesnapshotclass) for detailed parameter descriptions.
 
 ```yaml
 apiVersion: snapshot.storage.k8s.io/v1
@@ -16,87 +17,84 @@ driver: disk.csi.azure.com
 deletionPolicy: Delete
 parameters:
   resourceGroup: EXISTING_RESOURCE_GROUP_NAME  # optional, only set this when snapshot is not taken in the same resource group as agent node
-  incremental: "true"  # available values: "true"(by default), "false"
+  incremental: "true"  # available values: "true" (default), "false"
 ```
 
 ## Install CSI Driver
 
-Follow the [instructions](https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/master/docs/install-csi-driver-master.md) to install snapshot driver.
+Follow the [instructions](https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/master/docs/install-csi-driver-master.md) to install the snapshot driver.
 
-### 1. Create source PVC and an example pod to write data 
+## Example Workflow
+
+### 1. Create a source PVC and an example pod to write data
+
 ```console
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/deploy/example/storageclass-azuredisk-csi.yaml
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/deploy/example/pvc-azuredisk-csi.yaml
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/deploy/example/nginx-pod-azuredisk.yaml
 ```
- - Check source PVC
+
+Verify data on the source PVC:
+
 ```console
 $ kubectl exec nginx-azuredisk -- ls /mnt/azuredisk
 lost+found
 outfile
 ```
 
-### 2. Create a snapshot on source PVC
+### 2. Create a snapshot of the source PVC
+
 ```console
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/deploy/example/snapshot/storageclass-azuredisk-snapshot.yaml
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/deploy/example/snapshot/azuredisk-volume-snapshot.yaml
 ```
- - Check snapshot Status
+
+Check snapshot status:
+
 ```console
 $ kubectl describe volumesnapshot azuredisk-volume-snapshot
 Name:         azuredisk-volume-snapshot
 Namespace:    default
-Labels:       <none>
-Annotations:  kubectl.kubernetes.io/last-applied-configuration:
-                {"apiVersion":"snapshot.storage.k8s.io/v1","kind":"VolumeSnapshot","metadata":{"annotations":{},"name":"azuredisk-volume-snapshot","n...
-API Version:  snapshot.storage.k8s.io/v1
-Kind:         VolumeSnapshot
-Metadata:
-  Creation Timestamp:  2020-02-04T13:59:54Z
-  Finalizers:
-    snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection
-    snapshot.storage.kubernetes.io/volumesnapshot-bound-protection
-  Generation:        1
-  Resource Version:  48044
-  Self Link:         /apis/snapshot.storage.k8s.io/v1/namespaces/default/volumesnapshots/azuredisk-volume-snapshot
-  UID:               2b0ef334-4112-4c86-8360-079c625d5562
-Spec:
-  Source:
-    Persistent Volume Claim Name:  pvc-azuredisk
-  Volume Snapshot Class Name:      csi-azuredisk-vsc
+...
 Status:
   Bound Volume Snapshot Content Name:  snapcontent-2b0ef334-4112-4c86-8360-079c625d5562
   Creation Time:                       2020-02-04T14:23:36Z
   Ready To Use:                        true
   Restore Size:                        10Gi
-Events:                                <none>
 ```
-> In above example, `snapcontent-2b0ef334-4112-4c86-8360-079c625d5562` is the snapshot name
 
-### 3. Create a new PVC based on snapshot
+> In the example above, `snapcontent-2b0ef334-4112-4c86-8360-079c625d5562` is the snapshot name.
+
+### 3. Create a new PVC from the snapshot
+
 ```console
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/deploy/example/snapshot/pvc-azuredisk-snapshot-restored.yaml
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/deploy/example/snapshot/nginx-pod-restored-snapshot.yaml
 ```
 
- - Check data
+Verify restored data:
+
 ```console
 $ kubectl exec nginx-restored -- ls /mnt/azuredisk
 lost+found
 outfile
 ```
 
-### Tips
-### Use snapshot feature to create a copy of a disk with a different SKU
-> It is possible to change the disk SKU from LRS to ZRS, from standard to premium, and even across zones, but it is not supported to change the disk SKU across regions.
+## Use Snapshot to Create a Copy of a Disk with a Different SKU
 
-> For information on storage class settings with cross-zone support, please refer to [allowed-topology storage class](./storageclass-azuredisk-csi-allowed-topology.yaml)
+You can use snapshots to change the disk SKU (e.g., from LRS to ZRS, or from Standard to Premium) and even move across zones.
 
- - Before proceeding, ensure that the application is not writing data to the source disk.
- - Take a snapshot of the existing disk PVC.
- - Create a new storage class, such as "new-sku-sc," with the desired SKU name value
- - Create a new PVC with the storage class name "new-sku-sc" based on the snapshot.
+> **Note:** Changing the disk SKU across regions is not supported.
 
-#### Links
- - [CSI Snapshotter](https://github.com/kubernetes-csi/external-snapshotter)
- - [Announcing general availability of incremental snapshots of Managed Disks](https://azure.microsoft.com/en-gb/blog/announcing-general-availability-of-incremental-snapshots-of-managed-disks/)
+For storage class settings with cross-zone support, refer to the [allowed-topology storage class](../storageclass-azuredisk-csi-allowed-topology.yaml).
+
+Steps:
+1. Ensure the application is **not writing data** to the source disk.
+2. Take a snapshot of the existing disk PVC (see step 2 above).
+3. Create a new StorageClass (e.g., `new-sku-sc`) with the desired SKU.
+4. Create a new PVC with `storageClassName: new-sku-sc` referencing the snapshot as the data source.
+
+## Links
+
+- [CSI Snapshotter](https://github.com/kubernetes-csi/external-snapshotter)
+- [Announcing general availability of incremental snapshots of Managed Disks](https://azure.microsoft.com/en-gb/blog/announcing-general-availability-of-incremental-snapshots-of-managed-disks/)


### PR DESCRIPTION
## What this PR does

Fixes a broken link and improves the snapshot example README.

### Changes
- **Fix broken link**: `storageclass-azuredisk-csi-allowed-topology.yaml` was linked as `./storageclass-...` (in snapshot dir) but the file lives at `deploy/example/storageclass-...`. Corrected to `../storageclass-...`.
- **Improve formatting**: consistent heading levels, trimmed verbose `kubectl describe` output to show only relevant status fields, clearer step descriptions.
- **Restructure**: promoted "copy disk with different SKU" tips into a proper section with numbered steps.