### PR TITLE
chore: add metrics in formatAndMount

### DIFF
--- a/deploy/example/metrics/README.md
+++ b/deploy/example/metrics/README.md
@@ -12,11 +12,28 @@ These metrics are native to the Azure Disk CSI Driver and provide detailed opera
 |-------------|------|--------|-------------|
 | `azuredisk_csi_driver_operations_total` | Counter | `operation`, `success` | Total number of CSI operations |
 | `azuredisk_csi_driver_operation_duration_seconds` | Histogram | `operation`, `success` | Duration of CSI operations in seconds |
-| `azuredisk_csi_driver_operation_duration_seconds_labeled` | Histogram | `operation`, `success`, `storage_account_type` | Duration of CSI operations with additional disk-specific labels |
+| `azuredisk_csi_driver_operation_duration_seconds_labeled` | Histogram | `operation`, `success`, `storage_account_type`, `fsck_outcome`, `fs_type` | Duration of CSI operations with additional disk-specific labels |
 
 **Operation values:**
 - Controller: `controller_create_volume`, `controller_delete_volume`, `controller_modify_volume`, `controller_publish_volume`, `controller_unpublish_volume`, `controller_expand_volume`, `controller_create_snapshot`, `controller_delete_snapshot`
 - Node: `node_stage_volume`, `node_unstage_volume`, `node_publish_volume`, `node_unpublish_volume`, `node_expand_volume`
+
+**Linux format and mount operation values:**
+
+| Operation | When it is emitted | `success` value |
+|-----------|--------------------|-----------------|
+| `format_and_mount_blkid_no_signature` | `blkid` returned no filesystem signature, so fallback detection begins | `true` |
+| `format_and_mount_detect_fs_signature` | The read-only `fsck -n` filesystem detection completes | Result classified by `fsck_outcome` |
+| `format_and_mount_confirmed_no_signature` | `blkid`, `fsck -n`, and `wipefs` found no filesystem signature, so formatting is permitted | `true` |
+| `format_and_mount_mkfs` | The `mkfs` invocation completes | Whether `mkfs` succeeded |
+| `format_and_mount_detected_fs_signature_from_secondary_sb` | `blkid` returned empty, but fallback detection found a filesystem | `true` |
+| `format_and_mount_type_mismatch` | The detected filesystem type differs from the requested `fs_type` | `false` |
+| `format_and_mount_fsck_repair` | The pre-mount `fsck -a` repair completes | Result classified by `fsck_outcome` |
+| `format_and_mount_mount` | The final mount attempt completes, including the `directmount` path | Whether the mount succeeded |
+
+All format and mount operations expose the requested filesystem type through the `fs_type` label. The `format_and_mount_detect_fs_signature` and `format_and_mount_fsck_repair` operations additionally expose `fsck_outcome`, with possible values `clean`, `fresh_device`, `errors_corrected`, `errors_uncorrected`, `operational_error`, `not_found`, `fatal_error`, and `unknown`. Labels that do not apply to an operation have an empty value.
+
+For counts grouped by `storage_account_type`, `fsck_outcome`, or `fs_type`, use the histogram's `azuredisk_csi_driver_operation_duration_seconds_labeled_count` series. The `azuredisk_csi_driver_operations_total` counter contains only the `operation` and `success` labels.
 
 ### CSI Operation Latency Metrics (via cloud-provider-azure)
 

