### PR TITLE
test(e2e): add tags and userAgent snapshot class parameters

### DIFF
--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -895,6 +895,7 @@ func (t *dynamicProvisioningTestSuite) defineTests(isMultiZone bool) {
 			StorageClassParameters: map[string]string{"skuName": "StandardSSD_LRS"},
 			SnapshotStorageClassParameters: map[string]string{
 				"incremental": "true", "dataAccessAuthMode": "AzureActiveDirectory", "location": "westus2",
+				"tags": "environment=test,owner=e2e", "userAgent": "azuredisk-csi-driver-e2e",
 			},
 		}
 		if location == "westus2" {


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

Adds `tags` and `userAgent` VolumeSnapshotClass parameters to the large-storage cross-region snapshot restore e2e test to exercise those code paths in `CreateSnapshot`.

Related: kubernetes-sigs/azurefile-csi-driver#3343 (same idea on the file side).

**Release note**:
```release-note
NONE
```