### PR TITLE
fix: create volume leaks disk when throttled and PVC deleted

### DIFF
--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -466,6 +466,20 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		if strings.Contains(err.Error(), consts.NotFound) {
 			return nil, status.Error(codes.NotFound, err.Error())
 		}
+		// On Azure ARM throttling, the underlying PUT may have already been
+		// accepted by ARM (the throttle commonly fires on a polling GET inside
+		// the SDK poller after the disk creation has started). Returning
+		// codes.Internal here causes external-provisioner's checkError() to
+		// classify the operation as ProvisioningFinished — no retry, no
+		// cleanup — which leaks the disk in Azure if the PVC is meanwhile
+		// removed. Returning codes.Aborted ("Operation pending for the
+		// specified volume" per CSI spec) makes the provisioner classify the
+		// operation as ProvisioningInBackground and retry; CSI idempotency on
+		// the retry returns the existing disk's URI.
+		if azureutils.IsThrottlingError(err) {
+			klog.Warningf("CreateVolume(%s) throttled by Azure ARM; returning Aborted so external-provisioner retries: %v", req.GetName(), err)
+			return nil, status.Errorf(codes.Aborted, "%v", err)
+		}
 		return nil, status.Errorf(codes.Internal, "%v", err)
 	}
 

--- a/pkg/azuredisk/controllerserver_test.go
+++ b/pkg/azuredisk/controllerserver_test.go
@@ -52,6 +52,7 @@ import (
 	volumehelper "sigs.k8s.io/azuredisk-csi-driver/pkg/util"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/diskclient/mock_diskclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/mock_azclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/retryrepectthrottled"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/snapshotclient/mock_snapshotclient"
 	mockvmclient "sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachineclient/mock_virtualmachineclient"
 	azure "sigs.k8s.io/cloud-provider-azure/pkg/provider"
@@ -397,6 +398,35 @@ func TestCreateVolume(t *testing.T) {
 				expectedErr := status.Error(codes.NotFound, "invalid URI: ")
 				if !reflect.DeepEqual(err, expectedErr) {
 					t.Errorf("actualErr: (%v), expectedErr: (%v)", err, expectedErr)
+				}
+			},
+		},
+		{
+			name: "create managed disk throttled error returns Aborted",
+			testFunc: func(t *testing.T) {
+				cntl := gomock.NewController(t)
+				defer cntl.Finish()
+				d, _ := NewFakeDriver(cntl)
+				mp := make(map[string]string)
+				req := &csi.CreateVolumeRequest{
+					Name:               "unit-test",
+					VolumeCapabilities: createVolumeCapabilities(csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+					Parameters:         mp,
+				}
+				diskClient := mock_diskclient.NewMockInterface(cntl)
+				d.getClientFactory().(*mock_azclient.MockClientFactory).EXPECT().GetDiskClientForSub(gomock.Any()).Return(diskClient, nil).AnyTimes()
+				diskClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("not found")).AnyTimes()
+				diskClient.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, retryrepectthrottled.ErrTooManyRequest).AnyTimes()
+				_, err := d.CreateVolume(context.Background(), req)
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				st, ok := status.FromError(err)
+				if !ok {
+					t.Fatalf("expected gRPC status error, got %v", err)
+				}
+				if st.Code() != codes.Aborted {
+					t.Errorf("expected status code %v, got %v", codes.Aborted, st.Code())
 				}
 			},
 		},

--- a/pkg/azureutils/azure_disk_utils.go
+++ b/pkg/azureutils/azure_disk_utils.go
@@ -44,6 +44,7 @@ import (
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/optimization"
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/util"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader"
+	retryrepectthrottled "sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/retryrepectthrottled"
 	azure "sigs.k8s.io/cloud-provider-azure/pkg/provider"
 	azureconfig "sigs.k8s.io/cloud-provider-azure/pkg/provider/config"
 )
@@ -801,7 +802,9 @@ func SleepIfThrottled(err error, defaultSleepSec int) {
 func IsThrottlingError(err error) bool {
 	if err != nil {
 		errMsg := strings.ToLower(err.Error())
-		return strings.Contains(errMsg, strings.ToLower(consts.TooManyRequests)) || strings.Contains(errMsg, consts.ClientThrottled)
+		return strings.Contains(errMsg, strings.ToLower(consts.TooManyRequests)) ||
+			strings.Contains(errMsg, consts.ClientThrottled) ||
+			strings.Contains(errMsg, retryrepectthrottled.ErrTooManyRequest.Error())
 	}
 	return false
 }

--- a/pkg/azureutils/azure_disk_utils_test.go
+++ b/pkg/azureutils/azure_disk_utils_test.go
@@ -37,6 +37,7 @@ import (
 	consts "sigs.k8s.io/azuredisk-csi-driver/pkg/azureconstants"
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/util"
 	"sigs.k8s.io/azuredisk-csi-driver/test/utils/testutil"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/retryrepectthrottled"
 )
 
 func TestCheckDiskName(t *testing.T) {
@@ -1866,6 +1867,11 @@ func TestIsThrottlingError(t *testing.T) {
 		{
 			desc:     "match error message with TooManyRequests throttling",
 			err:      errors.New("could not list storage accounts for account type Premium_LRS: Retriable: true, RetryAfter: 2170s, HTTPStatusCode: 429, RawError: azure cloud provider throttled for operation StorageAccountListByResourceGroup with reason \"TooManyRequests\""),
+			expected: true,
+		},
+		{
+			desc:     "match cloud-provider-azure pipeline throttle string",
+			err:      retryrepectthrottled.ErrTooManyRequest,
 			expected: true,
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

**What this PR does / why we need it**:

When Azure throttles a `CreateVolume` request, the throttle commonly fires on a polling `GET` inside the SDK's async-operation poller — after the underlying `PUT` has already been accepted by ARM and the managed disk has begun provisioning. The driver currently returns `codes.Internal`, which the external-provisioner classifies as `ProvisioningFinished` (no retry, no cleanup). If the PVC is deleted before the next retry would have fired, the disk is leaked in Azure.
 
Fix: At the `CreateVolume` gRPC boundary, detect throttling errors via `azureutils.IsThrottlingError` and return `codes.Aborted` instead of `codes.Internal`. The CSI spec defines `Aborted` for `CreateVolume` as "Operation pending for the specified volume" — exactly this case. The external-provisioner's [`checkError()`](https://github.com/kubernetes-csi/external-provisioner/blob/6d3927887fda9105daa6317b1f64a5f88a3cbe65/pkg/controller/controller.go#L2035-L2070) then maps `Aborted` to `ProvisioningInBackground`, the work stays on the queue, and CSI idempotency converges on retry.

Side fix: `azureutils.IsThrottlingError` is broadened to recognize the cloud-provider-azure error from `vendor/sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/retryrepectthrottled`.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: create volume leaks disk when throttled and PVC deleted
```
