### PR TITLE
cleanup: remove unnecessary logs

### DIFF
--- a/pkg/azuredisk/migration_monitor.go
+++ b/pkg/azuredisk/migration_monitor.go
@@ -657,6 +657,8 @@ func (d *Driver) recoverMigrationMonitorsFromLabels(ctx context.Context) error {
 		}
 	}
 
-	klog.V(4).Infof("Recovered %d migration monitors from labels", recoveredCount)
+	if recoveredCount > 0 {
+		klog.V(4).Infof("Recovered %d migration monitors from labels", recoveredCount)
+	}
 	return nil
 }


### PR DESCRIPTION
Skip logging "Recovered 0 migration monitors from labels" when no monitors are actually recovered. This avoids noisy repeated log lines on every reconcile iteration when there is nothing to recover.

```
I0626 07:33:20.879000       1 migration_monitor.go:660] Recovered 0 migration monitors from labels
I0626 07:33:23.069354       1 migration_monitor.go:660] Recovered 0 migration monitors from labels
I0626 07:43:20.941653       1 migration_monitor.go:660] Recovered 0 migration monitors from labels
I0626 07:43:23.125033       1 migration_monitor.go:660] Recovered 0 migration monitors from labels
I0626 07:53:21.005585       1 migration_monitor.go:660] Recovered 0 migration monitors from labels
I0626 07:53:23.175792       1 migration_monitor.go:660] Recovered 0 migration monitors from labels
I0626 08:03:21.053565       1 migration_monitor.go:660] Recovered 0 migration monitors from labels
I0626 08:03:23.211529       1 migration_monitor.go:660] Recovered 0 migration monitors from labels
I0626 08:13:21.109236       1 migration_monitor.go:660] Recovered 0 migration monitors from labels
I0626 08:13:23.261446       1 migration_monitor.go:660] Recovered 0 migration monitors from labels
```

The log is only useful when monitors are actually recovered, so gate it behind `recoveredCount > 0`.