### PR TITLE
[WIP]feat: sdk call to check VM exist during DetachDisk

### DIFF
--- a/pkg/azuredisk/azure_controller_common.go
+++ b/pkg/azuredisk/azure_controller_common.go
@@ -88,6 +88,12 @@ var defaultBackOff = kwait.Backoff{
 	Jitter:   0.0,
 }
 
+// errDiskAlreadyDetached signals that a fresh disk read authoritatively confirmed the
+// disk is not attached to any VM (ManagedBy and ManagedByExtended are empty) or the
+// disk no longer exists. In these cases DetachDisk can return immediately without
+// polling waitForDiskManagedByTobeRemoved, since there is no stale ManagedBy to clear.
+var errDiskAlreadyDetached = errors.New("disk already detached")
+
 type controllerCommon struct {
 	diskStateMap  sync.Map // <diskURI, attaching/detaching state>
 	lockMap       *lockMap
@@ -386,10 +392,17 @@ func (c *controllerCommon) retrieveAttachBatchedDiskRequests(ctx context.Context
 
 // DetachDisk detaches a disk from VM
 func (c *controllerCommon) DetachDisk(ctx context.Context, diskName, diskURI string, nodeName types.NodeName) error {
-	if _, err := c.cloud.InstanceID(ctx, nodeName); err != nil {
+	if err := c.verifyInstanceForDetach(ctx, diskURI, nodeName); err != nil {
+		if errors.Is(err, errDiskAlreadyDetached) {
+			// a fresh disk read already confirmed the disk is detached (disk gone or
+			// ManagedBy/ManagedByExtended empty), so there is no stale ManagedBy to wait on.
+			klog.V(2).Infof("azureDisk - DetachDisk(%s) confirmed disk already detached from node %s, skip wait", diskURI, nodeName)
+			return nil
+		}
 		if errors.Is(err, cloudprovider.InstanceNotFound) {
-			// if host doesn't exist, no need to detach
-			klog.Warningf("azureDisk - failed to get azure instance id(%s), DetachDisk(%s) will assume disk is already detached",
+			// the instance is gone, but the disk may still carry a stale ManagedBy that
+			// takes a while to clear, so wait for it to be removed before assuming detached.
+			klog.Warningf("azureDisk - azure instance id(%s) not found, DetachDisk(%s) will assume disk is already detached",
 				nodeName, diskURI)
 			return c.waitForDiskManagedByTobeRemoved(ctx, diskURI, nodeName)
 		}
@@ -659,6 +672,24 @@ func (c *controllerCommon) GetNodeDataDisks(ctx context.Context, nodeName types.
 	return vmset.GetDataDisks(ctx, nodeName, crt)
 }
 
+// GetDiskByURI gets the managed disk identified by diskURI.
+func (c *controllerCommon) GetDiskByURI(ctx context.Context, diskURI string) (*armcompute.Disk, error) {
+	subsID, resourceGroup, diskName, err := azureutils.GetInfoFromURI(diskURI)
+	if err != nil {
+		return nil, err
+	}
+	return c.GetDisk(ctx, subsID, resourceGroup, diskName)
+}
+
+// GetDisk gets the managed disk identified by subsID, resourceGroup and diskName.
+func (c *controllerCommon) GetDisk(ctx context.Context, subsID, resourceGroup, diskName string) (*armcompute.Disk, error) {
+	diskclient, err := c.clientFactory.GetDiskClientForSub(subsID)
+	if err != nil {
+		return nil, err
+	}
+	return diskclient.Get(ctx, resourceGroup, diskName)
+}
+
 // GetDiskLun finds the lun on the host that the vhd is attached to, given a vhd's diskName and diskURI.
 func (c *controllerCommon) GetDiskLun(ctx context.Context, diskName, diskURI string, nodeName types.NodeName) (int32, *string, error) {
 	// GetNodeDataDisks need to fetch the cached data/fresh data if cache expired here
@@ -791,6 +822,11 @@ func (c *controllerCommon) waitForDiskManagedByTobeRemoved(ctx context.Context, 
 		}
 		disk, err = diskclient.Get(ctx, resourceGroup, diskName)
 		if err != nil {
+			if isInstanceNotFoundError(err) {
+				// the disk resource itself is gone, so it is fully detached.
+				klog.V(2).Infof("azureDisk - disk %s not found, assuming detached", diskURI)
+				return true, nil
+			}
 			return false, fmt.Errorf("error getting disk: %w", err)
 		}
 
@@ -818,6 +854,151 @@ func (c *controllerCommon) waitForDiskManagedByTobeRemoved(ctx context.Context, 
 		klog.Errorf("error in - waitForDiskManagedByTobeRemoved, disk %s still has ManagedBy (VM resource ID) %s", diskURI, *disk.ManagedBy)
 	}
 	return err
+}
+
+// vmResourceInfo captures the VM identity parsed from a node's providerID.
+type vmResourceInfo struct {
+	resourceGroup string
+	// vmssName is non-empty only for VMSS uniform instances.
+	vmssName string
+	// name is the VM resource name for standalone/flex VMs, or the instance ID for VMSS uniform instances.
+	name string
+}
+
+// parseProviderID extracts the VM resource identity from a node providerID.
+// Supported forms:
+//
+//	VMSS uniform:    azure:///subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmss}/virtualMachines/{instanceID}
+//	standalone/flex: azure:///subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Compute/virtualMachines/{name}
+func parseProviderID(providerID string) (*vmResourceInfo, error) {
+	resourceID := strings.TrimPrefix(providerID, "azure://")
+	parts := strings.Split(strings.Trim(resourceID, "/"), "/")
+	if len(parts) < 8 || !strings.EqualFold(parts[0], "subscriptions") || !strings.EqualFold(parts[2], "resourceGroups") || !strings.EqualFold(parts[4], "providers") {
+		return nil, fmt.Errorf("unexpected providerID format: %q", providerID)
+	}
+	resourceGroup := parts[3]
+	switch {
+	case len(parts) >= 10 && strings.EqualFold(parts[6], "virtualMachineScaleSets") && strings.EqualFold(parts[8], "virtualMachines"):
+		return &vmResourceInfo{resourceGroup: resourceGroup, vmssName: parts[7], name: parts[9]}, nil
+	case strings.EqualFold(parts[6], "virtualMachines"):
+		return &vmResourceInfo{resourceGroup: resourceGroup, name: parts[7]}, nil
+	default:
+		return nil, fmt.Errorf("unsupported resource type in providerID: %q", providerID)
+	}
+}
+
+// getNodeProviderID returns the spec.providerID of the given node from the Kubernetes API.
+func (c *controllerCommon) getNodeProviderID(ctx context.Context, nodeName string) (string, error) {
+	node, err := getNode(ctx, nodeName, c.cloud.KubeClient)
+	if err != nil {
+		return "", err
+	}
+	return node.Spec.ProviderID, nil
+}
+
+// verifyInstanceForDetach reports whether DetachDisk still needs to perform a detach
+// for (diskURI, nodeName). It returns:
+//   - nil when the disk should be detached from a live VM;
+//   - errDiskAlreadyDetached when a fresh disk read authoritatively confirms the disk
+//     is already detached (disk not found, or ManagedBy and ManagedByExtended both
+//     empty), so DetachDisk can return immediately without waiting;
+//   - cloudprovider.InstanceNotFound when the backing VM no longer exists but the disk
+//     may still carry a stale ManagedBy, so DetachDisk should wait for it to clear.
+//
+// For pure VMSS-uniform clusters (availability-set and VMSS-flex nodes disabled),
+// cloud.InstanceID is cache-backed and never triggers the subscription-wide VM List,
+// so it is used directly as the cheapest check. Otherwise it resolves the VM from the
+// node's providerID and issues a targeted GET, avoiding the subscription-wide VM List
+// that cloud.InstanceID may trigger via getVMManagementTypeByNodeName. When the node's
+// providerID is unavailable (e.g. the Node object was already deleted after the VM was
+// removed), it falls back to the disk's ManagedBy (authoritative Azure attachment
+// state), which is still List-free. Only when neither the providerID nor the disk can
+// be read does it fall back to cloud.InstanceID.
+func (c *controllerCommon) verifyInstanceForDetach(ctx context.Context, diskURI string, nodeName types.NodeName) error {
+	// Pure VMSS-uniform cluster: InstanceID is cache-backed and never lists VMs
+	// subscription-wide (getVMManagementTypeByNodeName short-circuits), so it is the
+	// cheapest option in the common case.
+	if c.cloud.DisableAvailabilitySetNodes && !c.cloud.EnableVmssFlexNodes {
+		_, err := c.cloud.InstanceID(ctx, nodeName)
+		return err
+	}
+
+	// Fast path: resolve the VM from the node's providerID (no ARM list, no disk GET).
+	providerID, nodeErr := c.getNodeProviderID(ctx, string(nodeName))
+	if nodeErr == nil && providerID != "" {
+		info, parseErr := parseProviderID(providerID)
+		if parseErr == nil {
+			return c.instanceExistsByResourceInfo(ctx, info)
+		}
+		klog.V(2).Infof("verifyInstanceForDetach: cannot parse providerID %q of node %s: %v", providerID, nodeName, parseErr)
+	} else {
+		klog.V(2).Infof("verifyInstanceForDetach: providerID unavailable for node %s: %v", nodeName, nodeErr)
+	}
+
+	// Fallback: the node/providerID is unavailable (e.g. the Node object was already
+	// deleted). Use the disk's ManagedBy/ManagedByExtended (authoritative attachment
+	// state) to decide, still avoiding a subscription-wide VM List.
+	disk, err := c.GetDiskByURI(ctx, diskURI)
+	if err != nil {
+		if isInstanceNotFoundError(err) {
+			// the disk resource itself no longer exists, so there is nothing to detach
+			// and nothing to wait on.
+			klog.V(2).Infof("verifyInstanceForDetach: disk %s not found, no detach needed for node %s", diskURI, nodeName)
+			return errDiskAlreadyDetached
+		}
+		klog.V(2).Infof("verifyInstanceForDetach: failed to get disk %s (err: %v), falling back to InstanceID for node %s", diskURI, err, nodeName)
+		_, idErr := c.cloud.InstanceID(ctx, nodeName)
+		return idErr
+	}
+	if disk == nil {
+		klog.V(2).Infof("verifyInstanceForDetach: disk %s returned nil, falling back to InstanceID for node %s", diskURI, nodeName)
+		_, idErr := c.cloud.InstanceID(ctx, nodeName)
+		return idErr
+	}
+	// ManagedBy covers non-shared disks; ManagedByExtended covers shared disks
+	// (maxShares > 1) that can be attached to multiple VMs.
+	if disk.ManagedBy == nil && len(disk.ManagedByExtended) == 0 {
+		// the disk is not attached to any VM (authoritative), so there is nothing to
+		// detach and nothing to wait on.
+		klog.V(2).Infof("verifyInstanceForDetach: disk %s is not attached to any VM, no detach needed for node %s", diskURI, nodeName)
+		return errDiskAlreadyDetached
+	}
+	managedByID := disk.ManagedBy
+	if managedByID == nil && len(disk.ManagedByExtended) > 0 {
+		managedByID = disk.ManagedByExtended[0]
+	}
+	if managedByID == nil {
+		return errDiskAlreadyDetached
+	}
+	info, err := parseProviderID(*managedByID)
+	if err != nil {
+		klog.V(2).Infof("verifyInstanceForDetach: cannot parse disk.ManagedBy %q (err: %v), falling back to InstanceID for node %s", *managedByID, err, nodeName)
+		_, idErr := c.cloud.InstanceID(ctx, nodeName)
+		return idErr
+	}
+	return c.instanceExistsByResourceInfo(ctx, info)
+}
+
+// instanceExistsByResourceInfo issues a targeted GET for the VM identified by info,
+// mapping a 404 (or equivalent) to cloudprovider.InstanceNotFound.
+func (c *controllerCommon) instanceExistsByResourceInfo(ctx context.Context, info *vmResourceInfo) error {
+	if info.vmssName != "" {
+		if _, err := c.clientFactory.GetVirtualMachineScaleSetVMClient().Get(ctx, info.resourceGroup, info.vmssName, info.name); err != nil {
+			if isInstanceNotFoundError(err) {
+				return cloudprovider.InstanceNotFound
+			}
+			return err
+		}
+		return nil
+	}
+
+	if _, err := c.clientFactory.GetVirtualMachineClient().Get(ctx, info.resourceGroup, info.name, nil); err != nil {
+		if isInstanceNotFoundError(err) {
+			return cloudprovider.InstanceNotFound
+		}
+		return err
+	}
+	return nil
 }
 
 func getValidCreationData(subscriptionID, resourceGroup string, options *ManagedDiskOptions) (armcompute.CreationData, error) {

--- a/pkg/azuredisk/azure_controller_common_test.go
+++ b/pkg/azuredisk/azure_controller_common_test.go
@@ -35,16 +35,20 @@ import (
 	autorestmocks "github.com/Azure/go-autorest/autorest/mocks"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 
+	"k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/azureconstants"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/diskclient/mock_diskclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/mock_azclient"
 	mockvmclient "sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachineclient/mock_virtualmachineclient"
+	mockvmssvmclient "sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachinescalesetvmclient/mock_virtualmachinescalesetvmclient"
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/provider"
@@ -338,6 +342,15 @@ func TestForceDetach(t *testing.T) {
 				clientFactory:                      testCloud.ComputeClientFactory,
 			}
 
+			// Provide the node's providerID so verifyInstanceForDetach uses the targeted
+			// VM GET fast path (avoiding the disk-based fallback).
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: string(test.nodeName)},
+				Spec: corev1.NodeSpec{ProviderID: fmt.Sprintf("azure:///subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s",
+					testCloud.SubscriptionID, testCloud.ResourceGroup, test.nodeName)},
+			}
+			testCloud.KubeClient = fake.NewSimpleClientset(node)
+
 			diskURI := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/%s",
 				testCloud.SubscriptionID, testCloud.ResourceGroup, test.diskName)
 
@@ -465,6 +478,14 @@ func TestCommonDetachDisk(t *testing.T) {
 			DetachOperationMinTimeoutInSeconds: 2,
 			clientFactory:                      testCloud.ComputeClientFactory,
 		}
+		// Provide the node's providerID so verifyInstanceForDetach uses the targeted
+		// VM GET fast path (avoiding the disk-based fallback).
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: string(test.nodeName)},
+			Spec: corev1.NodeSpec{ProviderID: fmt.Sprintf("azure:///subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s",
+				testCloud.SubscriptionID, testCloud.ResourceGroup, test.nodeName)},
+		}
+		testCloud.KubeClient = fake.NewSimpleClientset(node)
 		diskURI := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/disk-name",
 			testCloud.SubscriptionID, testCloud.ResourceGroup)
 		expectedVMs := setTestVirtualMachines(testCloud, test.vmList, false)
@@ -485,6 +506,303 @@ func TestCommonDetachDisk(t *testing.T) {
 
 		err := common.DetachDisk(ctx, test.diskName, diskURI, test.nodeName)
 		assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s, err: %v", i, test.desc, err)
+	}
+}
+
+func TestParseProviderID(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		providerID    string
+		expectErr     bool
+		resourceGroup string
+		vmssName      string
+		name          string
+	}{
+		{
+			desc:          "standalone/flex VM providerID",
+			providerID:    "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1",
+			resourceGroup: "rg",
+			name:          "vm1",
+		},
+		{
+			desc:          "VMSS uniform providerID",
+			providerID:    "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
+			resourceGroup: "rg",
+			vmssName:      "vmss",
+			name:          "0",
+		},
+		{
+			desc:          "providerID without azure scheme prefix",
+			providerID:    "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1",
+			resourceGroup: "rg",
+			name:          "vm1",
+		},
+		{
+			desc:       "empty providerID",
+			providerID: "",
+			expectErr:  true,
+		},
+		{
+			desc:       "malformed providerID",
+			providerID: "azure:///subscriptions/sub/foo/bar",
+			expectErr:  true,
+		},
+		{
+			desc:       "unsupported resource type",
+			providerID: "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/disks/disk1",
+			expectErr:  true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			info, err := parseProviderID(test.providerID)
+			if test.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, test.resourceGroup, info.resourceGroup)
+			assert.Equal(t, test.vmssName, info.vmssName)
+			assert.Equal(t, test.name, info.name)
+		})
+	}
+}
+
+func TestVerifyInstanceForDetach(t *testing.T) {
+	notFoundErr := &azcore.ResponseError{StatusCode: http.StatusNotFound}
+
+	testCases := []struct {
+		desc           string
+		nodeName       types.NodeName
+		providerID     string
+		hasNode        bool
+		getErr         error
+		expectNotFound bool
+		expectErr      bool
+	}{
+		{
+			desc:       "standalone VM exists via targeted GET",
+			nodeName:   "vm1",
+			providerID: "azure:///subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1",
+			hasNode:    true,
+		},
+		{
+			desc:           "standalone VM not found via targeted GET",
+			nodeName:       "vm1",
+			providerID:     "azure:///subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1",
+			hasNode:        true,
+			getErr:         notFoundErr,
+			expectNotFound: true,
+		},
+		{
+			desc:       "VMSS uniform instance exists via targeted GET",
+			nodeName:   "vmss000000",
+			providerID: "azure:///subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
+			hasNode:    true,
+		},
+		{
+			desc:           "VMSS uniform instance not found via targeted GET",
+			nodeName:       "vmss000000",
+			providerID:     "azure:///subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
+			hasNode:        true,
+			getErr:         notFoundErr,
+			expectNotFound: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			testCloud := provider.GetTestCloud(ctrl)
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: string(test.nodeName)},
+				Spec:       corev1.NodeSpec{ProviderID: test.providerID},
+			}
+			testCloud.KubeClient = fake.NewSimpleClientset(node)
+
+			info, err := parseProviderID(test.providerID)
+			assert.NoError(t, err)
+			if info.vmssName != "" {
+				mockVMSSVMClient := testCloud.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mockvmssvmclient.MockInterface)
+				mockVMSSVMClient.EXPECT().Get(gomock.Any(), info.resourceGroup, info.vmssName, info.name).
+					Return(&armcompute.VirtualMachineScaleSetVM{}, test.getErr).AnyTimes()
+			} else {
+				mockVMClient := testCloud.ComputeClientFactory.GetVirtualMachineClient().(*mockvmclient.MockInterface)
+				mockVMClient.EXPECT().Get(gomock.Any(), info.resourceGroup, info.name, gomock.Any()).
+					Return(&armcompute.VirtualMachine{}, test.getErr).AnyTimes()
+			}
+
+			common := &controllerCommon{
+				cloud:         testCloud,
+				lockMap:       newLockMap(),
+				clientFactory: testCloud.ComputeClientFactory,
+			}
+
+			diskURI := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/disk-name",
+				testCloud.SubscriptionID, testCloud.ResourceGroup)
+			err = common.verifyInstanceForDetach(t.Context(), diskURI, test.nodeName)
+			if test.expectNotFound {
+				assert.ErrorIs(t, err, cloudprovider.InstanceNotFound)
+				return
+			}
+			if test.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestVerifyInstanceForDetachDiskFallback covers the fallback path taken when the
+// node's providerID is unavailable (e.g. the Node object was already deleted):
+// the decision is driven by the disk's ManagedBy, and cloud.InstanceID is only
+// used when the disk itself cannot be read or its ManagedBy cannot be parsed.
+func TestVerifyInstanceForDetachDiskFallback(t *testing.T) {
+	notFoundErr := &azcore.ResponseError{StatusCode: http.StatusNotFound}
+	standaloneManagedBy := "/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1"
+	unparseableManagedBy := "/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/disks/disk1"
+
+	testCases := []struct {
+		desc                  string
+		diskGetErr            error
+		managedBy             *string
+		vmGetErr              error
+		instanceIDErr         error
+		expectNotFound        bool
+		expectAlreadyDetached bool
+		expectErr             bool
+	}{
+		{
+			desc:       "disk get fails -> InstanceID fallback (exists)",
+			diskGetErr: errors.New("throttled"),
+		},
+		{
+			desc:                  "disk not found (404) -> already detached (nothing to detach)",
+			diskGetErr:            notFoundErr,
+			expectAlreadyDetached: true,
+		},
+		{
+			desc:                  "disk ManagedBy nil -> already detached",
+			managedBy:             nil,
+			expectAlreadyDetached: true,
+		},
+		{
+			desc:      "disk ManagedBy points to existing VM -> exists",
+			managedBy: &standaloneManagedBy,
+		},
+		{
+			desc:           "disk ManagedBy points to missing VM -> InstanceNotFound",
+			managedBy:      &standaloneManagedBy,
+			vmGetErr:       notFoundErr,
+			expectNotFound: true,
+		},
+		{
+			desc:           "disk ManagedBy unparseable -> InstanceID fallback (not found)",
+			managedBy:      &unparseableManagedBy,
+			instanceIDErr:  cloudprovider.InstanceNotFound,
+			expectNotFound: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			testCloud := provider.GetTestCloud(ctrl)
+			testCloud.UseInstanceMetadata = false
+			// KubeClient is nil in GetTestCloud, so getNodeProviderID fails and the
+			// disk-based fallback is exercised.
+
+			diskClient := mock_diskclient.NewMockInterface(ctrl)
+			testCloud.ComputeClientFactory.(*mock_azclient.MockClientFactory).EXPECT().GetDiskClientForSub(gomock.Any()).Return(diskClient, nil).AnyTimes()
+			diskClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&armcompute.Disk{ManagedBy: test.managedBy}, test.diskGetErr).AnyTimes()
+
+			mockVMClient := testCloud.ComputeClientFactory.GetVirtualMachineClient().(*mockvmclient.MockInterface)
+			mockVMClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&armcompute.VirtualMachine{}, test.vmGetErr).AnyTimes()
+
+			mockVMSet := provider.NewMockVMSet(ctrl)
+			testCloud.VMSet = mockVMSet
+			mockVMSet.EXPECT().GetInstanceIDByNodeName(gomock.Any(), gomock.Any()).Return("id", test.instanceIDErr).AnyTimes()
+
+			common := &controllerCommon{
+				cloud:         testCloud,
+				lockMap:       newLockMap(),
+				clientFactory: testCloud.ComputeClientFactory,
+			}
+
+			diskURI := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/disk-name",
+				testCloud.SubscriptionID, testCloud.ResourceGroup)
+			err := common.verifyInstanceForDetach(t.Context(), diskURI, "vm1")
+			if test.expectAlreadyDetached {
+				assert.ErrorIs(t, err, errDiskAlreadyDetached)
+				return
+			}
+			if test.expectNotFound {
+				assert.ErrorIs(t, err, cloudprovider.InstanceNotFound)
+				return
+			}
+			if test.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestVerifyInstanceForDetachVMSSUniform covers the pure VMSS-uniform fast path
+// (DisableAvailabilitySetNodes && !EnableVmssFlexNodes), where cloud.InstanceID is
+// used directly instead of the providerID/disk targeted GET path.
+func TestVerifyInstanceForDetachVMSSUniform(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		instanceIDErr  error
+		expectNotFound bool
+	}{
+		{
+			desc: "vmss-uniform instance exists via InstanceID",
+		},
+		{
+			desc:           "vmss-uniform instance not found via InstanceID",
+			instanceIDErr:  cloudprovider.InstanceNotFound,
+			expectNotFound: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			testCloud := provider.GetTestCloud(ctrl)
+			testCloud.UseInstanceMetadata = false
+			testCloud.DisableAvailabilitySetNodes = true
+			testCloud.EnableVmssFlexNodes = false
+
+			mockVMSet := provider.NewMockVMSet(ctrl)
+			testCloud.VMSet = mockVMSet
+			mockVMSet.EXPECT().GetInstanceIDByNodeName(gomock.Any(), gomock.Any()).Return("id", test.instanceIDErr).AnyTimes()
+
+			common := &controllerCommon{
+				cloud:         testCloud,
+				lockMap:       newLockMap(),
+				clientFactory: testCloud.ComputeClientFactory,
+			}
+
+			diskURI := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/disk-name",
+				testCloud.SubscriptionID, testCloud.ResourceGroup)
+			err := common.verifyInstanceForDetach(t.Context(), diskURI, "vm1")
+			if test.expectNotFound {
+				assert.ErrorIs(t, err, cloudprovider.InstanceNotFound)
+				return
+			}
+			assert.NoError(t, err)
+		})
 	}
 }
 
