### PR TITLE
test: reduce WINDOWS_WORKER_MACHINE_COUNT to 2 for CI stability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ CSI_IMAGE_TAG_LATEST = $(REGISTRY)/$(IMAGE_NAME):latest
 REV = $(shell git describe --long --tags --dirty)
 BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 ENABLE_TOPOLOGY ?= false
+WINDOWS_WORKER_MACHINE_COUNT ?= 2
+export WINDOWS_WORKER_MACHINE_COUNT
 LDFLAGS ?= "-X ${PKG}/pkg/azuredisk.driverVersion=${IMAGE_VERSION} -X ${PKG}/pkg/azuredisk.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/azuredisk.buildDate=${BUILD_DATE} -extldflags "-static"" ${GOTAGS}
 E2E_HELM_OPTIONS ?= --set image.azuredisk.repository=$(REGISTRY)/$(IMAGE_NAME) --set image.azuredisk.tag=$(IMAGE_VERSION) --set image.azuredisk.pullPolicy=Always --set driver.userAgentSuffix="e2e-test" --set snapshot.VolumeSnapshotClass.enabled=true --set snapshot.enabled=true --set node.getNodeIDFromIMDS=true --set controller.runOnControlPlane=true --set controller.replicas=1 --set snapshot.snapshotController.replicas=1
 E2E_HELM_OPTIONS += ${EXTRA_HELM_OPTIONS}


### PR DESCRIPTION
## What this PR does

Export `WINDOWS_WORKER_MACHINE_COUNT=2` from the Makefile so CAPZ's `ci-entrypoint.sh` only waits for 2 Windows nodes instead of 3.

## Problem

The Windows E2E CI job (`pull-azuredisk-csi-driver-e2e-capz-windows-2022-hostprocess`) frequently times out waiting for 3 Windows nodes to become Ready. When a single VM fails to provision (Azure VMSS flake), the entire 30-minute `wait_for_nodes` timeout expires and the test suite never runs.

Example failure: only 2/3 Windows nodes joined the cluster, the 3rd never provisioned (DNS resolution failed), and the job exited with code 124 (timeout).

## Fix

Set `WINDOWS_WORKER_MACHINE_COUNT=2` as the default in the Makefile. This:
1. Reduces the number of Windows nodes CAPZ waits for from 3 to 2
2. Allows tests to start running even if one Windows VM fails to provision
3. Tests that need multiple nodes already skip gracefully (`ginkgo.Skip`)
4. Can still be overridden via environment variable if 3 nodes are needed

## How it works

CAPZ's `ci-entrypoint.sh` reads `WINDOWS_WORKER_MACHINE_COUNT` (default 2) to determine:
- How many Windows nodes to create in the MachineDeployment
- How many nodes to wait for in `wait_for_nodes()` (30 min timeout)
