### PR TITLE
[release-1.33] chore: bump Go to 1.26.6

### DIFF
--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -10,7 +10,7 @@ jobs:
             - name: Set up Go 1.x
               uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
               with:
-                go-version: 1.25.8
+                go-version: 1.26.6
               id: go
 
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: 1.25.12
+          go-version: 1.26.6
         id: go
 
       - name: Checkout code

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/azuredisk-csi-driver
 
-go 1.25.0
+go 1.26.0
 
 godebug winsymlink=0
 

--- a/pkg/azuredisk/controllerserver_test.go
+++ b/pkg/azuredisk/controllerserver_test.go
@@ -1767,6 +1767,14 @@ func TestControllerModifyVolume_MigrationLifecycleAndTimeout(t *testing.T) {
 	}
 
 	t.Run("lifecycle: start -> milestones -> completion -> label removed", func(t *testing.T) {
+		// The lifecycle case needs enough headroom to walk the full progress
+		// sequence and emit the completion event even when the goroutine
+		// scheduler is slower (observed as a flake under newer Go toolchains).
+		// Widen the timing here and restore the base values on exit so the
+		// subsequent subtests keep their intended timing semantics.
+		setTiming(20*time.Millisecond, 500*time.Millisecond, 3*time.Second)
+		defer setTiming(baseInterval, baseSlabTimeout, baseMaxTimeout)
+
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 


### PR DESCRIPTION
Cherry-pick of #3762 to release-1.33.

Bumps the Go version used by the trivy scan workflow and the golangci-lint job to `1.26.6`, and updates `go.mod` to `go 1.26.0` to pick up recent stdlib CVE fixes.

**Release note**:
```release-note
NONE
```