@@ -1606,6 +1924,15 @@ func TestDetachDiskWithVMSSTimeoutConfiguration(t *testing.T) {
 			diskName := "disk1"
 			diskURI := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/%s",
 				testCloud.SubscriptionID, testCloud.ResourceGroup, diskName)
+
+			// Provide the node's providerID so verifyInstanceForDetach uses the targeted
+			// VM GET fast path and DetachDisk proceeds to the detach logic under test.
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "vm1"},
+				Spec: corev1.NodeSpec{ProviderID: fmt.Sprintf("azure:///subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/vm1",
+					testCloud.SubscriptionID, testCloud.ResourceGroup)},
+			}
+			testCloud.KubeClient = fake.NewSimpleClientset(node)
 
 			expectedVMs := setTestVirtualMachines(testCloud, map[string]string{"vm1": "PowerState/Running"}, false)
 			mockVMClient := testCloud.ComputeClientFactory.GetVirtualMachineClient().(*mockvmclient.MockInterface)

--- a/pkg/azuredisk/azure_managedDiskController.go
+++ b/pkg/azuredisk/azure_managedDiskController.go
@@ -374,22 +374,6 @@ func (c *ManagedDiskController) DeleteManagedDisk(ctx context.Context, diskURI s
 	return nil
 }
 
