### PR TITLE
[release-1.34] fix: register QEMU binfmt before cross-platform docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,7 @@ container: azuredisk
 
 .PHONY: container-linux
 container-linux:
+	docker run --rm --privileged tonistiigi/binfmt --install all 2>/dev/null || true
 	docker buildx build . \
 		--pull \
 		--output=type=$(OUTPUT_TYPE) \


### PR DESCRIPTION
Register QEMU binfmt handlers before `docker buildx build` to prevent intermittent `Exec format error` failures when building arm64 images in CI DinD environments.

The single-stage Dockerfile runs `apt install` under QEMU emulation for arm64, which fails when binfmt registration is unstable. Running `tonistiigi/binfmt --install all` ensures handlers are always registered.

Similar to kubernetes-sigs/azurefile-csi-driver#3157.