### PR TITLE
pin all GitHub Actions in codeql-analysis.yml to commit SHAs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -63,4 +63,4 @@ jobs:
         make all
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4


### PR DESCRIPTION
Pin all actions in `codeql-analysis.yml` to full-length commit SHAs, as required by the repo's action pinning policy:

| Action | Version | SHA |
|---|---|---|
| `actions/setup-go` | v6 | `924ae3a` |
| `actions/checkout` | v7.0.0 | `9c091bb` |
| `github/codeql-action/init` | 4.37.0 | `99df26d` |
| `github/codeql-action/analyze` | 4.37.0 | `99df26d` |

Also bumps `codeql-action` from 4.36.3 to 4.37.0 — both init and analyze must be at the same version, otherwise CodeQL fails with:

```
Error: Loaded a configuration file for version 4.37.0, but running version 4.36.3
```