-func (c *ManagedDiskController) GetDiskByURI(ctx context.Context, diskURI string) (*armcompute.Disk, error) {
-	subsID, resourceGroup, diskName, err := azureutils.GetInfoFromURI(diskURI)
-	if err != nil {
-		return nil, err
-	}
-	return c.GetDisk(ctx, subsID, resourceGroup, diskName)
-}
-
-func (c *ManagedDiskController) GetDisk(ctx context.Context, subsID, resourceGroup, diskName string) (*armcompute.Disk, error) {
-	diskclient, err := c.clientFactory.GetDiskClientForSub(subsID)
-	if err != nil {
-		return nil, err
-	}
-	return diskclient.Get(ctx, resourceGroup, diskName)
-}
-
 // ResizeDisk Expand the disk to new size
 func (c *ManagedDiskController) ResizeDisk(ctx context.Context, diskURI string, oldSize resource.Quantity, newSize resource.Quantity, supportOnlineResize bool) (resource.Quantity, error) {
 	subsID, resourceGroup, diskName, err := azureutils.GetInfoFromURI(diskURI)

--- a/pkg/azuredisk/azuredisk.go
+++ b/pkg/azuredisk/azuredisk.go
@@ -756,15 +756,23 @@ func GetNodeInfoFromNodeLister(nodeName string, nodeLister cache.GenericLister) 
 	return zone, instanceType, nil
 }
 
