### PR TITLE
chore(lockMap): for cancelling wait on ctx cancellation

### DIFF
--- a/pkg/azuredisk/azure_controller_common.go
+++ b/pkg/azuredisk/azure_controller_common.go
@@ -200,7 +200,7 @@ func (c *controllerCommon) AttachDisk(ctx context.Context, diskName, diskURI str
 	}
 	node := strings.ToLower(string(nodeName))
 	diskuri := strings.ToLower(diskURI)
-	requestNum, err := c.batchAttachDiskRequest(diskuri, node, &options)
+	requestNum, err := c.batchAttachDiskRequest(ctx, diskuri, node, &options)
 	if err != nil {
 		return -1, err
 	}
@@ -208,8 +208,8 @@ func (c *controllerCommon) AttachDisk(ctx context.Context, diskName, diskURI str
 	var waitForDetachHappened bool
 	if c.WaitForDetach && c.isMaxDataDiskCountExceeded(ctx, string(nodeName)) {
 		// wait for disk detach to finish first on the same node
-		if err = kwait.PollUntilContextTimeout(ctx, 2*time.Second, 30*time.Second, true, func(context.Context) (bool, error) {
-			detachDiskReqeustNum, err := c.getDetachDiskRequestNum(node)
+		if err = kwait.PollUntilContextTimeout(ctx, 2*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+			detachDiskReqeustNum, err := c.getDetachDiskRequestNum(ctx, node)
 			if err != nil {
 				return false, err
 			}
@@ -224,7 +224,9 @@ func (c *controllerCommon) AttachDisk(ctx context.Context, diskName, diskURI str
 		}
 	}
 
-	c.lockMap.LockEntry(node)
+	if err := c.lockMap.LockEntry(ctx, node); err != nil {
+		return -1, fmt.Errorf("AttachDisk: failed to acquire node lock for node %s: %w", nodeName, err)
+	}
 	defer c.lockMap.UnlockEntry(node)
 
 	if !waitForDetachHappened && c.AttachDetachInitialDelayInMs > 0 && requestNum == 1 {
@@ -254,7 +256,7 @@ func (c *controllerCommon) AttachDisk(ctx context.Context, diskName, diskURI str
 		}
 	}
 
-	diskMap, err := c.retrieveAttachBatchedDiskRequests(node, diskuri)
+	diskMap, err := c.retrieveAttachBatchedDiskRequests(ctx, node, diskuri)
 	if err != nil {
 		return -1, err
 	}
@@ -323,10 +325,12 @@ func (c *controllerCommon) AttachDisk(ctx context.Context, diskName, diskURI str
 }
 
 // insertAttachDiskRequest return (attachDiskRequestQueueLength, error)
-func (c *controllerCommon) batchAttachDiskRequest(diskURI, nodeName string, options *provider.AttachDiskOptions) (int, error) {
+func (c *controllerCommon) batchAttachDiskRequest(ctx context.Context, diskURI, nodeName string, options *provider.AttachDiskOptions) (int, error) {
 	var diskMap map[string]*provider.AttachDiskOptions
 	attachDiskMapKey := nodeName + attachDiskMapKeySuffix
-	c.lockMap.LockEntry(attachDiskMapKey)
+	if err := c.lockMap.LockEntry(ctx, attachDiskMapKey); err != nil {
+		return -1, fmt.Errorf("batchAttachDiskRequest: failed to lock attach disk map for node %s: %w", nodeName, err)
+	}
 	defer c.lockMap.UnlockEntry(attachDiskMapKey)
 	v, ok := c.attachDiskMap.Load(nodeName)
 	if ok {
@@ -349,11 +353,13 @@ func (c *controllerCommon) batchAttachDiskRequest(diskURI, nodeName string, opti
 
 // clean up attach disk requests
 // return original attach disk requests
-func (c *controllerCommon) retrieveAttachBatchedDiskRequests(nodeName, diskURI string) (map[string]*provider.AttachDiskOptions, error) {
+func (c *controllerCommon) retrieveAttachBatchedDiskRequests(ctx context.Context, nodeName, diskURI string) (map[string]*provider.AttachDiskOptions, error) {
 	var diskMap map[string]*provider.AttachDiskOptions
 
 	attachDiskMapKey := nodeName + attachDiskMapKeySuffix
-	c.lockMap.LockEntry(attachDiskMapKey)
+	if err := c.lockMap.LockEntry(ctx, attachDiskMapKey); err != nil {
+		return nil, fmt.Errorf("retrieveAttachBatchedDiskRequests: failed to lock attach disk map for node %s: %w", nodeName, err)
+	}
 	defer c.lockMap.UnlockEntry(attachDiskMapKey)
 	nodeAttachRequests, ok := c.attachDiskMap.Load(nodeName)
 	if !ok {
@@ -390,12 +396,14 @@ func (c *controllerCommon) DetachDisk(ctx context.Context, diskName, diskURI str
 
 	node := strings.ToLower(string(nodeName))
 	formattedDiskURI := strings.ToLower(diskURI)
-	batchCount, err := c.batchDetachDiskRequest(diskName, formattedDiskURI, node)
+	batchCount, err := c.batchDetachDiskRequest(ctx, diskName, formattedDiskURI, node)
 	if err != nil {
 		return err
 	}
 
-	c.lockMap.LockEntry(node)
+	if err := c.lockMap.LockEntry(ctx, node); err != nil {
+		return fmt.Errorf("DetachDisk: failed to acquire node lock for node %s: %w", nodeName, err)
+	}
 	defer c.lockMap.UnlockEntry(node)
 
 	if c.AttachDetachInitialDelayInMs > 0 && batchCount == 1 {
@@ -403,7 +411,7 @@ func (c *controllerCommon) DetachDisk(ctx context.Context, diskName, diskURI str
 		time.Sleep(time.Duration(c.AttachDetachInitialDelayInMs) * time.Millisecond)
 	}
 
-	diskMap, err := c.retrieveDetachBatchedDiskRequests(node, formattedDiskURI)
+	diskMap, err := c.retrieveDetachBatchedDiskRequests(ctx, node, formattedDiskURI)
 	if err != nil {
 		return err
 	}
@@ -497,7 +505,9 @@ func (c *controllerCommon) UpdateVM(ctx context.Context, nodeName types.NodeName
 		return err
 	}
 	node := strings.ToLower(string(nodeName))
-	c.lockMap.LockEntry(node)
+	if err := c.lockMap.LockEntry(ctx, node); err != nil {
+		return fmt.Errorf("UpdateVM: failed to acquire node lock for node %s: %w", nodeName, err)
+	}
 	defer c.lockMap.UnlockEntry(node)
 
 	defer func() {
@@ -558,10 +568,12 @@ func (c *controllerCommon) verifyAttach(ctx context.Context, diskName, diskURI s
 }
 
 // batchDetachDiskRequest return (detachDiskRequestQueueLength, error)
-func (c *controllerCommon) batchDetachDiskRequest(diskName, diskURI, nodeName string) (int, error) {
+func (c *controllerCommon) batchDetachDiskRequest(ctx context.Context, diskName, diskURI, nodeName string) (int, error) {
 	var diskMap map[string]string
 	detachDiskMapKey := nodeName + detachDiskMapKeySuffix
-	c.lockMap.LockEntry(detachDiskMapKey)
+	if err := c.lockMap.LockEntry(ctx, detachDiskMapKey); err != nil {
+		return -1, fmt.Errorf("batchDetachDiskRequest: failed to lock detach disk map for node %s: %w", nodeName, err)
+	}
 	defer c.lockMap.UnlockEntry(detachDiskMapKey)
 	nodeDetachRequests, ok := c.detachDiskMap.Load(nodeName)
 	if ok {
@@ -587,11 +599,13 @@ func (c *controllerCommon) batchDetachDiskRequest(diskName, diskURI, nodeName st
 
 // retrieveDetachBatchedDiskRequests removes the current detach disk requests for the node
 // and returns it for processing
-func (c *controllerCommon) retrieveDetachBatchedDiskRequests(nodeName, diskURI string) (map[string]string, error) {
+func (c *controllerCommon) retrieveDetachBatchedDiskRequests(ctx context.Context, nodeName, diskURI string) (map[string]string, error) {
 	var diskMap map[string]string
 
 	detachDiskMapKey := nodeName + detachDiskMapKeySuffix
-	c.lockMap.LockEntry(detachDiskMapKey)
+	if err := c.lockMap.LockEntry(ctx, detachDiskMapKey); err != nil {
+		return nil, fmt.Errorf("retrieveDetachBatchedDiskRequests: failed to lock detach disk map for node %s: %w", nodeName, err)
+	}
 	defer c.lockMap.UnlockEntry(detachDiskMapKey)
 
 	// load all detach disk requests for the node
@@ -611,9 +625,11 @@ func (c *controllerCommon) retrieveDetachBatchedDiskRequests(nodeName, diskURI s
 	return diskMap, nil
 }
 
-func (c *controllerCommon) getDetachDiskRequestNum(nodeName string) (int, error) {
+func (c *controllerCommon) getDetachDiskRequestNum(ctx context.Context, nodeName string) (int, error) {
 	detachDiskMapKey := nodeName + detachDiskMapKeySuffix
-	c.lockMap.LockEntry(detachDiskMapKey)
+	if err := c.lockMap.LockEntry(ctx, detachDiskMapKey); err != nil {
+		return -1, fmt.Errorf("getDetachDiskRequestNum: failed to lock detach disk map for node %s: %w", nodeName, err)
+	}
 	defer c.lockMap.UnlockEntry(detachDiskMapKey)
 	v, ok := c.detachDiskMap.Load(nodeName)
 	if !ok {

--- a/pkg/azuredisk/azure_controller_common_test.go
+++ b/pkg/azuredisk/azure_controller_common_test.go
@@ -1059,16 +1059,16 @@ func TestAttachDiskRequest(t *testing.T) {
 			diskURI := fmt.Sprintf("%s%d", test.diskURI, i)
 			diskName := fmt.Sprintf("%s%d", test.diskName, i)
 			ops := &provider.AttachDiskOptions{DiskName: diskName}
-			_, err := common.batchAttachDiskRequest(diskURI, test.nodeName, ops)
+			_, err := common.batchAttachDiskRequest(context.Background(), diskURI, test.nodeName, ops)
 			assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s", i, test.desc)
 			if test.duplicateDiskRequest {
-				_, err := common.batchAttachDiskRequest(diskURI, test.nodeName, ops)
+				_, err := common.batchAttachDiskRequest(context.Background(), diskURI, test.nodeName, ops)
 				assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s", i, test.desc)
 			}
 		}
 
 		diskURI := fmt.Sprintf("%s%d", test.diskURI, test.diskNum)
-		diskMap, err := common.retrieveAttachBatchedDiskRequests(test.nodeName, diskURI)
+		diskMap, err := common.retrieveAttachBatchedDiskRequests(context.Background(), test.nodeName, diskURI)
 		assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s", i, test.desc)
 		assert.Equal(t, test.diskNum, len(diskMap), "TestCase[%d]: %s", i, test.desc)
 		for diskURI, opt := range diskMap {
@@ -1136,15 +1136,15 @@ func TestDetachDiskRequest(t *testing.T) {
 		for i := 1; i <= test.diskNum; i++ {
 			diskURI = fmt.Sprintf("%s%d", test.diskURI, i)
 			diskName := fmt.Sprintf("%s%d", test.diskName, i)
-			_, err := common.batchDetachDiskRequest(diskName, diskURI, test.nodeName)
+			_, err := common.batchDetachDiskRequest(context.Background(), diskName, diskURI, test.nodeName)
 			assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s", i, test.desc)
 			if test.duplicateDiskRequest {
-				_, err := common.batchDetachDiskRequest(diskName, diskURI, test.nodeName)
+				_, err := common.batchDetachDiskRequest(context.Background(), diskName, diskURI, test.nodeName)
 				assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s", i, test.desc)
 			}
 		}
 
-		diskMap, err := common.retrieveDetachBatchedDiskRequests(test.nodeName, diskURI)
+		diskMap, err := common.retrieveDetachBatchedDiskRequests(context.Background(), test.nodeName, diskURI)
 		assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s", i, test.desc)
 		assert.Equal(t, test.diskNum, len(diskMap), "TestCase[%d]: %s", i, test.desc)
 		for diskURI, diskName := range diskMap {
@@ -1211,15 +1211,15 @@ func TestGetDetachDiskRequestNum(t *testing.T) {
 		for i := 1; i <= test.diskNum; i++ {
 			diskURI := fmt.Sprintf("%s%d", test.diskURI, i)
 			diskName := fmt.Sprintf("%s%d", test.diskName, i)
-			_, err := common.batchDetachDiskRequest(diskName, diskURI, test.nodeName)
+			_, err := common.batchDetachDiskRequest(context.Background(), diskName, diskURI, test.nodeName)
 			assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s", i, test.desc)
 			if test.duplicateDiskRequest {
-				_, err := common.batchDetachDiskRequest(diskName, diskURI, test.nodeName)
+				_, err := common.batchDetachDiskRequest(context.Background(), diskName, diskURI, test.nodeName)
 				assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s", i, test.desc)
 			}
 		}
 
-		detachDiskReqeustNum, err := common.getDetachDiskRequestNum(test.nodeName)
+		detachDiskReqeustNum, err := common.getDetachDiskRequestNum(context.Background(), test.nodeName)
 		assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s", i, test.desc)
 		assert.Equal(t, test.diskNum, detachDiskReqeustNum, "TestCase[%d]: %s", i, test.desc)
 	}

--- a/pkg/azuredisk/util.go
+++ b/pkg/azuredisk/util.go
@@ -16,42 +16,56 @@ limitations under the License.
 
 package azuredisk
 
-import "sync"
+import (
+	"context"
+	"fmt"
+	"sync"
 
-// lockMap used to lock on entries
+	"golang.org/x/sync/semaphore"
+)
+
+// lockMap used to lock on entries. Each entry is backed by a weighted
+// semaphore (capacity 1) so that LockEntry honors context cancellation and
+// timeouts, and waiters are granted the lock in FIFO order (fairness).
 type lockMap struct {
 	sync.Mutex
-	mutexMap map[string]*sync.Mutex
+	semMap map[string]*semaphore.Weighted
 }
 
-// NewLockMap returns a new lock map
+// newLockMap returns a new lock map
 func newLockMap() *lockMap {
 	return &lockMap{
-		mutexMap: make(map[string]*sync.Mutex),
+		semMap: make(map[string]*semaphore.Weighted),
 	}
 }
 
-// LockEntry acquires a lock associated with the specific entry
-func (lm *lockMap) LockEntry(entry string) {
+// LockEntry acquires a lock associated with the specific entry. It blocks until
+// the lock is acquired or ctx is done, returning ctx.Err() in the latter case.
+// UnlockEntry must only be called when LockEntry returns nil.
+func (lm *lockMap) LockEntry(ctx context.Context, entry string) error {
 	lm.Lock()
-	// check if entry does not exists, then add entry
-	mutex, exists := lm.mutexMap[entry]
+	// check if entry does not exist, then add entry
+	sem, exists := lm.semMap[entry]
 	if !exists {
-		mutex = &sync.Mutex{}
-		lm.mutexMap[entry] = mutex
+		sem = semaphore.NewWeighted(1)
+		lm.semMap[entry] = sem
 	}
 	lm.Unlock()
-	mutex.Lock()
+	if err := sem.Acquire(ctx, 1); err != nil {
+		return fmt.Errorf("failed to acquire lock for entry %q: %w", entry, err)
+	}
+	return nil
 }
 
-// UnlockEntry release the lock associated with the specific entry
+// UnlockEntry releases the lock associated with the specific entry. It must
+// only be called after a successful LockEntry for the same entry.
 func (lm *lockMap) UnlockEntry(entry string) {
 	lm.Lock()
-	defer lm.Unlock()
+	sem, exists := lm.semMap[entry]
+	lm.Unlock()
 
-	mutex, exists := lm.mutexMap[entry]
 	if !exists {
 		return
 	}
-	mutex.Unlock()
+	sem.Release(1)
 }

--- a/pkg/azuredisk/util_test.go
+++ b/pkg/azuredisk/util_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azuredisk
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLockMapLockUnlock verifies that LockEntry provides mutual exclusion for
+// the same entry, so concurrent critical sections do not race.
+func TestLockMapLockUnlock(t *testing.T) {
+	lm := newLockMap()
+	const goroutines = 20
+	const incrementsPerGoroutine = 100
+
+	var counter int
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < incrementsPerGoroutine; j++ {
+				err := lm.LockEntry(context.Background(), "entry")
+				if !assert.NoError(t, err, "LockEntry should succeed with a live context") {
+					continue
+				}
+				// non-atomic increment is safe only because the lock serializes access
+				counter++
+				lm.UnlockEntry("entry")
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, goroutines*incrementsPerGoroutine, counter, "lock should serialize all increments")
+}
+
+// TestLockMapDifferentEntriesDoNotBlock verifies that locks on different
+// entries are independent and do not block each other.
+func TestLockMapDifferentEntriesDoNotBlock(t *testing.T) {
+	lm := newLockMap()
+
+	if !assert.NoError(t, lm.LockEntry(context.Background(), "entry-a")) {
+		return
+	}
+	defer lm.UnlockEntry("entry-a")
+
+	// A different entry must be acquirable even though entry-a is held.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := lm.LockEntry(ctx, "entry-b")
+	assert.NoError(t, err, "a different entry should not be blocked by entry-a")
+	lm.UnlockEntry("entry-b")
+}
+
+// TestLockMapContextTimeout verifies that LockEntry propagates the context
+// error when the entry is already held, and that a failed acquire leaves the
+// entry free (our code must not mark it held on error).
+func TestLockMapContextTimeout(t *testing.T) {
+	lm := newLockMap()
+
+	// Hold the entry so the next acquire must block and then fail.
+	assert.NoError(t, lm.LockEntry(context.Background(), "entry"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	err := lm.LockEntry(ctx, "entry")
+	assert.ErrorIs(t, err, context.DeadlineExceeded, "blocked LockEntry should return the context error on timeout")
+
+	// The failed acquire must not have taken the entry. After the holder
+	// releases, the entry must be immediately acquirable again.
+	lm.UnlockEntry("entry")
+	assert.NoError(t, lm.LockEntry(context.Background(), "entry"), "entry should be free after the holder releases")
+	lm.UnlockEntry("entry")
+}
+
+// TestLockMapCanceledContext verifies that LockEntry returns the context error
+// when the context is already canceled, and leaves the entry free.
+func TestLockMapCanceledContext(t *testing.T) {
+	lm := newLockMap()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := lm.LockEntry(ctx, "entry")
+	assert.ErrorIs(t, err, context.Canceled, "LockEntry should return the context error for an already-canceled context")
+
+	// Even though acquisition failed, the entry must remain free.
+	assert.NoError(t, lm.LockEntry(context.Background(), "entry"), "entry should still be acquirable after a canceled acquire")
+	lm.UnlockEntry("entry")
+}

--- a/vendor/golang.org/x/sync/semaphore/semaphore.go
+++ b/vendor/golang.org/x/sync/semaphore/semaphore.go
@@ -1,0 +1,160 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package semaphore provides a weighted semaphore implementation.
+package semaphore // import "golang.org/x/sync/semaphore"
+
+import (
+	"container/list"
+	"context"
+	"sync"
+)
+
+type waiter struct {
+	n     int64
+	ready chan<- struct{} // Closed when semaphore acquired.
+}
+
+// NewWeighted creates a new weighted semaphore with the given
+// maximum combined weight for concurrent access.
+func NewWeighted(n int64) *Weighted {
+	w := &Weighted{size: n}
+	return w
+}
+
+// Weighted provides a way to bound concurrent access to a resource.
+// The callers can request access with a given weight.
+type Weighted struct {
+	size    int64
+	cur     int64
+	mu      sync.Mutex
+	waiters list.List
+}
+
+// Acquire acquires the semaphore with a weight of n, blocking until resources
+// are available or ctx is done. On success, returns nil. On failure, returns
+// ctx.Err() and leaves the semaphore unchanged.
+func (s *Weighted) Acquire(ctx context.Context, n int64) error {
+	done := ctx.Done()
+
+	s.mu.Lock()
+	select {
+	case <-done:
+		// ctx becoming done has "happened before" acquiring the semaphore,
+		// whether it became done before the call began or while we were
+		// waiting for the mutex. We prefer to fail even if we could acquire
+		// the mutex without blocking.
+		s.mu.Unlock()
+		return ctx.Err()
+	default:
+	}
+	if s.size-s.cur >= n && s.waiters.Len() == 0 {
+		// Since we hold s.mu and haven't synchronized since checking done, if
+		// ctx becomes done before we return here, it becoming done must have
+		// "happened concurrently" with this call - it cannot "happen before"
+		// we return in this branch. So, we're ok to always acquire here.
+		s.cur += n
+		s.mu.Unlock()
+		return nil
+	}
+
+	if n > s.size {
+		// Don't make other Acquire calls block on one that's doomed to fail.
+		s.mu.Unlock()
+		<-done
+		return ctx.Err()
+	}
+
+	ready := make(chan struct{})
+	w := waiter{n: n, ready: ready}
+	elem := s.waiters.PushBack(w)
+	s.mu.Unlock()
+
+	select {
+	case <-done:
+		s.mu.Lock()
+		select {
+		case <-ready:
+			// Acquired the semaphore after we were canceled.
+			// Pretend we didn't and put the tokens back.
+			s.cur -= n
+			s.notifyWaiters()
+		default:
+			isFront := s.waiters.Front() == elem
+			s.waiters.Remove(elem)
+			// If we're at the front and there are extra tokens left, notify other waiters.
+			if isFront && s.size > s.cur {
+				s.notifyWaiters()
+			}
+		}
+		s.mu.Unlock()
+		return ctx.Err()
+
+	case <-ready:
+		// Acquired the semaphore. Check that ctx isn't already done.
+		// We check the done channel instead of calling ctx.Err because we
+		// already have the channel, and ctx.Err is O(n) with the nesting
+		// depth of ctx.
+		select {
+		case <-done:
+			s.Release(n)
+			return ctx.Err()
+		default:
+		}
+		return nil
+	}
+}
+
+// TryAcquire acquires the semaphore with a weight of n without blocking.
+// On success, returns true. On failure, returns false and leaves the semaphore unchanged.
+func (s *Weighted) TryAcquire(n int64) bool {
+	s.mu.Lock()
+	success := s.size-s.cur >= n && s.waiters.Len() == 0
+	if success {
+		s.cur += n
+	}
+	s.mu.Unlock()
+	return success
+}
+
+// Release releases the semaphore with a weight of n.
+func (s *Weighted) Release(n int64) {
+	s.mu.Lock()
+	s.cur -= n
+	if s.cur < 0 {
+		s.mu.Unlock()
+		panic("semaphore: released more than held")
+	}
+	s.notifyWaiters()
+	s.mu.Unlock()
+}
+
+func (s *Weighted) notifyWaiters() {
+	for {
+		next := s.waiters.Front()
+		if next == nil {
+			break // No more waiters blocked.
+		}
+
+		w := next.Value.(waiter)
+		if s.size-s.cur < w.n {
+			// Not enough tokens for the next waiter. We could keep going (to try to
+			// find a waiter with a smaller request), but under load that could cause
+			// starvation for large requests; instead, we leave all remaining waiters
+			// blocked.
+			//
+			// Consider a semaphore used as a read-write lock, with N tokens, N
+			// readers, and one writer. Each reader can Acquire(1) to obtain a read
+			// lock. The writer can Acquire(N) to obtain a write lock, excluding all
+			// of the readers. If we allow the readers to jump ahead in the queue,
+			// the writer will starve — there is always one token available for every
+			// reader.
+			break
+		}
+
+		s.cur += w.n
+		s.waiters.Remove(next)
+		close(w.ready)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -590,6 +590,7 @@ golang.org/x/oauth2/internal
 # golang.org/x/sync v0.21.0
 ## explicit; go 1.25.0
 golang.org/x/sync/errgroup
+golang.org/x/sync/semaphore
 golang.org/x/sync/singleflight
 # golang.org/x/sys v0.46.0
 ## explicit; go 1.25.0


### PR DESCRIPTION

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR swaps to using `sync.Semaphore` instead of `sync.Mutex` to cancel waiting if context expires. `sync.Semaphore` and `sync.Mutex` have similar fairness mechanisms. This prevents requests from hanging on mutex while context has actually already expired and no progress will be possible when calling any method that requires a non-cancelled mutex.


**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
