### PR TITLE
chore: bump Go to 1.26.6

### DIFF
--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -10,7 +10,7 @@ jobs:
             - name: Set up Go 1.x
               uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
               with:
-                go-version: 1.25.7
+                go-version: 1.26.6
               id: go
 
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.25.12
+          go-version: 1.26.6
         id: go
 
       - name: Checkout code

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/azuredisk-csi-driver
 
-go 1.25.0
+go 1.26.0
 
 godebug winsymlink=0
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Bumps the Go version used by the trivy scan workflow from `1.25.12` to `1.25.13` to pick up recent stdlib CVE fixes.

**Release note**:
```release-note
NONE
```