-// GetNodeInfoFromLabels gets zone, instanceType from node labels via the kubeClient API server.
-func GetNodeInfoFromLabels(ctx context.Context, nodeName string, kubeClient clientset.Interface) (string, string, error) {
+// getNode returns the Kubernetes Node object for the given nodeName.
+func getNode(ctx context.Context, nodeName string, kubeClient clientset.Interface) (*corev1.Node, error) {
 	if kubeClient == nil || kubeClient.CoreV1() == nil {
-		return "", "", fmt.Errorf("kubeClient is nil")
+		return nil, fmt.Errorf("kubeClient is nil")
 	}
-
 	node, err := kubeClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {
-		return "", "", fmt.Errorf("get node(%s) failed with %v", nodeName, err)
+		return nil, fmt.Errorf("get node(%s) failed with %v", nodeName, err)
+	}
+	return node, nil
+}
+
+// GetNodeInfoFromLabels gets zone, instanceType from node labels via the kubeClient API server.
+func GetNodeInfoFromLabels(ctx context.Context, nodeName string, kubeClient clientset.Interface) (string, string, error) {
+	node, err := getNode(ctx, nodeName, kubeClient)
+	if err != nil {
+		return "", "", err
 	}
 
 	if len(node.Labels) == 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Replace the InstanceID pre-check in DetachDisk with a purpose-built verifyInstanceForDetach that decides whether a detach is still needed without triggering the subscription-wide ListVirtualMachines call that InstanceID can cause in mixed-VM-type clusters.

What changed:
DetachDisk used to call `c.cloud.InstanceID(ctx, nodeName)` purely as an existence check ("if the host is gone, skip detach"). It now calls `verifyInstanceForDetach(ctx, diskURI, nodeName)`, which resolves the answer in the cheapest List-free way available and returns cloudprovider.InstanceNotFound or errDiskAlreadyDetached when the detach can be skipped (VM gone or disk already detached).

Decision order:

- Pure VMSS-uniform cluster (DisableAvailabilitySetNodes && !EnableVmssFlexNodes) → call InstanceID directly. In this config getVMManagementTypeByNodeName short-circuits, so InstanceID is fully cache-backed and never lists.

- Otherwise, providerID fast path → read the node's `spec.providerID`, parse it, and issue a single targeted GET:
1.VMSS uniform → GetVirtualMachineScaleSetVMClient().Get(rg, vmss, instanceID)
2.standalone/flex → GetVirtualMachineClient().Get(rg, name)

- providerID unavailable (e.g. Node object already deleted after the VM was removed) → fetch the disk and use ManagedBy/ManagedByExtended (authoritative, List-free): both empty or disk not found ⇒ errDiskAlreadyDetached; otherwise targeted GET on the attached VM.

- Only if the disk can't be read / ManagedBy can't be parsed → fall back to InstanceID.


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
