### PR TITLE
docs(charts): add GitHub Pages as alternate helm repo source

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -40,8 +40,18 @@
 
 ### add the Helm chart repository
 
+Pick **one** source (both host the same charts; the two commands share the repo name `azuredisk-csi-driver`, so running the second after the first will fail unless you pass `--force-update`):
+
+Option 1: raw.githubusercontent.com (default)
+
 ```console
 helm repo add azuredisk-csi-driver https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/charts
+```
+
+Option 2: GitHub Pages mirror (available since 1.33.7, not affected by raw.githubusercontent.com rate limits)
+
+```console
+helm repo add azuredisk-csi-driver https://kubernetes-sigs.github.io/azuredisk-csi-driver
 ```
 
 ### search for all available chart versions


### PR DESCRIPTION
## What this PR does

Documents `https://kubernetes-sigs.github.io/azuredisk-csi-driver` as an alternate helm repository source alongside the existing `raw.githubusercontent.com` source in `charts/README.md`.

Both sources host the same charts. The GitHub Pages mirror is not affected by `raw.githubusercontent.com` rate limits and is available starting from chart version **1.33.7** (the first version published by the workflow added in #3734).

## Why

`raw.githubusercontent.com` is aggressively rate-limited from shared IPs (CI runners, corporate NAT, etc.). Offering a GitHub Pages mirror gives users an unrate-limited alternative without breaking the existing installation path.

## Changes

- `charts/README.md`: under **add the Helm chart repository**, replace the single `helm repo add` block with two separate code blocks (one per source), plus an explicit "pick **one**" note so users don't accidentally run both (since `helm repo add` with an existing repo name errors out unless `--force-update` is passed).

Mirrors kubernetes-sigs/blob-csi-driver#2593 and kubernetes-sigs/azurefile-csi-driver#3295.

/kind documentation
/sig storage
/assign @andyzhangx
