### PR TITLE
fix:  avoid using formatAndMount from kubernetes mount utils

### DIFF
--- a/pkg/azuredisk/azure_common_darwin.go
+++ b/pkg/azuredisk/azure_common_darwin.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"k8s.io/klog/v2"
@@ -38,7 +39,7 @@ const sysClassBlockPath = "/sys/class/block/"
 func scsiHostRescan(io azureutils.IOHandler, m *mount.SafeFormatAndMount) {
 }
 
-func formatAndMount(source, target, fstype string, options []string, m *mount.SafeFormatAndMount) error {
+func formatAndMount(source, target, fstype string, options []string, m *mount.SafeFormatAndMount, _ chan any, _ time.Duration) error {
 	return nil
 }
 

--- a/pkg/azuredisk/azure_common_linux.go
+++ b/pkg/azuredisk/azure_common_linux.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
@@ -33,10 +34,19 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/volume"
 	mount "k8s.io/mount-utils"
+	utilexec "k8s.io/utils/exec"
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/azureutils"
 )
 
-const sysClassBlockPath = "/sys/class/block/"
+const (
+	sysClassBlockPath = "/sys/class/block/"
+	// 'fsck' found errors and corrected them
+	fsckErrorsCorrected = 1
+	// 'fsck' found errors but exited without correcting them
+	fsckErrorsUncorrected = 4
+	// 'fsck' found operational error, e.g fresh block device
+	fsckOperationalError = 8
+)
 
 // exclude those used by azure as resource and OS root in /dev/disk/azure, /dev/disk/azure/scsi0
 // "/dev/disk/azure/scsi0" dir is populated in Standard_DC4s/DC2s on Ubuntu 18.04
@@ -119,12 +129,132 @@ func findDiskByLun(lun int, io azureutils.IOHandler, _ *mount.SafeFormatAndMount
 	return "", fmt.Errorf("failed to find disk by lun %d", lun)
 }
 
-func formatAndMount(source, target, fstype string, options []string, m *mount.SafeFormatAndMount) error {
+func formatAndMount(source, target, fstype string, options []string, m *mount.SafeFormatAndMount, formatSem chan any, formatTimeout time.Duration) error {
 	if newOptions, exists := azureutils.RemoveOptionIfExists(options, "directmount"); exists {
 		klog.V(2).Infof("formatAndMount - skip format for %s, old options: %v, new options: %v", target, options, newOptions)
 		return m.Mount(source, target, fstype, newOptions)
 	}
-	return m.FormatAndMount(source, target, fstype, options)
+
+	readOnly := false
+	for _, option := range options {
+		if option == "ro" {
+			readOnly = true
+			break
+		}
+	}
+
+	// Only single source of truth to know whether the disk is formatted or not is through blkid.
+	diskFSFormat, err := m.GetDiskFormat(source)
+	if err != nil {
+		klog.Errorf("formatAndMount - failed to get disk format for %s with error(%v)", source, err)
+		return fmt.Errorf("failed to get disk format for %s with error(%v)", source, err)
+	}
+
+	if diskFSFormat == "" {
+		// As part of auto-recovery from mount failures, we run fsck on the disk. If the disk was pulled
+		// out or a power loss occurred during a previous fsck run, the primary superblocks may have been
+		// corrupted depending on the stage at which fsck was interrupted. We run fsck here to detect and
+		// repair such issues before formatting.
+		// Note: fsck is a no-op if the disk already has an xfs signature.
+		// If filesystem was detected at this stage don't format return the error
+		isFilesystemExist, err := detectFilesystemExistence(source, m)
+		if err != nil {
+			klog.Errorf("formatAndMount - failed to check existence of filesystem on disk %s with error(%v)", source, err)
+			return fmt.Errorf("formatAndMount - failed to check existence of filesystem on disk %s with error(%v)", source, err)
+		}
+
+		if !isFilesystemExist {
+			if readOnly {
+				return fmt.Errorf("formatAndMount - disk %s is not formatted, but mount options specify read-only", source)
+			}
+
+			// If filesystem doesn't exist then we can format the disk with the given fstype.
+			// Disk is unformatted
+			args := []string{source}
+			if fstype == "ext4" || fstype == "ext3" {
+				args = []string{
+					"-m0", // Zero blocks reserved for super-user
+					source,
+				}
+			} else if fstype == "xfs" {
+				args = []string{
+					source,
+				}
+			}
+
+			klog.Infof("Disk %q appears to be unformatted, attempting to format as type: %q with options: %v", source, fstype, args)
+			output, err := mkfsWithConcurrencyLimit(m, formatSem, formatTimeout, fstype, args)
+			if err != nil {
+				klog.Errorf("formatAndMount - failed to format disk %s as type %s with options %v: %v error: %v", source, fstype, args, string(output), err)
+				return fmt.Errorf("failed to format disk %s as type %s with options %v: %v error: %v", source, fstype, args, string(output), err)
+			}
+			// Format was successful
+			diskFSFormat = fstype
+		} else {
+			// Re-read the filesystem signature to determine the existing format.
+			reReadFormat, err := m.GetDiskFormat(source)
+			if err != nil {
+				klog.Errorf("formatAndMount - failed to re-read filesystem signature on disk %s with error: %v", source, err)
+				return fmt.Errorf("failed to re-read filesystem signature on disk %s with error: %v", source, err)
+			}
+			klog.Infof("Disk %q contains filesystem signature post running fsck, skipping format; detected filesystem type: %q", source, reReadFormat)
+			diskFSFormat = reReadFormat
+		}
+	}
+
+	if !strings.EqualFold(fstype, diskFSFormat) {
+		// Verify that the disk is formatted with filesystem type we are expecting
+		klog.Errorf("formatAndMount - configured to mount disk %s as %s but current format is %s, things might break", source, fstype, diskFSFormat)
+		return fmt.Errorf("configured to mount disk %s as %s but current format is %s, things might break", source, fstype, diskFSFormat)
+	}
+
+	// Running fsck on the disk to detect and repair any filesystem issues before mounting
+	if !readOnly {
+		_, err := detectAndRepairFilesystem(source, []string{"-a"}, m)
+		if err != nil {
+			klog.Errorf("formatAndMount - failed to run fsck on disk %s with error: %v", source, err)
+			return fmt.Errorf("failed to run fsck on disk %s with error: %v", source, err)
+		}
+	}
+
+	klog.V(4).Infof("Attempting to mount disk %s in %s format at %s", source, fstype, target)
+	options = append(options, "defaults")
+	if err := m.Mount(source, target, fstype, options); err != nil {
+		klog.Errorf("formatAndMount - failed to mount disk %s at %s with options %v and error: %v", source, target, options, err)
+		return fmt.Errorf("failed to mount disk %s at %s with options %v and error: %v", source, target, options, err)
+	}
+
+	return nil
+}
+
+// mkfsWithConcurrencyLimit runs mkfs.<fstype> while honoring the max-concurrent-format
+// semaphore. Because this driver formats the disk with a direct exec call (instead of
+// mount.SafeFormatAndMount.FormatAndMount) to insert the pre-format fsck auto-recovery
+// step, it must reproduce SafeFormatAndMount's WithMaxConcurrentFormat gating here to
+// avoid unbounded concurrent mkfs operations under load. The logic mirrors the upstream
+// (unexported) SafeFormatAndMount.format method: once formatTimeout elapses the token is
+// released so another format can proceed, while the original mkfs is allowed to complete.
+func mkfsWithConcurrencyLimit(m *mount.SafeFormatAndMount, formatSem chan any, formatTimeout time.Duration, fstype string, args []string) ([]byte, error) {
+	if formatSem != nil {
+		done := make(chan struct{})
+		defer close(done)
+
+		formatSem <- struct{}{}
+
+		go func() {
+			defer func() { <-formatSem }()
+
+			timeout := time.NewTimer(formatTimeout)
+			defer timeout.Stop()
+
+			select {
+			case <-done:
+			case <-timeout.C:
+			}
+		}()
+	}
+
+	return m.Exec.Command("mkfs."+fstype, args...).CombinedOutput()
 }
 
 // finds a device mounted to "current" node
@@ -289,6 +419,76 @@ func rescanAllVolumes(io azureutils.IOHandler) error {
 		}
 	}
 	return nil
