### PR TITLE
chore: bump github/codeql-action to 4.37.1

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+      uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -63,4 +63,4 @@ jobs:
         make all
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+      uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4


### PR DESCRIPTION
Bump both `github/codeql-action/init` and `github/codeql-action/analyze` from 4.37.0 to 4.37.1.

Keeping the two action refs in sync avoids the "Loaded a configuration file for version 'X', but running version 'Y'" mismatch error that occurs when only one of them is bumped (as seen in kubernetes-sigs/azurefile-csi-driver#3273).

- `init`: `99df26d` → `7188fc3` (v4.37.1)
- `analyze`: `99df26d` → `7188fc3` (v4.37.1)