### PR TITLE
[WIP] fix: use "0" instead of empty string for non-zonal topology zone value

### DIFF
--- a/pkg/azureconstants/azure_constants.go
+++ b/pkg/azureconstants/azure_constants.go
@@ -86,6 +86,7 @@ const (
 	UserAgentField                    = "useragent"
 	VolumeAttributePartition          = "partition"
 	WellKnownTopologyKey              = "topology.kubernetes.io/zone"
+	TopologyRegionalZoneValue         = "0"
 	InstanceTypeKey                   = "node.kubernetes.io/instance-type"
 	WriteAcceleratorEnabled           = "writeacceleratorenabled"
 	ZonedField                        = "zoned"

--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -394,13 +394,17 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		}
 		// make volume scheduled on all non-zone nodes
 		topology := &csi.Topology{
-			Segments: map[string]string{topologyKey: ""},
+			Segments: map[string]string{topologyKey: consts.TopologyRegionalZoneValue},
 		}
 		accessibleTopology = append(accessibleTopology, topology)
 	} else {
+		zone := diskZone
+		if zone == "" {
+			zone = consts.TopologyRegionalZoneValue
+		}
 		accessibleTopology = []*csi.Topology{
 			{
-				Segments: map[string]string{topologyKey: diskZone},
+				Segments: map[string]string{topologyKey: zone},
 			},
 		}
 	}

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -352,7 +352,7 @@ func (d *Driver) NodeGetCapabilities(_ context.Context, _ *csi.NodeGetCapabiliti
 // NodeGetInfo return info of the node on which this plugin is running
 func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
 	topology := &csi.Topology{
-		Segments: map[string]string{topologyKey: ""},
+		Segments: map[string]string{topologyKey: consts.TopologyRegionalZoneValue},
 	}
 
 	var failureDomainFromLabels, instanceTypeFromLabels string


### PR DESCRIPTION
Use `TopologyRegionalZoneValue` (`"0"`) instead of empty string for the CSI topology zone value on non-zonal (regional) nodes and disks. This aligns with cloud-provider-azure which assigns `"0"` to regional VMs in `topology.kubernetes.io/zone`, ensuring consistent zone representation across the storage and compute stacks.

The change applies to:
- **NodeGetInfo**: default topology for non-zonal nodes
- **CreateVolume (ZRS)**: non-zone topology entry for ZRS disks  
- **CreateVolume (LRS)**: topology when `diskZone` is empty (non-zonal region)

Previously, the CSI driver used an empty string `""` to represent non-zonal topology, while cloud-provider-azure uses `"0"` (fault domain 0). This mismatch caused issues when systems that normalize the CSI topology key (`topology.disk.csi.azure.com/zone`) to the well-known key (`topology.kubernetes.io/zone`) could not match the empty value against nodes labeled with `"0"`.

problem:
this PR would break old PVs using empty string value since when there is csi driver upgrade with the fix, old PVs could not match topology.disk.csi.azure.com/zone = "0", and finally old PVs cannot be attached to the node, user needs to do the PV migration, that would be very huge efforts. since there is already simple workaround here, I would suggest do not change the value in csi driver itself.