### PR TITLE
test: increase timing tolerance in TestForceDetach for Windows CI

### DIFF
--- a/pkg/azuredisk/azure_controller_common_test.go
+++ b/pkg/azuredisk/azure_controller_common_test.go
@@ -361,8 +361,9 @@ func TestForceDetach(t *testing.T) {
 							contextDeadline, ok := ctx.Deadline()
 							assert.True(t, ok, "Context should have a deadline")
 							assert.True(t, contextDeadline.After(time.Now()), "Context deadline should be in the future")
-							assert.True(t, time.Until(contextDeadline) >= time.Duration(test.detachOperationTimeout)*time.Millisecond-500*time.Millisecond, "Context deadline should exceed min detach timeout.")
-							assert.True(t, time.Until(contextDeadline) >= test.contextTimeout/2-500*time.Millisecond, "Context deadline should be at least half of context timeout.")
+							remaining := time.Until(contextDeadline)
+							assert.True(t, remaining >= time.Duration(test.detachOperationTimeout)*time.Second-500*time.Millisecond, "Context deadline should exceed min detach timeout.")
+							assert.True(t, remaining >= test.contextTimeout/2-500*time.Millisecond, "Context deadline should be at least half of context timeout.")
 							// Simulate timeout by sleeping longer than context deadline
 							if test.firstDetachError == context.DeadlineExceeded {
 								time.Sleep(time.Until(contextDeadline.Add(50 * time.Millisecond)))

--- a/pkg/azuredisk/azure_controller_common_test.go
+++ b/pkg/azuredisk/azure_controller_common_test.go
@@ -290,7 +290,7 @@ func TestForceDetach(t *testing.T) {
 			diskName:               "disk1",
 			forceDetachBackoff:     true,
 			detachOperationTimeout: 1,
-			contextTimeout:         2 * time.Second,
+			contextTimeout:         5 * time.Second,
 			firstDetachError:       context.DeadlineExceeded,
 			forceDetachError:       errors.New("force detach failed"),
 			expectedErr:            true,
@@ -361,8 +361,8 @@ func TestForceDetach(t *testing.T) {
 							contextDeadline, ok := ctx.Deadline()
 							assert.True(t, ok, "Context should have a deadline")
 							assert.True(t, contextDeadline.After(time.Now()), "Context deadline should be in the future")
-							assert.True(t, time.Until(contextDeadline) >= time.Duration(test.detachOperationTimeout)*time.Millisecond-100*time.Millisecond, "Context deadline should exceed min detach timeout.")
-							assert.True(t, time.Until(contextDeadline) >= test.contextTimeout/2-100*time.Millisecond, "Context deadline should be at least half of context timeout.")
+							assert.True(t, time.Until(contextDeadline) >= time.Duration(test.detachOperationTimeout)*time.Millisecond-500*time.Millisecond, "Context deadline should exceed min detach timeout.")
+							assert.True(t, time.Until(contextDeadline) >= test.contextTimeout/2-500*time.Millisecond, "Context deadline should be at least half of context timeout.")
 							// Simulate timeout by sleeping longer than context deadline
 							if test.firstDetachError == context.DeadlineExceeded {
 								time.Sleep(time.Until(contextDeadline.Add(50 * time.Millisecond)))


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
Fixes flaky `TestForceDetach/should_return_error_when_force_detach_also_fails` on Windows CI.

The test uses a 2s context timeout, but on slow Windows runners the elapsed time between context creation and the assertion check causes `time.Until(deadline)` to drop below `contextTimeout/2 - 100ms`, failing the assertion.

**Fix:**
- Increase `contextTimeout` from 2s to 5s for the affected test case
- Increase assertion tolerance from 100ms to 500ms to handle CI scheduling jitter

**Which issue(s) this PR fixes:**
Fixes flaky Windows CI test failure in `TestForceDetach`.

**Does this PR introduce a user-facing change?**
```release-note
NONE
```