### PR TITLE
feat(azuredisk): skip detach for already-unattached disk on ControllerUnpublishVolume

### DIFF
--- a/pkg/azuredisk/azuredisk.go
+++ b/pkg/azuredisk/azuredisk.go
@@ -21,11 +21,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -138,6 +140,7 @@ type Driver struct {
 	forceDetachBackoff                 bool
 	waitForDetach                      bool
 	waitForDetachDiskComplete          bool
+	skipDetachForUnattachedDisk        bool
 	endpoint                           string
 	disableAVSetNodes                  bool
 	removeNotReadyTaint                bool
@@ -200,6 +203,7 @@ func NewDriver(options *DriverOptions) *Driver {
 	driver.forceDetachBackoff = options.ForceDetachBackoff
 	driver.waitForDetach = options.WaitForDetach
 	driver.waitForDetachDiskComplete = options.WaitForDetachDiskComplete
+	driver.skipDetachForUnattachedDisk = options.SkipDetachForUnattachedDisk
 	driver.endpoint = options.Endpoint
 	driver.disableAVSetNodes = options.DisableAVSetNodes
 	driver.removeNotReadyTaint = options.RemoveNotReadyTaint
@@ -474,6 +478,27 @@ func (d *Driver) checkDiskExists(ctx context.Context, diskURI string) (*armcompu
 	newCtx, cancel := context.WithTimeout(ctx, time.Duration(d.getDiskTimeoutInSeconds)*time.Second)
 	defer cancel()
 	return d.diskController.GetDiskByURI(newCtx, diskURI)
+}
+
+// diskHasNoOwner reports whether the managed disk is currently attached to no
+// VM, i.e. it is already detached from every node. A non-shared disk records
+// its single owner in ManagedBy; a shared disk (MaxShares > 1) records every
+// owner in ManagedByExtended. The disk has no owner only when both are empty,
+// which is the steady state after Azure deletes the owning VM(s). It returns
+// false for a nil disk (e.g. GetDisk skipped due to throttling).
+func diskHasNoOwner(disk *armcompute.Disk) bool {
+	if disk == nil {
+		return false
+	}
+	return disk.ManagedBy == nil && len(disk.ManagedByExtended) == 0
+}
+
+// isDiskNotFoundError reports whether err indicates the managed disk does not
+// exist (HTTP 404). A non-existent disk is attached to no node, so per the CSI
+// spec a ControllerUnpublishVolume can be safely regarded as already complete.
+func isDiskNotFoundError(err error) bool {
+	var respErr *azcore.ResponseError
+	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
 }
 
 func (d *Driver) checkDiskCapacity(ctx context.Context, subsID, resourceGroup, diskName string, requestGiB int) (bool, error) {

--- a/pkg/azuredisk/azuredisk_option.go
+++ b/pkg/azuredisk/azuredisk_option.go
@@ -65,6 +65,7 @@ type DriverOptions struct {
 	CheckDiskCountForBatching          bool
 	WaitForDetach                      bool
 	WaitForDetachDiskComplete          bool
+	SkipDetachForUnattachedDisk        bool
 	Kubeconfig                         string
 	Endpoint                           string
 	DisableAVSetNodes                  bool
@@ -124,6 +125,7 @@ func (o *DriverOptions) AddFlags() *flag.FlagSet {
 	fs.BoolVar(&o.ForceDetachBackoff, "force-detach-backoff", true, "boolean flag to force detach in disk detach backoff")
 	fs.BoolVar(&o.WaitForDetach, "wait-for-detach", true, "boolean flag to wait for detach before attaching disk on the same node")
 	fs.BoolVar(&o.WaitForDetachDiskComplete, "wait-for-detach-disk-complete", true, "boolean flag to wait until disk ManagedBy is cleared or no longer refers to the original node after detach")
+	fs.BoolVar(&o.SkipDetachForUnattachedDisk, "skip-detach-for-unattached-disk", true, "boolean flag to skip detach when the disk is already detached from every node (disk missing or has no owning VM)")
 	fs.StringVar(&o.Kubeconfig, "kubeconfig", "", "Absolute path to the kubeconfig file. Required only when running out of cluster.")
 	fs.BoolVar(&o.DisableAVSetNodes, "disable-avset-nodes", false, "disable DisableAvailabilitySetNodes in cloud config for controller")
 	fs.BoolVar(&o.RemoveNotReadyTaint, "remove-not-ready-taint", true, "remove NotReady taint from node when node is ready")

--- a/pkg/azuredisk/azuredisk_test.go
+++ b/pkg/azuredisk/azuredisk_test.go
@@ -18,13 +18,16 @@ package azuredisk
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -616,5 +619,99 @@ func TestGetUsedLunsFromNode(t *testing.T) {
 		if !reflect.DeepEqual(result, test.expectedUsedLunList) {
 			t.Errorf("test(%s): result(%v) != expected result(%v)", test.name, result, test.expectedUsedLunList)
 		}
+	}
+}
+
+func TestDiskHasNoOwner(t *testing.T) {
+	otherVM := "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/node1"
+	tests := []struct {
+		name     string
+		disk     *armcompute.Disk
+		expected bool
+	}{
+		{
+			name:     "nil disk (e.g. throttled GetDisk) -> false",
+			disk:     nil,
+			expected: false,
+		},
+		{
+			name:     "no owner, no properties -> true",
+			disk:     &armcompute.Disk{},
+			expected: true,
+		},
+		{
+			name:     "no owner, MaxShares=1 -> true",
+			disk:     &armcompute.Disk{Properties: &armcompute.DiskProperties{MaxShares: ptr.To(int32(1))}},
+			expected: true,
+		},
+		{
+			name:     "owned by a VM -> false",
+			disk:     &armcompute.Disk{ManagedBy: ptr.To(otherVM)},
+			expected: false,
+		},
+		{
+			name:     "shared disk (MaxShares>1) detached from all VMs -> true",
+			disk:     &armcompute.Disk{Properties: &armcompute.DiskProperties{MaxShares: ptr.To(int32(2))}},
+			expected: true,
+		},
+		{
+			name:     "shared disk (MaxShares>1) owned via ManagedBy -> false",
+			disk:     &armcompute.Disk{ManagedBy: ptr.To(otherVM), Properties: &armcompute.DiskProperties{MaxShares: ptr.To(int32(2))}},
+			expected: false,
+		},
+		{
+			name:     "shared disk (MaxShares>1) owned via ManagedByExtended -> false",
+			disk:     &armcompute.Disk{ManagedByExtended: []*string{ptr.To(otherVM)}, Properties: &armcompute.DiskProperties{MaxShares: ptr.To(int32(2))}},
+			expected: false,
+		},
+		{
+			name:     "non-shared disk with stale ManagedByExtended entry -> false",
+			disk:     &armcompute.Disk{ManagedByExtended: []*string{ptr.To(otherVM)}},
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, diskHasNoOwner(tt.disk), tt.name)
+		})
+	}
+}
+
+func TestIsDiskNotFoundError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error -> false",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "unrelated error -> false",
+			err:      errors.New("some transient failure"),
+			expected: false,
+		},
+		{
+			name:     "ResponseError 404 -> true",
+			err:      &azcore.ResponseError{StatusCode: http.StatusNotFound},
+			expected: true,
+		},
+		{
+			name:     "wrapped ResponseError 404 -> true",
+			err:      fmt.Errorf("get disk failed: %w", &azcore.ResponseError{StatusCode: http.StatusNotFound}),
+			expected: true,
+		},
+		{
+			name:     "ResponseError 429 (throttled) -> false",
+			err:      &azcore.ResponseError{StatusCode: http.StatusTooManyRequests},
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isDiskNotFoundError(tt.err), tt.name)
+		})
 	}
 }

