### PR TITLE
docs: fix networkAccessPolicy and publicNetworkAccess default values in driver-parameters.md

### DIFF
--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -55,8 +55,8 @@ diskEncryptionSetID | ResourceId of the disk encryption set to use for [enabling
 diskEncryptionType | encryption type of the disk encryption set | `EncryptionAtRestWithCustomerKey`(by default), `EncryptionAtRestWithPlatformAndCustomerKeys` | No | ""
 writeAcceleratorEnabled | [Write Accelerator on Azure Disks](https://learn.microsoft.com/en-us/azure/virtual-machines/how-to-enable-write-accelerator) | `true`, `false` | No | ""
 perfProfile | [Block device performance tuning using perfProfiles](./perf-profiles.md) | `none`, `basic`, `advanced` | No | `none`
-networkAccessPolicy | NetworkAccessPolicy property to prevent anybody from generating the SAS URI for a disk or a snapshot | `AllowAll`, `DenyAll`, `AllowPrivate` | No | `AllowAll`
-publicNetworkAccess | Enabling or disabling public access to the underlying data of a disk on the internet, even when the NetworkAccessPolicy is set to `AllowAll` | `Enabled`, `Disabled` | No | `Enabled`
+networkAccessPolicy | NetworkAccessPolicy property to prevent anybody from generating the SAS URI for a disk or a snapshot | `AllowAll`, `DenyAll`, `AllowPrivate` | No | `DenyAll`
+publicNetworkAccess | Enabling or disabling public access to the underlying data of a disk on the internet, even when the NetworkAccessPolicy is set to `AllowAll` | `Enabled`, `Disabled` | No | `Disabled`
 diskAccessID | ARM id of the [DiskAccess](https://aka.ms/disksprivatelinksdoc) resource for using private endpoints on disks | | No  | ``
 enableBursting | [enable on-demand bursting](https://learn.microsoft.com/en-us/azure/virtual-machines/disk-bursting) beyond the provisioned performance target of the disk. On-demand bursting can only be applied to Premium disk, disk size > 512GB, Ultra & shared disk is not supported. Bursting is disabled by default. | `true`, `false` | No | `false`
 enablePerformancePlus | [enabling performance plus](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-performance), this setting only applies to Premium SSD, Standard SSD and HDD with disk size > 512GB. | `true`, `false` | No | `false`


### PR DESCRIPTION
**What this PR does / why we need it:**

The `driver-parameters.md` table still documents the Azure ARM defaults for two StorageClass parameters, but the CSI driver has been overriding them for over a year:

| parameter | doc (before) | actual driver default |
| --- | --- | --- |
| `networkAccessPolicy` | `AllowAll` | `DenyAll` (not set on Azure Stack) |
| `publicNetworkAccess` | `Enabled` | `Disabled` (not set on Azure Stack) |

Introduced in commit 0596506 ("chore: disable public network access for new disk creation by default", July 2025) in `pkg/azuredisk/azure_managedDiskController.go` — when the user does not specify the value in the StorageClass, the driver now falls back to `DenyAll` / `Disabled` for new managed disks.

Checked the rest of the table (`cachingMode`, `attachDiskInitialDelay`, `LogicalSectorSize`, `enableBursting`, `enablePerformancePlus`, `perfProfile`, `kind`, `fsType`, VolumeSnapshotClass `incremental` / `dataAccessAuthMode`, etc.) — those defaults still match the code.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```