### PR TITLE
fix: node lookup should be best effort and not blocking

### DIFF
--- a/pkg/azuredisk/azure_controller_common.go
+++ b/pkg/azuredisk/azure_controller_common.go
@@ -69,6 +69,12 @@ const (
 	// default timeout for VMSS detach operation before polling on GET VM to verify detach status
 	defaultVMSSDetachTimeoutInSeconds = 20
 
+	// nodeInfoLookupTimeout bounds the best-effort kube-apiserver Node Get used by
+	// AttachDisk to look up the instance type for disk-count batching. The lookup
+	// runs under the per-node attach lock, so a slow/throttled apiserver must not
+	// be allowed to pin it.
+	nodeInfoLookupTimeout = 5 * time.Second
+
 	// WriteAcceleratorEnabled support for Azure Write Accelerator on Azure Disks
 	// https://docs.microsoft.com/azure/virtual-machines/windows/how-to-enable-write-accelerator
 	WriteAcceleratorEnabled = "writeacceleratorenabled"
@@ -234,9 +240,14 @@ func (c *controllerCommon) AttachDisk(ctx context.Context, diskName, diskURI str
 
 	numDisksAllowed := math.MaxInt
 	if c.CheckDiskCountForBatching {
-		_, instanceType, err := GetNodeInfoFromLabels(ctx, string(nodeName), c.cloud.KubeClient)
+		// Best-effort lookup: bound the wait so a slow/throttled kube-apiserver
+		// cannot pin the per-node lock taken above. On timeout/error we fall through
+		// with numDisksAllowed=math.MaxInt, which matches pre-CheckDiskCountForBatching behavior.
+		nodeInfoCtx, nodeInfoCancel := context.WithTimeout(ctx, nodeInfoLookupTimeout)
+		_, instanceType, err := GetNodeInfoFromLabels(nodeInfoCtx, string(nodeName), c.cloud.KubeClient)
+		nodeInfoCancel()
 		if err != nil {
-			klog.Errorf("failed to get node info from labels: %v", err)
+			klog.V(2).Infof("skip disk-count check for node(%s), failed to get node info from labels: %v", nodeName, err)
 		} else if instanceType != "" {
 			maxNumDisks, instanceExists := GetMaxDataDiskCount(instanceType)
 			if instanceExists {


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`controllerCommon.AttachDisk` takes a per-node `lockMap` entry and then calls
`GetNodeInfoFromLabels` (a direct `Nodes().Get` against kube-apiserver) inside
that critical section to compute the disk-count batching budget when
`CheckDiskCountForBatching` is enabled.

The `azuredisk` controller container does not set `--kube-api-qps` / `--kube-api-burst`,
so it inherits the client-go defaults (5 QPS / 10 burst). Under fan-out, many
pending `VolumeAttachment` reconciles plus periodic `VolumeAttachments().List`
calls, the client-go rate limiter saturates and the per-attach `Nodes().Get`
queues behind it. While that Get is queued, the per-node mutex stays held, so
every other attach/detach targeting the same node serializes behind it.


**Which issue(s) this PR fixes**:
This PR makes the lookup best-effort with a hard ceiling so it cannot pin the
per-node lock:

- Wraps `GetNodeInfoFromLabels` in a `context.WithTimeout` derived from the
  parent attach context (`nodeInfoLookupTimeout = 5s`, defined alongside the
  other package-level timeout constants).
- On timeout/error, falls through with `numDisksAllowed = math.MaxInt`, which
  is the same effective behavior as when `CheckDiskCountForBatching` is off.
  The disk-count batching optimization is opportunistic; degrading to
  "no batch trim" on a transient apiserver hiccup is strictly safer than
  holding the lock indefinitely.

**Risk**:

- **None for clusters where kube-apiserver is healthy.** A 5s budget is
  comfortably above realistic latencies; `Nodes().Get` returns well under
  that bound and the disk-count batching path runs exactly as before.
- **Strict improvement for clusters under apiserver pressure.** Worst case
  is "the disk-count trimming step is skipped on this attempt" — which is
  the pre-`CheckDiskCountForBatching` behavior and what the flag-off path
  also produces.


**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
