### PR TITLE
cleanup: preserve tail of truncated error messages in kube-events

### DIFF
--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -57,6 +57,22 @@ const (
 	maxSnapshotSizeDifferenceAllowed = 50 // in GiB
 )
 
+// truncateErrMsg truncates long error messages while preserving both the
+// beginning (context) and end (critical details like permission errors).
+// This ensures that important information at the tail of verbose Azure
+// error messages (e.g., missing permissions) remains visible in kube-events
+// which are limited to 1024 bytes.
+func truncateErrMsg(errMsg string) string {
+	if len(errMsg) <= maxErrMsgLength {
+		return errMsg
+	}
+	// Keep head (~40%) for context and tail (~60%) for critical error details.
+	const ellipsis = " ... "
+	headLen := (maxErrMsgLength - len(ellipsis)) * 2 / 5
+	tailLen := maxErrMsgLength - headLen - len(ellipsis)
+	return errMsg[:headLen] + ellipsis + errMsg[len(errMsg)-tailLen:]
+}
+
 // listVolumeStatus explains the return status of `listVolumesByResourceGroup`
 type listVolumeStatus struct {
 	numVisited    int  // the number of iterated azure disks
@@ -755,9 +771,7 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 			if err != nil {
 				klog.Errorf("Attach volume %s to instance %s failed with %v", diskName, nodeName, err)
 				errMsg := fmt.Sprintf("Attach volume %s to instance %s failed with %v", diskName, nodeName, err)
-				if len(errMsg) > maxErrMsgLength {
-					errMsg = errMsg[:maxErrMsgLength]
-				}
+				errMsg = truncateErrMsg(errMsg)
 				return nil, status.Errorf(codes.Internal, "%v", errMsg)
 			}
 		}
@@ -807,9 +821,7 @@ func (d *Driver) ControllerUnpublishVolume(ctx context.Context, req *csi.Control
 		} else {
 			klog.Errorf("Could not detach volume %s from node %s: %v", diskURI, nodeID, err)
 			errMsg := fmt.Sprintf("Could not detach volume %s from node %s: %v", diskURI, nodeID, err)
-			if len(errMsg) > maxErrMsgLength {
-				errMsg = errMsg[:maxErrMsgLength]
-			}
+			errMsg = truncateErrMsg(errMsg)
 			return nil, status.Errorf(codes.Internal, "%v", errMsg)
 		}
 	}

--- a/pkg/azuredisk/controllerserver_test.go
+++ b/pkg/azuredisk/controllerserver_test.go
@@ -5036,3 +5036,57 @@ func TestHasVolumeAttachmentForDiskOnNode(t *testing.T) {
 		})
 	}
 }
+
+func TestTruncateErrMsg(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantLen  int
+		wantHead string
+		wantTail string
+	}{
+		{
+			name:    "short message not truncated",
+			input:   "short error",
+			wantLen: len("short error"),
+		},
+		{
+			name:    "exactly at limit not truncated",
+			input:   strings.Repeat("a", maxErrMsgLength),
+			wantLen: maxErrMsgLength,
+		},
+		{
+			name:     "long message preserves head and tail",
+			input:    strings.Repeat("H", 500) + strings.Repeat("T", 600),
+			wantLen:  maxErrMsgLength,
+			wantHead: "HHHH",
+			wantTail: "TTTT",
+		},
+		{
+			name:     "permission error preserves critical tail",
+			input:    "Attach volume pvc-xxx to instance aks-node failed with PUT https://long-url/..." + strings.Repeat("x", 900) + "does not have permission to perform action 'Microsoft.Compute/diskEncryptionSets/read' on the linked scope",
+			wantLen:  maxErrMsgLength,
+			wantTail: "diskEncryptionSets/read' on the linked scope",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := truncateErrMsg(tc.input)
+			if len(result) > maxErrMsgLength {
+				t.Errorf("truncateErrMsg() length = %d, want <= %d", len(result), maxErrMsgLength)
+			}
+			if tc.wantLen > 0 && len(result) != tc.wantLen {
+				t.Errorf("truncateErrMsg() length = %d, want %d", len(result), tc.wantLen)
+			}
+			if tc.wantHead != "" && !strings.HasPrefix(result, tc.wantHead) {
+				t.Errorf("truncateErrMsg() should start with %q, got prefix %q", tc.wantHead, result[:20])
+			}
+			if tc.wantTail != "" && !strings.HasSuffix(result, tc.wantTail) {
+				t.Errorf("truncateErrMsg() should end with %q, got suffix %q", tc.wantTail, result[len(result)-50:])
+			}
+			if len(tc.input) > maxErrMsgLength && !strings.Contains(result, " ... ") {
+				t.Error("truncateErrMsg() should contain ellipsis for truncated messages")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it

When Azure ARM returns verbose error messages (e.g., `LinkedAuthorizationFailed` for DiskEncryptionSet permission issues), the critical information about which permission is missing appears at the **end** of the message. The current simple head-truncation (`errMsg[:990]`) always cuts off this critical tail, making it impossible for customers to identify the root cause from kube-events alone.

### Example

**Before (truncated, critical info lost):**
```
AttachVolume.Attach failed for volume "pvc-xxx" : rpc error: ... "message": "The client 'xxx' with object id 'yyy' has permission to perform action 'Microsoft.Compute/virtualMachineScaleSets/virtualMachine
```

**After (head + tail preserved):**
```
AttachVolume.Attach failed for volume "pvc-xxx" : rpc error: ... "The client 'xxx' with object id ... does not have permission to perform action(s) 'Microsoft.Compute/diskEncryptionSets/read' on the linked scope(s) '/subscriptions/.../diskEncryptionSets/des-xxx'
```

### Changes

- Introduces `truncateErrMsg()` helper that preserves both head (~40% for context) and tail (~60% for critical error details) with an ellipsis in the middle
- Applies to both `ControllerPublishVolume` (attach) and `ControllerUnpublishVolume` (detach) error paths
- Adds unit tests for the new helper

### Why not just increase the limit?

The Kubernetes API server enforces a hard 1024-byte limit on event messages ([`pkg/apis/core/validation/events.go#L38`](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/validation/events.go#L38)). The CSI driver pre-truncates to 990 bytes to account for kubelet-added prefixes. This PR works within that constraint while maximizing information density.

## Which issue(s) this PR fixes
Fixes customers being unable to identify missing RBAC permissions (e.g., `Microsoft.Compute/diskEncryptionSets/read`) from kube-events when using DiskEncryptionSets, because the critical tail of the error message is always truncated.