--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -801,6 +801,32 @@ func (d *Driver) ControllerUnpublishVolume(ctx context.Context, req *csi.Control
 
 	klog.V(2).Infof("Trying to detach volume %s from node %s", diskURI, nodeID)
 
+	// Fast-path: a cheap disk read can show the volume is already detached from
+	// every node, letting us skip the node-centric DetachDisk path that
+	// serializes on the global VMManagementType mutex during mass detach (e.g.
+	// when many spot/preemptible nodes are deleted at once). Two cases qualify,
+	// both of which the CSI spec says SHOULD/MUST return OK:
+	//   - the disk no longer exists (404), so it is attached to nothing; or
+	//   - the disk exists but has no owning VM (e.g. its node was deleted).
+	// checkDiskExists honors GetDisk throttling (returns nil,nil while throttled)
+	// and a timeout, so under throttling or any other read error we simply fall
+	// through to the normal detach. Gated by --skip-detach-for-unattached-disk.
+	if d.skipDetachForUnattachedDisk {
+		disk, derr := d.checkDiskExists(ctx, diskURI)
+		switch {
+		case derr != nil:
+			if isDiskNotFoundError(derr) {
+				klog.V(2).Infof("volume %s not found, assuming already detached from node %s", diskURI, nodeID)
+				isOperationSucceeded = true
+				return &csi.ControllerUnpublishVolumeResponse{}, nil
+			}
+		case diskHasNoOwner(disk):
+			klog.V(2).Infof("volume %s has no owning VM, assuming already detached from node %s", diskURI, nodeID)
+			isOperationSucceeded = true
+			return &csi.ControllerUnpublishVolumeResponse{}, nil
+		}
+	}
+
 	if err := d.diskController.DetachDisk(ctx, diskName, diskURI, nodeName); err != nil {
 		if strings.Contains(err.Error(), consts.ErrDiskNotFound) {
 			klog.Warningf("volume %s already detached from node %s", diskURI, nodeID)


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

During mass detach (e.g. when many spot/preemptible nodes are deleted at once), ControllerUnpublishVolume calls DetachDisk per volume, which serializes on the global VMManagementType mutex and can stall the controller.

Add a fast-path that does a cheap disk read first: if the disk no longer exists (HTTP 404) or exists but has no owning VM (ManagedBy and ManagedByExtended both empty), the volume is already detached from every node, so we return success without taking the node-centric DetachDisk path. checkDiskExists honors GetDisk throttling and a timeout, so any read error simply falls through to the normal detach.

The behavior is gated by a new CLI flag --skip-detach-for-unattached-disk (default true). Adds unit tests for diskHasNoOwner and isDiskNotFoundError.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Release note**:
```
none
```