+}
+
+// detectFilesystemExistence checks whether the given device already contains a filesystem signature.
+// 2. Detects filesystem signature using wipefs --no-act --noheadings --output TYPE <device>.
+func detectFilesystemExistence(source string, mounter *mount.SafeFormatAndMount) (bool, error) {
+	isFSExist, err := detectAndRepairFilesystem(source, []string{"-n"}, mounter)
+	if err != nil {
+		klog.Errorf("detectFilesystemExistence - failed to check existence of filesystem on disk %s through 'fsck' with error(%v)", source, err)
+		return false, fmt.Errorf("detectFilesystemExistence - failed to check existence of filesystem on disk %s through 'fsck' with error(%v)", source, err)
+	}
+	if isFSExist {
+		return true, nil
+	}
+
+	args := []string{"--no-act", "--output", "TYPE", "--noheadings", source}
+	fsType, err := mounter.Exec.Command("wipefs", args...).CombinedOutput()
+	if err != nil {
+		klog.Errorf("detectFilesystemExistence - failed to check existence of filesystem on disk %s through 'wipefs' with error(%v)", source, err)
+		return false, fmt.Errorf("detectFilesystemExistence - failed to check existence of filesystem on disk %s through 'wipefs' with error(%v)", source, err)
+	}
+	if len(fsType) > 0 {
+		return true, nil
+	}
+	return false, nil
+}
+
+// detectAndRepairFilesystem runs fsck on the given device to determine whether it already contains
+// a filesystem and to repair any recoverable inconsistencies in place based on provided options.
+//
+// It returns:
+//   - (true, nil): a filesystem is present (clean or recoverable errors corrected).
+//   - (false, nil): no filesystem signature (fresh/unformatted device).
+//   - (false, error): fsck could not be executed or returned an operational/ambiguous failure.
+//   - (true, error): fsck found errors it could not correct.
+//
+// fsckOptions control fsck's behavior, e.g. "-n" for a read-only detection check or "-y"/"-E ..."
+// to attempt repairs.
+func detectAndRepairFilesystem(source string, fsckOptions []string, mounter *mount.SafeFormatAndMount) (bool, error) {
+	klog.V(2).Infof("Checking for issues with fsck on disk: %s with options %v", source, fsckOptions)
+	args := append(append([]string(nil), fsckOptions...), source)
+	out, err := mounter.Exec.Command("fsck", args...).CombinedOutput()
+	if err != nil {
+		ee, isExitError := err.(utilexec.ExitError)
+		switch {
+		case err == utilexec.ErrExecutableNotFound:
+			klog.Errorf("'fsck' not found on system; cannot verify filesystem signature on %s, returning error.", source)
+			return false, fmt.Errorf("'fsck' not found to detect filesystem on device %s with options %v: %v", source, fsckOptions, err)
+		case isExitError && ee.ExitStatus() == fsckOperationalError:
+			if strings.Contains(strings.ToLower(string(out)), "superblock could not be read or does not describe a valid ext2/ext3/ext4") {
+				klog.Infof("Device %s may be fresh block device with no filesystem signature, fsck output: %s", source, string(out))
+				return false, nil
+			}
+			klog.Warningf("Unable to run fsck on device %s with options %v, fsck output: %s", source, fsckOptions, string(out))
+			return false, fmt.Errorf("Unable to run fsck on device %s with options %v, fsck error: %v", source, fsckOptions, err)
+		case isExitError && ee.ExitStatus() == fsckErrorsCorrected:
+			klog.Warningf("Device %s has errors which were corrected by fsck: %s", source, string(out))
+		case isExitError && ee.ExitStatus() == fsckErrorsUncorrected:
+			// Filesystem exists but fsck found errors that it could not correct
+			klog.Errorf("Device %s has errors which fsck could not correct with options %v: %s", source, fsckOptions, string(out))
+			return true, fmt.Errorf("'fsck' found errors on device %s with options %v but could not correct them (exit status %d)", source, fsckOptions, ee.ExitStatus())
+		case isExitError && ee.ExitStatus() > fsckErrorsUncorrected:
+			klog.Errorf("`fsck` error %s", string(out))
+			return false, fmt.Errorf("'fsck' failed on device %s with options %v: %v", source, fsckOptions, err)
+		default:
+			klog.Warningf("fsck on device %s failed with error %v, output: %v", source, err, string(out))
+		}
+	}
+	// In case if device is formatted with other filesystem, fsck will return 0
+	klog.Infof("fsck on device %s completed successfully with output: %s", source, string(out))
+	return true, nil
 }
 
 func (d *Driver) GetVolumeStats(_ context.Context, m *mount.SafeFormatAndMount, _, target string, hostutil hostUtil) ([]*csi.VolumeUsage, error) {

--- a/pkg/azuredisk/azure_common_linux.go
+++ b/pkg/azuredisk/azure_common_linux.go
@@ -173,11 +173,13 @@ func formatAndMount(source, target, fstype string, options []string, m *mount.Sa
 			args := []string{source}
 			if fstype == "ext4" || fstype == "ext3" {
 				args = []string{
+					"-F",  // Force flag, if we reached this point then mostly it's a fresh disk without any fs signature
 					"-m0", // Zero blocks reserved for super-user
 					source,
 				}
 			} else if fstype == "xfs" {
 				args = []string{
+					"-f",
 					source,
 				}
 			}
@@ -439,7 +441,7 @@ func detectFilesystemExistence(source string, mounter *mount.SafeFormatAndMount)
 		klog.Errorf("detectFilesystemExistence - failed to check existence of filesystem on disk %s through 'wipefs' with error(%v)", source, err)
 		return false, fmt.Errorf("detectFilesystemExistence - failed to check existence of filesystem on disk %s through 'wipefs' with error(%v)", source, err)
 	}
-	if len(fsType) > 0 {
+	if len(strings.TrimSpace(string(fsType))) > 0 {
 		return true, nil
 	}
 	return false, nil

--- a/pkg/azuredisk/azure_common_linux.go
+++ b/pkg/azuredisk/azure_common_linux.go
@@ -428,8 +428,12 @@ func rescanAllVolumes(io azureutils.IOHandler) error {
 func detectFilesystemExistence(source string, mounter *mount.SafeFormatAndMount) (bool, error) {
 	isFSExist, err := detectAndRepairFilesystem(source, []string{"-n"}, mounter)
 	if err != nil {
-		klog.Errorf("detectFilesystemExistence - failed to check existence of filesystem on disk %s through 'fsck' with error(%v)", source, err)
-		return false, fmt.Errorf("detectFilesystemExistence - failed to check existence of filesystem on disk %s through 'fsck' with error(%v)", source, err)
+		if strings.Contains(strings.ToLower(err.Error()), "superblock could not be read or does not describe a valid ext2/ext3/ext4") {
+			klog.Infof("Device %s may be fresh block device with no filesystem signature, fsck output: %s", source, err.Error())
+		} else {
+			klog.Errorf("detectFilesystemExistence - failed to check existence of filesystem on disk %s through 'fsck' with error(%v)", source, err)
+			return false, fmt.Errorf("detectFilesystemExistence - failed to check existence of filesystem on disk %s through 'fsck' with error(%v)", source, err)
+		}
 	}
 	if isFSExist {
 		return true, nil
@@ -469,12 +473,8 @@ func detectAndRepairFilesystem(source string, fsckOptions []string, mounter *mou
 			klog.Errorf("'fsck' not found on system; cannot verify filesystem signature on %s, returning error.", source)
 			return false, fmt.Errorf("'fsck' not found to detect filesystem on device %s with options %v: %v", source, fsckOptions, err)
 		case isExitError && ee.ExitStatus() == fsckOperationalError:
-			if strings.Contains(strings.ToLower(string(out)), "superblock could not be read or does not describe a valid ext2/ext3/ext4") {
-				klog.Infof("Device %s may be fresh block device with no filesystem signature, fsck output: %s", source, string(out))
-				return false, nil
-			}
 			klog.Warningf("Unable to run fsck on device %s with options %v, fsck output: %s", source, fsckOptions, string(out))
-			return false, fmt.Errorf("Unable to run fsck on device %s with options %v, fsck error: %v", source, fsckOptions, err)
+			return false, fmt.Errorf("Unable to run fsck on device %s with options %v, fsck error: %v output: %s", source, fsckOptions, err, string(out))
 		case isExitError && ee.ExitStatus() == fsckErrorsCorrected:
 			klog.Warningf("Device %s has errors which were corrected by fsck: %s", source, string(out))
 		case isExitError && ee.ExitStatus() == fsckErrorsUncorrected:

--- a/pkg/azuredisk/azure_common_linux_test.go
+++ b/pkg/azuredisk/azure_common_linux_test.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 /*
 Copyright 2022 The Kubernetes Authors.
 
@@ -17,16 +20,305 @@ limitations under the License.
 package azuredisk
 
 import (
-	"runtime"
+	"reflect"
 	"testing"
+	"time"
 
+	"k8s.io/utils/exec"
+	testingexec "k8s.io/utils/exec/testing"
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/azureutils"
+	testmounter "sigs.k8s.io/azuredisk-csi-driver/pkg/mounter"
 )
 
-func TestRescanAllVolumes(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skipf("skip test on GOOS=%s", runtime.GOOS)
+func TestFormatAndMountFormatsUnformattedDisk(t *testing.T) {
+	fakeSafeMounter, err := testmounter.NewFakeSafeMounter()
+	if err != nil {
+		t.Fatalf("NewFakeSafeMounter failed: %v", err)
 	}
+
+	fakeExec := fakeSafeMounter.Exec.(*testmounter.FakeSafeMounter)
+	fakeExec.CommandScript = []testingexec.FakeCommandAction{
+		blkidAction(t, "/dev/sdz", testingexec.FakeExitError{Status: 2}, ""),
+		// fsck reports a fresh block device (exit status 8), so no filesystem exists yet.
+		fsckAction(t, []string{"-n", "/dev/sdz"}, testingexec.FakeExitError{Status: fsckOperationalError}, "fsck.ext4: Superblock could not be read or does not describe a valid ext2/ext3/ext4 filesystem"),
+		// wipefs finds no filesystem signature, confirming the disk is unformatted.
+		wipefsAction(t, "/dev/sdz", nil, ""),
+		mkfsAction(t),
+		// fsck runs once more with "-a" to repair any issues before mounting.
+		fsckAction(t, []string{"-a", "/dev/sdz"}, nil, ""),
+	}
+
+	if err := formatAndMount("/dev/sdz", "/mnt/test", "ext4", nil, fakeSafeMounter, nil, 0); err != nil {
+		t.Fatalf("formatAndMount returned error: %v", err)
+	}
+
+	if got, want := fakeExec.CommandCalls, 5; got != want {
+		t.Fatalf("unexpected command count: got %d, want %d", got, want)
+	}
+}
+
+// TestFormatAndMountSkipsFormatWhenFsckDetectsFilesystem verifies that when blkid reports no
+// filesystem but fsck finds/repairs an existing filesystem, the disk is not reformatted.
+func TestFormatAndMountSkipsFormatWhenFsckDetectsFilesystem(t *testing.T) {
+	fakeSafeMounter, err := testmounter.NewFakeSafeMounter()
+	if err != nil {
+		t.Fatalf("NewFakeSafeMounter failed: %v", err)
+	}
+
+	fakeExec := fakeSafeMounter.Exec.(*testmounter.FakeSafeMounter)
+	fakeExec.CommandScript = []testingexec.FakeCommandAction{
+		blkidAction(t, "/dev/sdz", testingexec.FakeExitError{Status: 2}, ""),
+		// fsck exits cleanly, meaning a filesystem already exists on the disk.
+		fsckAction(t, []string{"-n", "/dev/sdz"}, nil, ""),
+		// The existing filesystem is re-read to determine its format instead of reformatting.
+		blkidAction(t, "/dev/sdz", nil, "TYPE=ext4\n"),
+		// fsck runs once more with "-a" to repair any issues before mounting.
+		fsckAction(t, []string{"-a", "/dev/sdz"}, nil, ""),
+	}
+
+	if err := formatAndMount("/dev/sdz", "/mnt/test", "ext4", nil, fakeSafeMounter, nil, 0); err != nil {
+		t.Fatalf("formatAndMount returned error: %v", err)
+	}
+
+	// blkid, fsck, the re-read blkid, and the pre-mount fsck should run; mkfs must be skipped.
+	if got, want := fakeExec.CommandCalls, 4; got != want {
+		t.Fatalf("unexpected command count: got %d, want %d", got, want)
+	}
+}
+
+func TestFormatAndMountDoesNotReformatWhenAlreadyFormatted(t *testing.T) {
+	fakeSafeMounter, err := testmounter.NewFakeSafeMounter()
+	if err != nil {
+		t.Fatalf("NewFakeSafeMounter failed: %v", err)
+	}
+
+	fakeExec := fakeSafeMounter.Exec.(*testmounter.FakeSafeMounter)
+	fakeExec.CommandScript = []testingexec.FakeCommandAction{
+		// First call: disk is unformatted.
+		blkidAction(t, "/dev/sdz", testingexec.FakeExitError{Status: 2}, ""),
+		// First call: fsck reports a fresh block device, so the disk gets formatted.
+		fsckAction(t, []string{"-n", "/dev/sdz"}, testingexec.FakeExitError{Status: fsckOperationalError}, "fsck.ext4: Superblock could not be read or does not describe a valid ext2/ext3/ext4 filesystem"),
+		// First call: wipefs finds no filesystem signature.
+		wipefsAction(t, "/dev/sdz", nil, ""),
+		// First call: mkfs succeeds.
+		mkfsAction(t),
+		// First call: fsck runs with "-a" to repair any issues before mounting.
+		fsckAction(t, []string{"-a", "/dev/sdz"}, nil, ""),
+		// Second call: disk is already ext4, so no fsck/mkfs should run.
+		blkidAction(t, "/dev/sdz", nil, "TYPE=ext4\n"),
+		// Second call: fsck runs with "-a" to repair any issues before mounting.
+		fsckAction(t, []string{"-a", "/dev/sdz"}, nil, ""),
+	}
+
+	if err := formatAndMount("/dev/sdz", "/mnt/test", "ext4", nil, fakeSafeMounter, nil, 0); err != nil {
+		t.Fatalf("first formatAndMount returned error: %v", err)
+	}
+
+	if err := formatAndMount("/dev/sdz", "/mnt/test", "ext4", nil, fakeSafeMounter, nil, 0); err != nil {
+		t.Fatalf("second formatAndMount returned error: %v", err)
+	}
+
+	if got, want := fakeExec.CommandCalls, 7; got != want {
+		t.Fatalf("unexpected command count: got %d, want %d", got, want)
+	}
+}
+
+// TestDetectAndRepairFilesystem verifies detectAndRepairFilesystem's handling of the various fsck
+// exit codes using a fake mounter, which lets us deterministically simulate each outcome without
+// requiring root privileges or real loopback/block devices.
+func TestDetectAndRepairFilesystem(t *testing.T) {
+	tests := []struct {
+		name        string
+		fsckErr     error
+		fsckOutput  string
+		wantFsExist bool
+		wantErr     bool
+	}{
+		{
+			// fsck exits 0 on a healthy ext4/xfs filesystem (xfs check is effectively a no-op).
+			name:        "healthy filesystem",
+			fsckErr:     nil,
+			wantFsExist: true,
+			wantErr:     false,
+		},
+		{
+			// fsck exits 8 (operational error) on a fresh block device: its output reports that the
+			// superblock could not be read, which we treat as "no filesystem signature".
+			name:        "fresh block device with no filesystem",
+			fsckErr:     testingexec.FakeExitError{Status: fsckOperationalError},
+			fsckOutput:  "fsck.ext4: Superblock could not be read or does not describe a valid ext2/ext3/ext4 filesystem",
+			wantFsExist: false,
+			wantErr:     false,
+		},
+		{
+			// fsck exits 8 (operational error) without the "no filesystem" signature: we cannot rule
+			// out a filesystem, so surface the error instead of assuming a fresh device.
+			name:        "operational error with a filesystem present",
+			fsckErr:     testingexec.FakeExitError{Status: fsckOperationalError},
+			fsckOutput:  "fsck.ext4: unable to set superblock flags",
+			wantFsExist: false,
+			wantErr:     true,
+		},
+		{
+			name:        "errors corrected by fsck (exit 1)",
+			fsckErr:     testingexec.FakeExitError{Status: fsckErrorsCorrected},
+			wantFsExist: true,
+			wantErr:     false,
+		},
+		{
+			name:        "errors left uncorrected by fsck (exit 4)",
+			fsckErr:     testingexec.FakeExitError{Status: fsckErrorsUncorrected},
+			wantFsExist: true,
+			wantErr:     true,
+		},
+		{
+			name:        "fsck exit status greater than uncorrected (exit 16)",
+			fsckErr:     testingexec.FakeExitError{Status: 16},
+			wantFsExist: false,
+			wantErr:     true,
+		},
+		{
+			// When fsck is unavailable we cannot detect a filesystem, so surface an error rather
+			// than making an assumption about the device's contents.
+			name:        "fsck binary not found",
+			fsckErr:     exec.ErrExecutableNotFound,
+			wantFsExist: false,
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeSafeMounter, err := testmounter.NewFakeSafeMounter()
+			if err != nil {
+				t.Fatalf("NewFakeSafeMounter failed: %v", err)
+			}
+
+			fakeExec := fakeSafeMounter.Exec.(*testmounter.FakeSafeMounter)
+			fakeExec.CommandScript = []testingexec.FakeCommandAction{
+				fsckAction(t, []string{"-y", "/dev/sdz"}, tc.fsckErr, tc.fsckOutput),
+			}
+
+			isFilesystemExist, err := detectAndRepairFilesystem("/dev/sdz", []string{"-y"}, fakeSafeMounter)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("detectAndRepairFilesystem error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if isFilesystemExist != tc.wantFsExist {
+				t.Fatalf("isFilesystemExist = %v, want %v", isFilesystemExist, tc.wantFsExist)
+			}
+		})
+	}
+}
+
+// TestFormatAndMountHonorsConcurrentFormatSemaphore verifies that when a max-concurrent-format
+// semaphore is configured, formatAndMount acquires a token before running mkfs and releases it
+// afterwards, so subsequent formats are not permanently blocked.
+func TestFormatAndMountHonorsConcurrentFormatSemaphore(t *testing.T) {
+	fakeSafeMounter, err := testmounter.NewFakeSafeMounter()
+	if err != nil {
+		t.Fatalf("NewFakeSafeMounter failed: %v", err)
+	}
+
+	fakeExec := fakeSafeMounter.Exec.(*testmounter.FakeSafeMounter)
+	fakeExec.CommandScript = []testingexec.FakeCommandAction{
+		blkidAction(t, "/dev/sdz", testingexec.FakeExitError{Status: 2}, ""),
+		fsckAction(t, []string{"-n", "/dev/sdz"}, testingexec.FakeExitError{Status: fsckOperationalError}, "fsck.ext4: Superblock could not be read or does not describe a valid ext2/ext3/ext4 filesystem"),
+		wipefsAction(t, "/dev/sdz", nil, ""),
+		mkfsAction(t),
+		fsckAction(t, []string{"-a", "/dev/sdz"}, nil, ""),
+	}
+
+	formatSem := make(chan any, 1)
+	if err := formatAndMount("/dev/sdz", "/mnt/test", "ext4", nil, fakeSafeMounter, formatSem, 30*time.Second); err != nil {
+		t.Fatalf("formatAndMount returned error: %v", err)
+	}
+
+	// The concurrency token must be released after formatting so the semaphore is drained.
+	// Release happens in a background goroutine, so poll briefly to avoid a race.
+	released := false
+	for i := 0; i < 200; i++ {
+		if len(formatSem) == 0 {
+			released = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !released {
+		t.Fatalf("format semaphore not released: got %d tokens held, want 0", len(formatSem))
+	}
+}
+
+// blkidAction returns a fake command action asserting a GetDiskFormat (blkid) invocation and
+// returning the given combined output and error.
+func blkidAction(t *testing.T, source string, err error, output string) testingexec.FakeCommandAction {
+	return func(cmd string, args ...string) exec.Cmd {
+		expectedArgs := []string{"-p", "-s", "TYPE", "-s", "PTTYPE", "-o", "export", source}
+		if cmd != "blkid" || !reflect.DeepEqual(args, expectedArgs) {
+			t.Fatalf("unexpected blkid command: %s %v", cmd, args)
+		}
+
+		fakeCmd := &testingexec.FakeCmd{CombinedOutputScript: []testingexec.FakeAction{
+			func() ([]byte, []byte, error) {
+				return []byte(output), []byte{}, err
+			},
+		}}
+		return testingexec.InitFakeCmd(fakeCmd, cmd, args...)
+	}
+}
+
+// fsckAction returns a fake command action asserting an fsck invocation with the expected args and
+// returning the given combined output and error.
+func fsckAction(t *testing.T, expectedArgs []string, err error, output string) testingexec.FakeCommandAction {
+	return func(cmd string, args ...string) exec.Cmd {
+		if cmd != "fsck" || !reflect.DeepEqual(args, expectedArgs) {
+			t.Fatalf("unexpected fsck command: %s %v", cmd, args)
+		}
+
+		fakeCmd := &testingexec.FakeCmd{CombinedOutputScript: []testingexec.FakeAction{
+			func() ([]byte, []byte, error) {
+				return []byte(output), []byte{}, err
+			},
+		}}
+		return testingexec.InitFakeCmd(fakeCmd, cmd, args...)
+	}
+}
+
+// wipefsAction returns a fake command action asserting a wipefs --no-act invocation used to detect
+// an existing filesystem signature, returning the given combined output and error.
+func wipefsAction(t *testing.T, source string, err error, output string) testingexec.FakeCommandAction {
+	return func(cmd string, args ...string) exec.Cmd {
+		expectedArgs := []string{"--no-act", "--output", "TYPE", "--noheadings", source}
+		if cmd != "wipefs" || !reflect.DeepEqual(args, expectedArgs) {
+			t.Fatalf("unexpected wipefs command: %s %v", cmd, args)
+		}
+
+		fakeCmd := &testingexec.FakeCmd{CombinedOutputScript: []testingexec.FakeAction{
+			func() ([]byte, []byte, error) {
+				return []byte(output), []byte{}, err
+			},
+		}}
+		return testingexec.InitFakeCmd(fakeCmd, cmd, args...)
+	}
+}
+
+// mkfsAction returns a fake command action asserting a successful mkfs.ext4 invocation.
+func mkfsAction(t *testing.T) testingexec.FakeCommandAction {
+	return func(cmd string, args ...string) exec.Cmd {
+		expectedArgs := []string{"-m0", "/dev/sdz"}
+		if cmd != "mkfs.ext4" || !reflect.DeepEqual(args, expectedArgs) {
+			t.Fatalf("unexpected mkfs command: %s %v", cmd, args)
+		}
+
+		fakeCmd := &testingexec.FakeCmd{CombinedOutputScript: []testingexec.FakeAction{
+			func() ([]byte, []byte, error) {
+				return []byte{}, []byte{}, nil
+			},
+		}}
+		return testingexec.InitFakeCmd(fakeCmd, cmd, args...)
+	}
+}
+
+func TestRescanAllVolumes(t *testing.T) {
 	err := rescanAllVolumes(azureutils.NewOSIOHandler())
 	if err != nil {
 		t.Errorf("rescanAllVolumes failed with error: %v", err)

--- a/pkg/azuredisk/azure_common_linux_test.go
+++ b/pkg/azuredisk/azure_common_linux_test.go
@@ -104,7 +104,7 @@ func TestFormatAndMountDoesNotReformatWhenAlreadyFormatted(t *testing.T) {
 		mkfsAction(t),
 		// First call: fsck runs with "-a" to repair any issues before mounting.
 		fsckAction(t, []string{"-a", "/dev/sdz"}, nil, ""),
-		// Second call: disk is already ext4, so no fsck/mkfs should run.
+		// Second call: disk is already ext4, so it should skip the detection fsck/mkfs path.
 		blkidAction(t, "/dev/sdz", nil, "TYPE=ext4\n"),
 		// Second call: fsck runs with "-a" to repair any issues before mounting.
 		fsckAction(t, []string{"-a", "/dev/sdz"}, nil, ""),
@@ -304,7 +304,7 @@ func wipefsAction(t *testing.T, source string, err error, output string) testing
 // mkfsAction returns a fake command action asserting a successful mkfs.ext4 invocation.
 func mkfsAction(t *testing.T) testingexec.FakeCommandAction {
 	return func(cmd string, args ...string) exec.Cmd {
-		expectedArgs := []string{"-m0", "/dev/sdz"}
+		expectedArgs := []string{"-F", "-m0", "/dev/sdz"}
 		if cmd != "mkfs.ext4" || !reflect.DeepEqual(args, expectedArgs) {
 			t.Fatalf("unexpected mkfs command: %s %v", cmd, args)
 		}

--- a/pkg/azuredisk/azure_common_linux_test.go
+++ b/pkg/azuredisk/azure_common_linux_test.go
@@ -143,12 +143,14 @@ func TestDetectAndRepairFilesystem(t *testing.T) {
 		},
 		{
 			// fsck exits 8 (operational error) on a fresh block device: its output reports that the
-			// superblock could not be read, which we treat as "no filesystem signature".
-			name:        "fresh block device with no filesystem",
+			// superblock could not be read. detectAndRepairFilesystem always surfaces an operational
+			// error; interpreting that output as "no filesystem signature" is the caller's job (see
+			// TestDetectFilesystemExistence).
+			name:        "operational error on a fresh block device",
 			fsckErr:     testingexec.FakeExitError{Status: fsckOperationalError},
 			fsckOutput:  "fsck.ext4: Superblock could not be read or does not describe a valid ext2/ext3/ext4 filesystem",
 			wantFsExist: false,
-			wantErr:     false,
+			wantErr:     true,
 		},
 		{
 			// fsck exits 8 (operational error) without the "no filesystem" signature: we cannot rule
@@ -205,6 +207,108 @@ func TestDetectAndRepairFilesystem(t *testing.T) {
 			}
 			if isFilesystemExist != tc.wantFsExist {
 				t.Fatalf("isFilesystemExist = %v, want %v", isFilesystemExist, tc.wantFsExist)
+			}
+		})
+	}
+}
+
+// TestDetectFilesystemExistence verifies that detectFilesystemExistence interprets an fsck
+// operational error whose output reports an unreadable superblock as a fresh block device and
+// falls back to wipefs, while still surfacing other fsck failures.
+func TestDetectFilesystemExistence(t *testing.T) {
+	const superblockOutput = "fsck.ext4: Superblock could not be read or does not describe a valid ext2/ext3/ext4 filesystem"
+
+	tests := []struct {
+		name         string
+		fsckErr      error
+		fsckOutput   string
+		expectWipefs bool
+		wipefsErr    error
+		wipefsOutput string
+		wantFsExist  bool
+		wantErr      bool
+	}{
+		{
+			// fsck exits 0, so a filesystem already exists and wipefs is not consulted.
+			name:        "fsck reports an existing filesystem",
+			fsckErr:     nil,
+			wantFsExist: true,
+			wantErr:     false,
+		},
+		{
+			// fsck exits 8 with the unreadable-superblock signature: treated as a fresh device, so
+			// wipefs is consulted and reports no signature.
+			name:         "fresh block device confirmed by wipefs",
+			fsckErr:      testingexec.FakeExitError{Status: fsckOperationalError},
+			fsckOutput:   superblockOutput,
+			expectWipefs: true,
+			wipefsErr:    nil,
+			wipefsOutput: "",
+			wantFsExist:  false,
+			wantErr:      false,
+		},
+		{
+			// fsck reports an unreadable superblock but wipefs still finds a filesystem signature.
+			name:         "unreadable superblock but wipefs finds a signature",
+			fsckErr:      testingexec.FakeExitError{Status: fsckOperationalError},
+			fsckOutput:   superblockOutput,
+			expectWipefs: true,
+			wipefsErr:    nil,
+			wipefsOutput: "ext4\n",
+			wantFsExist:  true,
+			wantErr:      false,
+		},
+		{
+			// fsck fails with an operational error unrelated to a missing superblock: surface it.
+			name:        "operational error unrelated to superblock",
+			fsckErr:     testingexec.FakeExitError{Status: fsckOperationalError},
+			fsckOutput:  "fsck.ext4: unable to set superblock flags",
+			wantFsExist: false,
+			wantErr:     true,
+		},
+		{
+			// fsck reports a fresh device but wipefs itself fails: surface the wipefs error.
+			name:         "wipefs failure is surfaced",
+			fsckErr:      testingexec.FakeExitError{Status: fsckOperationalError},
+			fsckOutput:   superblockOutput,
+			expectWipefs: true,
+			wipefsErr:    testingexec.FakeExitError{Status: 1},
+			wipefsOutput: "",
+			wantFsExist:  false,
+			wantErr:      true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeSafeMounter, err := testmounter.NewFakeSafeMounter()
+			if err != nil {
+				t.Fatalf("NewFakeSafeMounter failed: %v", err)
+			}
+
+			fakeExec := fakeSafeMounter.Exec.(*testmounter.FakeSafeMounter)
+			script := []testingexec.FakeCommandAction{
+				fsckAction(t, []string{"-n", "/dev/sdz"}, tc.fsckErr, tc.fsckOutput),
+			}
+			if tc.expectWipefs {
+				script = append(script, wipefsAction(t, "/dev/sdz", tc.wipefsErr, tc.wipefsOutput))
+			}
+			fakeExec.CommandScript = script
+
+			isFilesystemExist, err := detectFilesystemExistence("/dev/sdz", fakeSafeMounter)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("detectFilesystemExistence error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if isFilesystemExist != tc.wantFsExist {
+				t.Fatalf("isFilesystemExist = %v, want %v", isFilesystemExist, tc.wantFsExist)
+			}
+
+			wantCalls := 1
+			if tc.expectWipefs {
+				wantCalls = 2
+			}
+			if got := fakeExec.CommandCalls; got != wantCalls {
+				t.Fatalf("unexpected command count: got %d, want %d", got, wantCalls)
 			}
 		})
 	}

--- a/pkg/azuredisk/azure_common_windows.go
+++ b/pkg/azuredisk/azure_common_windows.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
@@ -35,7 +36,7 @@ import (
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 )
 
-func formatAndMount(source, target, fstype string, options []string, m *mount.SafeFormatAndMount) error {
+func formatAndMount(source, target, fstype string, options []string, m *mount.SafeFormatAndMount, _ chan any, _ time.Duration) error {
 	if proxy, ok := m.Interface.(mounter.CSIProxyMounter); ok {
 		return proxy.FormatAndMount(source, target, fstype, options)
 	}

--- a/pkg/azuredisk/azuredisk.go
+++ b/pkg/azuredisk/azuredisk.go
@@ -153,6 +153,10 @@ type Driver struct {
 	volStatsCache           azcache.Resource
 	maxConcurrentFormat     int64
 	concurrentFormatTimeout int64
+	// formatSem limits the number of concurrent mkfs operations, mirroring
+	// mount.SafeFormatAndMount's WithMaxConcurrentFormat semaphore. nil means unlimited.
+	formatSem               chan any
+	formatTimeout           time.Duration
 	enableMinimumRetryAfter bool
 	volumeLocks             *volumehelper.VolumeLocks
 	// a timed cache for throttling
@@ -215,6 +219,10 @@ func NewDriver(options *DriverOptions) *Driver {
 	driver.neverStopTaintRemoval = options.NeverStopTaintRemoval
 	driver.maxConcurrentFormat = options.MaxConcurrentFormat
 	driver.concurrentFormatTimeout = options.ConcurrentFormatTimeout
+	if options.MaxConcurrentFormat > 0 {
+		driver.formatSem = make(chan any, int(options.MaxConcurrentFormat))
+		driver.formatTimeout = time.Duration(options.ConcurrentFormatTimeout) * time.Second
+	}
 	driver.enableMinimumRetryAfter = options.EnableMinimumRetryAfter
 	driver.volumeLocks = volumehelper.NewVolumeLocks()
 	driver.ioHandler = azureutils.NewOSIOHandler()

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -662,7 +662,7 @@ func (d *Driver) ensureMountPoint(target string) (bool, error) {
 }
 
 func (d *Driver) formatAndMount(source, target, fstype string, options []string) error {
-	return formatAndMount(source, target, fstype, options, d.mounter)
+	return formatAndMount(source, target, fstype, options, d.mounter, d.formatSem, d.formatTimeout)
 }
 
 func (d *Driver) getDevicePathWithLUN(lunStr string) (string, error) {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR avoids using FormatAndMount function from kubernetes mount-utils
and got replaced with following changes:
- Check existence of filesystem through blkid, fsck and wipefs with specific `no-op` options
    - If filesystem exist then run fsck and perform mount it.
    - If filesystem doesn't exist read filesystem signatures from secondary superblock and fail if fs signature already exists.
    - If filesystem doesn't even exist in secondary superblock then format and mount the disk at target path.
    Note: This PR also removes the force option while formatting the device with filesystem.



**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
In specific scenario csi driver ends in re-formatting the device.
T0: Application scheduled for the first time on node, as part of NodeStageVolume request csi driver formated and mounted the disk.
T1: Application written good amount of data but before flushing there is restart of node.
T2: Node came back online, pod got re-started/re-scheduled where csi-node driver received NodeStageVolume request for same volume. So, with existing flow CSI driver detects existence of filesystem and fsck.
T3: While fsck is in progress there is restart of node which ends in corrupting primary super blocks of filesystem (Assumption that fsck corrupted it)
T4: Once node back online, CSI driver received NodeStageVolume request as part of the request driver checked the existence of filesystem which shown empty. So, at this point disk formatted with ext4 filesystem which ends in wiping the previous data.

**This will not fully fix the issue, but it is an attempt to avoid running fsck**



**Release note**:
```
none
```