--- a/pkg/azuredisk/azure_common_linux.go
+++ b/pkg/azuredisk/azure_common_linux.go
@@ -36,6 +36,7 @@ import (
 	mount "k8s.io/mount-utils"
 	utilexec "k8s.io/utils/exec"
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/azureutils"
+	csiMetrics "sigs.k8s.io/azuredisk-csi-driver/pkg/metrics"
 )
 
 const (
@@ -132,7 +133,7 @@ func findDiskByLun(lun int, io azureutils.IOHandler, _ *mount.SafeFormatAndMount
 func formatAndMount(source, target, fstype string, options []string, m *mount.SafeFormatAndMount, formatSem chan any, formatTimeout time.Duration) error {
 	if newOptions, exists := azureutils.RemoveOptionIfExists(options, "directmount"); exists {
 		klog.V(2).Infof("formatAndMount - skip format for %s, old options: %v, new options: %v", target, options, newOptions)
-		return m.Mount(source, target, fstype, newOptions)
+		return mountWithMetrics(source, target, fstype, newOptions, m)
 	}
 
 	readOnly := false
@@ -151,13 +152,16 @@ func formatAndMount(source, target, fstype string, options []string, m *mount.Sa
 	}
 
 	if diskFSFormat == "" {
+		// blkid found no filesystem signature, so fall back to fsck/wipefs detection before formatting.
+		csiMetrics.NewCSIMetricContext("format_and_mount_blkid_no_signature").WithLabel(csiMetrics.FsType, fstype).Observe(true)
+
 		// As part of auto-recovery from mount failures, we run fsck on the disk. If the disk was pulled
 		// out or a power loss occurred during a previous fsck run, the primary superblocks may have been
 		// corrupted depending on the stage at which fsck was interrupted. We run fsck here to detect and
 		// repair such issues before formatting.
 		// Note: fsck is a no-op if the disk already has an xfs signature.
 		// If filesystem was detected at this stage don't format return the error
-		isFilesystemExist, err := detectFilesystemExistence(source, m)
+		isFilesystemExist, err := detectFilesystemExistence(source, fstype, m)
 		if err != nil {
 			klog.Errorf("formatAndMount - failed to check existence of filesystem on disk %s with error(%v)", source, err)
 			return fmt.Errorf("formatAndMount - failed to check existence of filesystem on disk %s with error(%v)", source, err)
@@ -167,6 +171,9 @@ func formatAndMount(source, target, fstype string, options []string, m *mount.Sa
 			if readOnly {
 				return fmt.Errorf("formatAndMount - disk %s is not formatted, but mount options specify read-only", source)
 			}
+
+			// blkid, fsck and wipefs all report no signature, so formatting is permitted.
+			csiMetrics.NewCSIMetricContext("format_and_mount_confirmed_no_signature").WithLabel(csiMetrics.FsType, fstype).Observe(true)
 
 			// If filesystem doesn't exist then we can format the disk with the given fstype.
 			// Disk is unformatted
@@ -185,7 +192,9 @@ func formatAndMount(source, target, fstype string, options []string, m *mount.Sa
 			}
 
 			klog.Infof("Disk %q appears to be unformatted, attempting to format as type: %q with options: %v", source, fstype, args)
+			mkfsMetric := csiMetrics.NewCSIMetricContext("format_and_mount_mkfs").WithLabel(csiMetrics.FsType, fstype)
 			output, err := mkfsWithConcurrencyLimit(m, formatSem, formatTimeout, fstype, args)
+			mkfsMetric.Observe(err == nil)
 			if err != nil {
 				klog.Errorf("formatAndMount - failed to format disk %s as type %s with options %v: %v error: %v", source, fstype, args, string(output), err)
 				return fmt.Errorf("failed to format disk %s as type %s with options %v: %v error: %v", source, fstype, args, string(output), err)
@@ -193,6 +202,9 @@ func formatAndMount(source, target, fstype string, options []string, m *mount.Sa
 			// Format was successful
 			diskFSFormat = fstype
 		} else {
+			// blkid was empty, but fsck or wipefs found a filesystem; the disk was saved from a reformat.
+			csiMetrics.NewCSIMetricContext("format_and_mount_detected_fs_signature_from_secondary_sb").WithLabel(csiMetrics.FsType, fstype).Observe(true)
+
 			// Re-read the filesystem signature to determine the existing format.
 			reReadFormat, err := m.GetDiskFormat(source)
 			if err != nil {
@@ -206,14 +218,14 @@ func formatAndMount(source, target, fstype string, options []string, m *mount.Sa
 
 	if !strings.EqualFold(fstype, diskFSFormat) {
 		// Verify that the disk is formatted with filesystem type we are expecting
+		csiMetrics.NewCSIMetricContext("format_and_mount_type_mismatch").WithLabel(csiMetrics.FsType, fstype).Observe(false)
 		klog.Errorf("formatAndMount - configured to mount disk %s as %s but current format is %s, things might break", source, fstype, diskFSFormat)
 		return fmt.Errorf("configured to mount disk %s as %s but current format is %s, things might break", source, fstype, diskFSFormat)
 	}
 
 	// Running fsck on the disk to detect and repair any filesystem issues before mounting
 	if !readOnly {
-		_, err := detectAndRepairFilesystem(source, []string{"-a"}, m)
-		if err != nil {
+		if _, err := detectAndRepairFilesystem(source, fstype, []string{"-a"}, m, "format_and_mount_fsck_repair"); err != nil {
 			klog.Errorf("formatAndMount - failed to run fsck on disk %s with error: %v", source, err)
 			return fmt.Errorf("failed to run fsck on disk %s with error: %v", source, err)
 		}
@@ -221,7 +233,14 @@ func formatAndMount(source, target, fstype string, options []string, m *mount.Sa
 
 	klog.V(4).Infof("Attempting to mount disk %s in %s format at %s", source, fstype, target)
 	options = append(options, "defaults")
-	if err := m.Mount(source, target, fstype, options); err != nil {
+	return mountWithMetrics(source, target, fstype, options, m)
+}
+
+func mountWithMetrics(source, target, fstype string, options []string, m *mount.SafeFormatAndMount) error {
+	mountMetric := csiMetrics.NewCSIMetricContext("format_and_mount_mount").WithLabel(csiMetrics.FsType, fstype)
+	err := m.Mount(source, target, fstype, options)
+	mountMetric.Observe(err == nil)
+	if err != nil {
 		klog.Errorf("formatAndMount - failed to mount disk %s at %s with options %v and error: %v", source, target, options, err)
 		return fmt.Errorf("failed to mount disk %s at %s with options %v and error: %v", source, target, options, err)
 	}
@@ -425,8 +444,8 @@ func rescanAllVolumes(io azureutils.IOHandler) error {
 
 // detectFilesystemExistence checks whether the given device already contains a filesystem signature.
 // 2. Detects filesystem signature using wipefs --no-act --noheadings --output TYPE <device>.
-func detectFilesystemExistence(source string, mounter *mount.SafeFormatAndMount) (bool, error) {
-	isFSExist, err := detectAndRepairFilesystem(source, []string{"-n"}, mounter)
+func detectFilesystemExistence(source, fsType string, mounter *mount.SafeFormatAndMount) (bool, error) {
+	isFSExist, err := detectAndRepairFilesystem(source, fsType, []string{"-n"}, mounter, "format_and_mount_detect_fs_signature")
 	if err != nil {
 		if strings.Contains(strings.ToLower(err.Error()), "superblock could not be read or does not describe a valid ext2/ext3/ext4") {
 			klog.Infof("Device %s may be fresh block device with no filesystem signature, fsck output: %s", source, err.Error())
@@ -440,12 +459,12 @@ func detectFilesystemExistence(source string, mounter *mount.SafeFormatAndMount)
 	}
 
 	args := []string{"--no-act", "--output", "TYPE", "--noheadings", source}
-	fsType, err := mounter.Exec.Command("wipefs", args...).CombinedOutput()
+	detectedFsType, err := mounter.Exec.Command("wipefs", args...).CombinedOutput()
 	if err != nil {
 		klog.Errorf("detectFilesystemExistence - failed to check existence of filesystem on disk %s through 'wipefs' with error(%v)", source, err)
 		return false, fmt.Errorf("detectFilesystemExistence - failed to check existence of filesystem on disk %s through 'wipefs' with error(%v)", source, err)
 	}
-	if len(strings.TrimSpace(string(fsType))) > 0 {
+	if len(strings.TrimSpace(string(detectedFsType))) > 0 {
 		return true, nil
 	}
 	return false, nil
@@ -462,29 +481,54 @@ func detectFilesystemExistence(source string, mounter *mount.SafeFormatAndMount)
 //
 // fsckOptions control fsck's behavior, e.g. "-n" for a read-only detection check or "-y"/"-E ..."
 // to attempt repairs.
-func detectAndRepairFilesystem(source string, fsckOptions []string, mounter *mount.SafeFormatAndMount) (bool, error) {
+func detectAndRepairFilesystem(source, fsType string, fsckOptions []string, mounter *mount.SafeFormatAndMount, operation string) (fsExist bool, retErr error) {
 	klog.V(2).Infof("Checking for issues with fsck on disk: %s with options %v", source, fsckOptions)
 	args := append(append([]string(nil), fsckOptions...), source)
+	readOnlyDetection := false
+	for _, option := range fsckOptions {
+		if option == "-n" {
+			readOnlyDetection = true
+			break
+		}
+	}
+
+	mc := csiMetrics.NewCSIMetricContext(operation)
+	outcome := "clean"
+	success := true
+	defer func() {
+		mc.ObserveWithLabels(success, csiMetrics.FsType, fsType, csiMetrics.FsckOutcome, outcome)
+	}()
+
 	out, err := mounter.Exec.Command("fsck", args...).CombinedOutput()
 	if err != nil {
 		ee, isExitError := err.(utilexec.ExitError)
 		switch {
 		case err == utilexec.ErrExecutableNotFound:
+			outcome, success = "not_found", false
 			klog.Errorf("'fsck' not found on system; cannot verify filesystem signature on %s, returning error.", source)
 			return false, fmt.Errorf("'fsck' not found to detect filesystem on device %s with options %v: %v", source, fsckOptions, err)
 		case isExitError && ee.ExitStatus() == fsckOperationalError:
+			if readOnlyDetection && strings.Contains(strings.ToLower(string(out)), "superblock could not be read or does not describe a valid ext2/ext3/ext4") {
+				outcome, success = "fresh_device", true
+			} else {
+				outcome, success = "operational_error", false
+			}
 			klog.Warningf("Unable to run fsck on device %s with options %v, fsck output: %s", source, fsckOptions, string(out))
 			return false, fmt.Errorf("Unable to run fsck on device %s with options %v, fsck error: %v output: %s", source, fsckOptions, err, string(out))
 		case isExitError && ee.ExitStatus() == fsckErrorsCorrected:
+			outcome, success = "errors_corrected", true
 			klog.Warningf("Device %s has errors which were corrected by fsck: %s", source, string(out))
 		case isExitError && ee.ExitStatus() == fsckErrorsUncorrected:
 			// Filesystem exists but fsck found errors that it could not correct
+			outcome, success = "errors_uncorrected", false
 			klog.Errorf("Device %s has errors which fsck could not correct with options %v: %s", source, fsckOptions, string(out))
 			return true, fmt.Errorf("'fsck' found errors on device %s with options %v but could not correct them (exit status %d)", source, fsckOptions, ee.ExitStatus())
 		case isExitError && ee.ExitStatus() > fsckErrorsUncorrected:
+			outcome, success = "fatal_error", false
 			klog.Errorf("`fsck` error %s", string(out))
 			return false, fmt.Errorf("'fsck' failed on device %s with options %v: %v", source, fsckOptions, err)
 		default:
+			outcome, success = "unknown", true
 			klog.Warningf("fsck on device %s failed with error %v, output: %v", source, err, string(out))
 		}
 	}

--- a/pkg/azuredisk/azure_common_linux_test.go
+++ b/pkg/azuredisk/azure_common_linux_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/utils/exec"
 	testingexec "k8s.io/utils/exec/testing"
 	"sigs.k8s.io/azuredisk-csi-driver/pkg/azureutils"
@@ -129,10 +130,13 @@ func TestFormatAndMountDoesNotReformatWhenAlreadyFormatted(t *testing.T) {
 func TestDetectAndRepairFilesystem(t *testing.T) {
 	tests := []struct {
 		name        string
+		fsckOptions []string
 		fsckErr     error
 		fsckOutput  string
 		wantFsExist bool
 		wantErr     bool
+		wantSuccess string
+		wantOutcome string
 	}{
 		{
 			// fsck exits 0 on a healthy ext4/xfs filesystem (xfs check is effectively a no-op).
@@ -140,17 +144,30 @@ func TestDetectAndRepairFilesystem(t *testing.T) {
 			fsckErr:     nil,
 			wantFsExist: true,
 			wantErr:     false,
+			wantSuccess: "true",
+			wantOutcome: "clean",
 		},
 		{
-			// fsck exits 8 (operational error) on a fresh block device: its output reports that the
-			// superblock could not be read. detectAndRepairFilesystem always surfaces an operational
-			// error; interpreting that output as "no filesystem signature" is the caller's job (see
-			// TestDetectFilesystemExistence).
+			// During read-only detection, an unreadable superblock identifies a fresh device.
 			name:        "operational error on a fresh block device",
+			fsckOptions: []string{"-n"},
 			fsckErr:     testingexec.FakeExitError{Status: fsckOperationalError},
 			fsckOutput:  "fsck.ext4: Superblock could not be read or does not describe a valid ext2/ext3/ext4 filesystem",
 			wantFsExist: false,
 			wantErr:     true,
+			wantSuccess: "true",
+			wantOutcome: "fresh_device",
+		},
+		{
+			// During repair, the same output aborts the mount and must be reported as a failure.
+			name:        "unreadable superblock during repair",
+			fsckOptions: []string{"-a"},
+			fsckErr:     testingexec.FakeExitError{Status: fsckOperationalError},
+			fsckOutput:  "fsck.ext4: Superblock could not be read or does not describe a valid ext2/ext3/ext4 filesystem",
+			wantFsExist: false,
+			wantErr:     true,
+			wantSuccess: "false",
+			wantOutcome: "operational_error",
 		},
 		{
 			// fsck exits 8 (operational error) without the "no filesystem" signature: we cannot rule
@@ -160,24 +177,32 @@ func TestDetectAndRepairFilesystem(t *testing.T) {
 			fsckOutput:  "fsck.ext4: unable to set superblock flags",
 			wantFsExist: false,
 			wantErr:     true,
+			wantSuccess: "false",
+			wantOutcome: "operational_error",
 		},
 		{
 			name:        "errors corrected by fsck (exit 1)",
 			fsckErr:     testingexec.FakeExitError{Status: fsckErrorsCorrected},
 			wantFsExist: true,
 			wantErr:     false,
+			wantSuccess: "true",
+			wantOutcome: "errors_corrected",
 		},
 		{
 			name:        "errors left uncorrected by fsck (exit 4)",
 			fsckErr:     testingexec.FakeExitError{Status: fsckErrorsUncorrected},
 			wantFsExist: true,
 			wantErr:     true,
+			wantSuccess: "false",
+			wantOutcome: "errors_uncorrected",
 		},
 		{
 			name:        "fsck exit status greater than uncorrected (exit 16)",
 			fsckErr:     testingexec.FakeExitError{Status: 16},
 			wantFsExist: false,
 			wantErr:     true,
+			wantSuccess: "false",
+			wantOutcome: "fatal_error",
 		},
 		{
 			// When fsck is unavailable we cannot detect a filesystem, so surface an error rather
@@ -186,11 +211,18 @@ func TestDetectAndRepairFilesystem(t *testing.T) {
 			fsckErr:     exec.ErrExecutableNotFound,
 			wantFsExist: false,
 			wantErr:     true,
+			wantSuccess: "false",
+			wantOutcome: "not_found",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			fsckOptions := tc.fsckOptions
+			if fsckOptions == nil {
+				fsckOptions = []string{"-y"}
+			}
+
 			fakeSafeMounter, err := testmounter.NewFakeSafeMounter()
 			if err != nil {
 				t.Fatalf("NewFakeSafeMounter failed: %v", err)
@@ -198,15 +230,66 @@ func TestDetectAndRepairFilesystem(t *testing.T) {
 
 			fakeExec := fakeSafeMounter.Exec.(*testmounter.FakeSafeMounter)
 			fakeExec.CommandScript = []testingexec.FakeCommandAction{
-				fsckAction(t, []string{"-y", "/dev/sdz"}, tc.fsckErr, tc.fsckOutput),
+				fsckAction(t, append(append([]string(nil), fsckOptions...), "/dev/sdz"), tc.fsckErr, tc.fsckOutput),
 			}
 
-			isFilesystemExist, err := detectAndRepairFilesystem("/dev/sdz", []string{"-y"}, fakeSafeMounter)
+			operation := "test_detect_and_repair_" + tc.name
+			isFilesystemExist, err := detectAndRepairFilesystem("/dev/sdz", "ext4", fsckOptions, fakeSafeMounter, operation)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("detectAndRepairFilesystem error = %v, wantErr %v", err, tc.wantErr)
 			}
 			if isFilesystemExist != tc.wantFsExist {
 				t.Fatalf("isFilesystemExist = %v, want %v", isFilesystemExist, tc.wantFsExist)
+			}
+
+			families, err := legacyregistry.DefaultGatherer.Gather()
+			if err != nil {
+				t.Fatalf("failed to gather metrics: %v", err)
+			}
+
+			foundCounter := false
+			foundLabeledHistogram := false
+			for _, family := range families {
+				for _, metric := range family.GetMetric() {
+					labels := map[string]string{}
+					for _, label := range metric.GetLabel() {
+						labels[label.GetName()] = label.GetValue()
+					}
+					if labels["operation"] != operation {
+						continue
+					}
+
+					switch family.GetName() {
+					case "azuredisk_csi_driver_operations_total":
+						foundCounter = true
+						if labels["success"] != tc.wantSuccess {
+							t.Errorf("operations_total success = %q, want %q", labels["success"], tc.wantSuccess)
+						}
+						if metric.GetCounter().GetValue() != 1 {
+							t.Errorf("operations_total value = %v, want 1", metric.GetCounter().GetValue())
+						}
+					case "azuredisk_csi_driver_operation_duration_seconds_labeled":
+						foundLabeledHistogram = true
+						if labels["success"] != tc.wantSuccess {
+							t.Errorf("labeled histogram success = %q, want %q", labels["success"], tc.wantSuccess)
+						}
+						if labels["fsck_outcome"] != tc.wantOutcome {
+							t.Errorf("fsck_outcome = %q, want %q", labels["fsck_outcome"], tc.wantOutcome)
+						}
+						if labels["fs_type"] != "ext4" {
+							t.Errorf("fs_type = %q, want %q", labels["fs_type"], "ext4")
+						}
+						if metric.GetHistogram().GetSampleCount() != 1 {
+							t.Errorf("labeled histogram count = %d, want 1", metric.GetHistogram().GetSampleCount())
+						}
+					}
+				}
+			}
+			if !foundCounter {
+				t.Error("operations_total metric not found")
+			}
+			if !foundLabeledHistogram {
+				t.Error("labeled operation duration metric not found")
 			}
 		})
 	}
@@ -295,7 +378,7 @@ func TestDetectFilesystemExistence(t *testing.T) {
 			}
 			fakeExec.CommandScript = script
 
-			isFilesystemExist, err := detectFilesystemExistence("/dev/sdz", fakeSafeMounter)
+			isFilesystemExist, err := detectFilesystemExistence("/dev/sdz", "ext4", fakeSafeMounter)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("detectFilesystemExistence error = %v, wantErr %v", err, tc.wantErr)
 			}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -30,6 +30,8 @@ const (
 
 	// Label keys for metrics
 	StorageAccountType = "storage_account_type"
+	FsckOutcome        = "fsck_outcome"
+	FsType             = "fs_type"
 )
 
 var (
@@ -52,7 +54,7 @@ var (
 			Buckets:        []float64{0.1, 0.2, 0.5, 1, 5, 10, 15, 20, 30, 40, 50, 60, 100, 200, 300},
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"operation", "success", StorageAccountType},
+		[]string{"operation", "success", StorageAccountType, FsckOutcome, FsType},
 	)
 
 	operationTotal = metrics.NewCounterVec(
@@ -148,11 +150,15 @@ func (mc *CSIMetricContext) Observe(success bool) {
 	// Record detailed metrics if labels are present
 	if len(mc.labels) > 0 {
 		storageAccountType := mc.labels[StorageAccountType]
+		fsckOutcome := mc.labels[FsckOutcome]
+		fsType := mc.labels[FsType]
 
 		operationDurationWithLabels.WithLabelValues(
 			mc.operation,
 			successStr,
 			storageAccountType,
+			fsckOutcome,
+			fsType,
 		).Observe(duration)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
PR #3711 moved the format/mount decision logic out of Kubernetes mount-utils SafeFormatAndMount.FormatAndMount and into the driver, adding several new decision branches (blkid → fsck -n → wipefs → format vs. recover vs. already-formatted).

New operation values emitted in azure_common_linux.go:
| Operation | When it's emitted | Value |
|-----------|------------------|--------|
| `format_and_mount_blkid_no_signature` | `blkid` returned empty, so fall back to `fsck`/`wipefs` detection | always `true` |
| `format_and_mount_detect_fs_signature` | `fsck -n` detection probe result (also carries an `fsck_outcome` label) | detection ran (`true`/`false`) |
| `format_and_mount_confirmed_no_signature` | `blkid` + `fsck -n` + `wipefs` all empty → formatting permitted | always `true` |
| `format_and_mount_mkfs` | `mkfs` invocation result | `mkfs` succeeded (`true`/`false`) |
| `format_and_mount_detected_fs_signature_from_secondary_sb` | `blkid` was empty, but `fsck`/`wipefs` found a filesystem (disk saved from a reformat) | always `true` |
| `format_and_mount_type_mismatch` | detected filesystem type ≠ requested `fstype` | always `false` |
| `format_and_mount_fsck_repair` | pre-mount `fsck -a` repair result (also carries an `fsck_outcome` label) | repair completed (`true`/`false`) |
| `format_and_mount_mount` | final `m.Mount` result | mount succeeded (`true`/`false`) |

**Notes:**
- The two `fsck`-based operations (`format_and_mount_detect_fs_signature` and `format_and_mount_fsck_repair`) both flow through `detectAndRepairFilesystem` and additionally emit an `fsck_outcome` label with one of: `clean`, `fresh_device`, `errors_corrected`, `errors_uncorrected`, `operational_error`, `not_found`, `fatal_error`, `unknown`.
- `fsck_outcome`, `fs_type`, and s`torage_account_type` are exposed through the labeled duration histogram; counts by these labels are available through its built-in `_count` series.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
