### PR TITLE
cleanup: demote empty GRPC response log to V(6)

### DIFF
--- a/pkg/csi-common/utils.go
+++ b/pkg/csi-common/utils.go
@@ -109,7 +109,15 @@ func LogGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 	if err != nil {
 		klog.Errorf("GRPC error: %v", err)
 	} else {
-		klog.V(level).Infof("GRPC response: %s", protosanitizer.StripSecrets(resp))
+		respStr := protosanitizer.StripSecrets(resp).String()
+		// Empty response bodies carry zero diagnostic value but dominate node
+		// logs (kubelet reconciles NodePublishVolume/NodeUnpublishVolume on
+		// every sync loop, all of which return "{}" on success). Demote to V(6).
+		respLevel := level
+		if respStr == "{}" {
+			respLevel = klog.Level(6)
+		}
+		klog.V(respLevel).Infof("GRPC response: %s", respStr)
 	}
 	return resp, err
 }

--- a/pkg/csi-common/utils.go
+++ b/pkg/csi-common/utils.go
@@ -108,11 +108,14 @@ func LogGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 	resp, err := handler(ctx, req)
 	if err != nil {
 		klog.Errorf("GRPC error: %v", err)
-	} else {
-		respStr := protosanitizer.StripSecrets(resp).String()
+	} else if klog.V(level).Enabled() {
+		// Only serialize once we know V(level) is enabled so that
+		// protosanitizer's lazy formatting is preserved for disabled levels
+		// (e.g. probe/NodeGetCapabilities at V(6) in production).
 		// Empty response bodies carry zero diagnostic value but dominate node
 		// logs (kubelet reconciles NodePublishVolume/NodeUnpublishVolume on
 		// every sync loop, all of which return "{}" on success). Demote to V(6).
+		respStr := protosanitizer.StripSecrets(resp).String()
 		respLevel := level
 		if respStr == "{}" {
 			respLevel = klog.Level(6)

--- a/pkg/csi-common/utils_test.go
+++ b/pkg/csi-common/utils_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"flag"
+	"io"
 	"os"
 	"runtime"
 	"testing"
@@ -144,6 +145,71 @@ func TestLogGRPC(t *testing.T) {
 
 			// CLEANUP
 			buf.Reset()
+		})
+	}
+}
+
+func TestLogGRPCEmptyResponse(t *testing.T) {
+	buf := new(bytes.Buffer)
+	klog.SetOutput(buf)
+	defer klog.SetOutput(io.Discard)
+
+	var vLevel klog.Level
+	// Restore verbosity after the test so we do not leak state.
+	defer func() { _ = vLevel.Set("100") }()
+
+	info := grpc.UnaryServerInfo{FullMethod: "/csi.v1.Node/NodePublishVolume"}
+	req := &csi.NodePublishVolumeRequest{VolumeId: "vol_1"}
+
+	emptyHandler := func(_ context.Context, _ interface{}) (interface{}, error) {
+		return &csi.NodePublishVolumeResponse{}, nil
+	}
+	nonEmptyHandler := func(_ context.Context, _ interface{}) (interface{}, error) {
+		return &csi.NodeGetInfoResponse{NodeId: "node-1"}, nil
+	}
+
+	tests := []struct {
+		name             string
+		v                string
+		handler          grpc.UnaryHandler
+		expectResponse   bool
+		expectedResponse string
+	}{
+		{
+			name:           "empty response is suppressed at V(2)",
+			v:              "2",
+			handler:        emptyHandler,
+			expectResponse: false,
+		},
+		{
+			name:             "empty response is visible at V(6)",
+			v:                "6",
+			handler:          emptyHandler,
+			expectResponse:   true,
+			expectedResponse: "GRPC response: {}",
+		},
+		{
+			name:             "non-empty response is still visible at V(2)",
+			v:                "2",
+			handler:          nonEmptyHandler,
+			expectResponse:   true,
+			expectedResponse: `GRPC response: {"node_id":"node-1"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_ = vLevel.Set(test.v)
+			buf.Reset()
+
+			_, _ = LogGRPC(context.Background(), req, &info, test.handler)
+			klog.Flush()
+
+			if test.expectResponse {
+				assert.Contains(t, buf.String(), test.expectedResponse)
+			} else {
+				assert.NotContains(t, buf.String(), "GRPC response:")
+			}
 		})
 	}
 }

--- a/pkg/csi-common/utils_test.go
+++ b/pkg/csi-common/utils_test.go
@@ -158,9 +158,15 @@ func TestLogGRPCEmptyResponse(t *testing.T) {
 	klog.SetOutput(buf)
 	defer klog.SetOutput(io.Discard)
 
+	// Snapshot and restore -v so this test does not leak verbosity state
+	// into other tests (e.g. TestLogGRPC relies on -v=100).
+	vFlag := flag.Lookup("v")
+	var originalV string
+	if vFlag != nil {
+		originalV = vFlag.Value.String()
+		defer func() { _ = vFlag.Value.Set(originalV) }()
+	}
 	var vLevel klog.Level
-	// Restore verbosity after the test so we do not leak state.
-	defer func() { _ = vLevel.Set("100") }()
 
 	info := grpc.UnaryServerInfo{FullMethod: "/csi.v1.Node/NodePublishVolume"}
 	req := &csi.NodePublishVolumeRequest{VolumeId: "vol_1"}

--- a/pkg/csi-common/utils_test.go
+++ b/pkg/csi-common/utils_test.go
@@ -151,6 +151,10 @@ func TestLogGRPC(t *testing.T) {
 
 func TestLogGRPCEmptyResponse(t *testing.T) {
 	buf := new(bytes.Buffer)
+	// klog defaults to logtostderr=true, which bypasses SetOutput. Disable it
+	// so the buffer captures the log output.
+	klog.LogToStderr(false)
+	defer klog.LogToStderr(true)
 	klog.SetOutput(buf)
 	defer klog.SetOutput(io.Discard)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

An empty GRPC response body (`{}`) carries zero diagnostic value but dominates node driver logs. Kubelet reconciles `NodePublishVolume` / `NodeUnpublishVolume` on every sync loop, and every successful call returns `{}`. On a sample azurefile node log (2355 lines, ~15 min window) `GRPC response: {}` alone accounted for **202 lines (~9%)** — azuredisk has the same pattern.

This PR demotes the "GRPC response" log to `klog.V(6)` **only when the sanitized response body is exactly `{}`**. Non-empty responses and error paths are unchanged, so all diagnostic signal is preserved at default verbosity.

The change is isolated to `pkg/csi-common/utils.go` (`LogGRPC`) and is applied uniformly to every RPC — no per-caller update needed.

**Test coverage**

`TestLogGRPCEmptyResponse` asserts:

- empty protobuf response is suppressed at V(2)
- empty protobuf response is visible at V(6)
- non-empty response is still visible at V(2)

Companion to:
- https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/3348
- https://github.com/kubernetes-sigs/blob-csi-driver/pull/2639

**Which issue(s) this PR fixes:**

Fixes # (n/a — log-noise cleanup)

**Requirements:**

- [x] Does the affected code have corresponding tests? new `TestLogGRPCEmptyResponse`.
- [x] Are the changes documented? klog-only change.
- [ ] Is the change backward compatible? Log-only change; default verbosity unchanged. Operators who need to see empty responses can raise `-v=6`.

**Release note:**

```release-note
`GRPC response: {}` (empty response body) is now emitted at klog `V(6)` across all node RPCs. Non-empty responses and error paths keep their existing verbosity. On typical node logs this removes ~9% of lines at default verbosity without losing diagnostic signal.
```
