### PR TITLE
chore: add fstype allowlist

### DIFF
--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -43,7 +43,7 @@ Name | Meaning | Available Value | Mandatory | Default value
 --- | --- | --- | --- | ---
 skuName | azure disk storage account type (alias: `storageAccountType`)| `Standard_LRS`, `Premium_LRS`, `StandardSSD_LRS`, `UltraSSD_LRS`, `Premium_ZRS`, `StandardSSD_ZRS`, `PremiumV2_LRS`<br>(Note: [PremiumV2_LRS](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-deploy-premium-v2) and [UltraSSD_LRS](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-ultra-ssd) only support `None` caching mode) | No | `StandardSSD_LRS`
 kind | managed or unmanaged(blob based) disk | `managed` (`dedicated`, `shared` are deprecated) | No | `managed`
-fsType | File System Type | `ext4`, `ext3`, `ext2`, `xfs`, `btrfs` on Linux, `ntfs` on Windows | No | `ext4` on Linux, `ntfs` on Windows
+fsType | File System Type | `ext4`, `ext3`, `ext2`, `xfs`, `btrfs` on Linux, `ntfs` on Windows<br>(an unsupported value fails volume staging on Linux; on Windows it logs a warning and falls back to `ntfs`) | No | `ext4` on Linux, `ntfs` on Windows
 cachingMode | [Azure Data Disk Host Cache Setting](https://learn.microsoft.com/en-us/azure/virtual-machines/premium-storage-performance#disk-caching) | `None`, `ReadOnly`, `ReadWrite`<br>(`ReadWrite` caching mode is deprecated, [PremiumV2_LRS](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-deploy-premium-v2) and [UltraSSD_LRS](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-ultra-ssd) only support `None` caching mode) | No | `ReadOnly`
 location | specify Azure region in which Azure disk will be created, region name should only have lower-case letter or digit number. | `eastus2`, `westus`, etc. | No | if empty, driver will use the same region name as current k8s cluster
 resourceGroup | specify the resource group in which azure disk will be created | existing resource group name | No | if empty, driver will use the same resource group name as current k8s cluster
@@ -82,7 +82,7 @@ subscriptionID | specify Azure subscription ID in which Azure disk will be creat
 Name | Meaning | Available Value | Mandatory | Default value
 --- | --- | --- | --- | ---
 volumeHandle| Azure disk URI | `/subscriptions/{sub-id}/resourcegroups/{group-name}/providers/microsoft.compute/disks/{disk-id}` | Yes | N/A
-volumeAttributes.fsType | File System Type | `ext4`, `ext3`, `ext2`, `xfs`, `btrfs` on Linux, `ntfs` on Windows | No | `ext4` on Linux, `ntfs` on Windows
+volumeAttributes.fsType | File System Type | `ext4`, `ext3`, `ext2`, `xfs`, `btrfs` on Linux, `ntfs` on Windows<br>(an unsupported value fails volume staging on Linux; on Windows it logs a warning and falls back to `ntfs`) | No | `ext4` on Linux, `ntfs` on Windows
 volumeAttributes.partition | partition num of the existing disk (only supported on Linux) | `1`, `2`, `3` | No | empty(no partition)<br>make sure partition format is like `-part1`
 volumeAttributes.cachingMode | [disk host cache setting](https://learn.microsoft.com/en-us/azure/virtual-machines/premium-storage-performance#disk-caching)| `None`, `ReadOnly`, `ReadWrite` | No  | `ReadOnly`
 volumeAttributes.attachDiskInitialDelay | setting a large number for the initial delay in milliseconds for batch disk attach/detach could reduce the number of operations and ARM throttling |  | No | `1000`

--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -57,117 +57,12 @@ const (
 	maxSnapshotSizeDifferenceAllowed = 50 // in GiB
 )
 
-// truncateErrMsg truncates long error messages while preserving both the
-// beginning (context) and end (critical details like permission errors).
-// This ensures that important information at the tail of verbose Azure
-// error messages (e.g., missing permissions) remains visible in kube-events
-// which are limited to 1024 bytes.
-func truncateErrMsg(errMsg string) string {
-	if len(errMsg) <= maxErrMsgLength {
-		return errMsg
-	}
-	// Keep head (~40%) for context and tail (~60%) for critical error details.
-	const ellipsis = " ... "
-	headLen := (maxErrMsgLength - len(ellipsis)) * 2 / 5
-	tailLen := maxErrMsgLength - headLen - len(ellipsis)
-	return errMsg[:headLen] + ellipsis + errMsg[len(errMsg)-tailLen:]
-}
-
 // listVolumeStatus explains the return status of `listVolumesByResourceGroup`
 type listVolumeStatus struct {
 	numVisited    int  // the number of iterated azure disks
 	isCompleteRun bool // isCompleteRun is flagged true if the function iterated through all azure disks
 	entries       []*csi.ListVolumesResponse_Entry
 	err           error
-}
-
-// startSKUMigrationMonitor starts (idempotently) an asynchronous monitor that tracks
-// migration of a managed disk from one SKU to another (currently only when moving
-// to PremiumV2).
-//
-// Parameters:
-//
-//	ctx                - request context
-//	isProvisioningFlow - true when invoked from CreateVolume (PV may not exist yet);
-//	                     false when invoked from ModifyVolume (PV should already exist).
-//	fromSKUStr         - original disk SKU name (string form, may differ in casing)
-//	toSKU              - target armcompute.DiskStorageAccountTypes (must be PremiumV2LRS to proceed)
-//	diskURI            - full Azure disk resource ID
-//	pvName             - Kubernetes PV name if known (CreateVolume path supplies req.Name;
-//	                     ModifyVolume path does not, so we derive it from diskURI)
-//	sizeBytes          - disk size (used to derive migration timeout)
-//
-// Workflow / decision points:
-// 1. Guard clauses:
-//   - If no migration monitor is configured OR fromSKUStr empty: do nothing.
-//   - If target SKU is not PremiumV2 OR already matches fromSKU: no migration needed.
-//
-// 2. PV name resolution:
-//   - If pvName is empty (ModifyVolume path) attempt to parse diskURI and use its last
-//     token (disk name) as the PV name.
-//   - If the cluster used static provisioning with a PV name different from the Azure
-//     disk name, this heuristic cannot map the disk to the PV; monitoring is skipped.
-//
-// 3. StartMonitoring call:
-//   - Calls migrationMonitor.StartMigrationMonitoring(ctx, isProvisioningFlow, ...).
-//   - isProvisioningFlow influences initial behavior inside the monitor:
-//   - Provisioning (true): PV may not yet exist. The monitor records a task with
-//     empty PVC metadata, attempts an initial label add (may fail if PV absent),
-//     and defers PV / PVC discovery, labeling, and start event emission to the
-//     periodic polling loop (monitorMigrationProgress).
-//   - Modify (false): PV should exist. The monitor immediately fetches the PV,
-//     derives PVC name/namespace, adds/ensures the migration label, and emits
-//     the "Started" event (unless label already existed; then it logs a resume).
-//
-// 4. Label management:
-//   - addMigrationLabelIfNotExists is executed once at start; if it fails (e.g. PV
-//     not yet created) task.PVLabeled remains false. The polling loop will retry
-//     labeling until successful.
-//
-// 5. Asynchronous monitoring:
-//   - A goroutine watches progress (polling Azure), emitting events for start (if
-//     deferred), incremental progress, completion, failure or timeout.
-//
-// 6. Error handling:
-//   - Non‑fatal issues (parse failure, start error) are logged and abort initiation
-//     for that disk; they do not propagate back to the CSI operation.
-//
-// Concurrency notes:
-//   - This function itself is lightweight and only delegates; StartMigrationMonitoring
-//     handles internal synchronization of task state.
-//   - Idempotency: if monitoring is already active for diskURI, underlying monitor
-//     short‑circuits.
-//
-// Returns: nothing; logs warnings on recoverable issues.
-//
-// NOTE: If future migrations support additional target SKUs, relax the toSKU check.
-func (d *Driver) startSKUMigrationMonitor(
-	ctx context.Context,
-	isProvisioningFlow bool,
-	fromSKUStr string,
-	toSKU armcompute.DiskStorageAccountTypes,
-	diskURI, pvName string,
-	sizeBytes int64,
-) {
-	if d.migrationMonitor == nil || fromSKUStr == "" {
-		return
-	}
-
-	if toSKU != armcompute.DiskStorageAccountTypesPremiumV2LRS || fromSKUStr == string(toSKU) {
-		return
-	}
-	if pvName == "" {
-		var parseErr error
-		_, _, pvName, parseErr = azureutils.GetInfoFromURI(diskURI)
-		if parseErr != nil {
-			klog.Warningf("Skipping monitor, failed to extract pv name from URI %s: %v", diskURI, parseErr)
-			return
-		}
-	}
-	if err := d.migrationMonitor.StartMigrationMonitoring(
-		ctx, isProvisioningFlow, diskURI, pvName, fromSKUStr, toSKU, sizeBytes); err != nil {
-		klog.Warningf("failed to start SKU migration monitoring for %s: %v", diskURI, err)
-	}
 }
 
 // CreateVolume provisions an azure disk
@@ -1610,6 +1505,95 @@ func (d *Driver) getSnapshot(ctx context.Context, sourceID string) (*armcompute.
 	return snapshotRetrieved, nil
 }
 
+// startSKUMigrationMonitor starts (idempotently) an asynchronous monitor that tracks
+// migration of a managed disk from one SKU to another (currently only when moving
+// to PremiumV2).
+//
+// Parameters:
+//
+//	ctx                - request context
+//	isProvisioningFlow - true when invoked from CreateVolume (PV may not exist yet);
+//	                     false when invoked from ModifyVolume (PV should already exist).
+//	fromSKUStr         - original disk SKU name (string form, may differ in casing)
+//	toSKU              - target armcompute.DiskStorageAccountTypes (must be PremiumV2LRS to proceed)
+//	diskURI            - full Azure disk resource ID
+//	pvName             - Kubernetes PV name if known (CreateVolume path supplies req.Name;
+//	                     ModifyVolume path does not, so we derive it from diskURI)
+//	sizeBytes          - disk size (used to derive migration timeout)
+//
+// Workflow / decision points:
+// 1. Guard clauses:
+//   - If no migration monitor is configured OR fromSKUStr empty: do nothing.
+//   - If target SKU is not PremiumV2 OR already matches fromSKU: no migration needed.
+//
+// 2. PV name resolution:
+//   - If pvName is empty (ModifyVolume path) attempt to parse diskURI and use its last
+//     token (disk name) as the PV name.
+//   - If the cluster used static provisioning with a PV name different from the Azure
+//     disk name, this heuristic cannot map the disk to the PV; monitoring is skipped.
+//
+// 3. StartMonitoring call:
+//   - Calls migrationMonitor.StartMigrationMonitoring(ctx, isProvisioningFlow, ...).
+//   - isProvisioningFlow influences initial behavior inside the monitor:
+//   - Provisioning (true): PV may not yet exist. The monitor records a task with
+//     empty PVC metadata, attempts an initial label add (may fail if PV absent),
+//     and defers PV / PVC discovery, labeling, and start event emission to the
+//     periodic polling loop (monitorMigrationProgress).
+//   - Modify (false): PV should exist. The monitor immediately fetches the PV,
+//     derives PVC name/namespace, adds/ensures the migration label, and emits
+//     the "Started" event (unless label already existed; then it logs a resume).
+//
+// 4. Label management:
+//   - addMigrationLabelIfNotExists is executed once at start; if it fails (e.g. PV
+//     not yet created) task.PVLabeled remains false. The polling loop will retry
+//     labeling until successful.
+//
+// 5. Asynchronous monitoring:
+//   - A goroutine watches progress (polling Azure), emitting events for start (if
+//     deferred), incremental progress, completion, failure or timeout.
+//
+// 6. Error handling:
+//   - Non‑fatal issues (parse failure, start error) are logged and abort initiation
+//     for that disk; they do not propagate back to the CSI operation.
+//
+// Concurrency notes:
+//   - This function itself is lightweight and only delegates; StartMigrationMonitoring
+//     handles internal synchronization of task state.
+//   - Idempotency: if monitoring is already active for diskURI, underlying monitor
+//     short‑circuits.
+//
+// Returns: nothing; logs warnings on recoverable issues.
+//
+// NOTE: If future migrations support additional target SKUs, relax the toSKU check.
+func (d *Driver) startSKUMigrationMonitor(
+	ctx context.Context,
+	isProvisioningFlow bool,
+	fromSKUStr string,
+	toSKU armcompute.DiskStorageAccountTypes,
+	diskURI, pvName string,
+	sizeBytes int64,
+) {
+	if d.migrationMonitor == nil || fromSKUStr == "" {
+		return
+	}
+
+	if toSKU != armcompute.DiskStorageAccountTypesPremiumV2LRS || fromSKUStr == string(toSKU) {
+		return
+	}
+	if pvName == "" {
+		var parseErr error
+		_, _, pvName, parseErr = azureutils.GetInfoFromURI(diskURI)
+		if parseErr != nil {
+			klog.Warningf("Skipping monitor, failed to extract pv name from URI %s: %v", diskURI, parseErr)
+			return
+		}
+	}
+	if err := d.migrationMonitor.StartMigrationMonitoring(
+		ctx, isProvisioningFlow, diskURI, pvName, fromSKUStr, toSKU, sizeBytes); err != nil {
+		klog.Warningf("failed to start SKU migration monitoring for %s: %v", diskURI, err)
+	}
+}
+
 // getSnapshotSKU retrieves the SKU of the snapshot and returns the SKU or if any error occurs
 func getSnapshotSKUFromSnapshot(computeSnapshot *armcompute.Snapshot) (string, error) {
 	if computeSnapshot == nil {
@@ -1643,4 +1627,20 @@ func inlineVolumeSpecMatchesDisk(driverName, diskURI string, va *storagev1.Volum
 		return true
 	}
 	return false
+}
+
+// truncateErrMsg truncates long error messages while preserving both the
+// beginning (context) and end (critical details like permission errors).
+// This ensures that important information at the tail of verbose Azure
+// error messages (e.g., missing permissions) remains visible in kube-events
+// which are limited to 1024 bytes.
+func truncateErrMsg(errMsg string) string {
+	if len(errMsg) <= maxErrMsgLength {
+		return errMsg
+	}
+	// Keep head (~40%) for context and tail (~60%) for critical error details.
+	const ellipsis = " ... "
+	headLen := (maxErrMsgLength - len(ellipsis)) * 2 / 5
+	tailLen := maxErrMsgLength - headLen - len(ellipsis)
+	return errMsg[:headLen] + ellipsis + errMsg[len(errMsg)-tailLen:]
 }

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -51,14 +51,6 @@ const (
 	volumeOperationAlreadyExistsFmt = "An operation with the given Volume ID %s already exists"
 )
 
-func getDefaultFsType() string {
-	if runtime.GOOS == "windows" {
-		return defaultWindowsFsType
-	}
-
-	return defaultLinuxFsType
-}
-
 // NodeStageVolume mount disk device to a staging path
 func (d *Driver) NodeStageVolume(_ context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
@@ -83,6 +75,13 @@ func (d *Driver) NodeStageVolume(_ context.Context, req *csi.NodeStageVolumeRequ
 	}
 
 	if err := azureutils.IsValidVolumeCapabilities([]*csi.VolumeCapability{volumeCapability}, maxShares); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// Resolve fsType before device discovery so a bad value fails fast, rather than after
+	// a LUN rescan that polls for two minutes.
+	fstype, mountFlags, err := resolveFSType(volumeCapability, params)
+	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -140,21 +139,7 @@ func (d *Driver) NodeStageVolume(_ context.Context, req *csi.NodeStageVolumeRequ
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
 
-	// Get fsType and mountOptions that the volume will be formatted and mounted with
-	fstype := getDefaultFsType()
-	options := []string{}
-	if mnt := volumeCapability.GetMount(); mnt != nil {
-		if mnt.FsType != "" {
-			fstype = mnt.FsType
-		}
-		options = append(options, collectMountOptions(fstype, mnt.MountFlags)...)
-	}
-
-	volContextFSType := azureutils.GetFStype(req.GetVolumeContext())
-	if volContextFSType != "" {
-		// respect "fstype" setting in storage class parameters
-		fstype = volContextFSType
-	}
+	options := collectMountOptions(fstype, mountFlags)
 
 	// If partition is specified, should mount it only instead of the entire disk.
 	if partition, ok := req.GetVolumeContext()[consts.VolumeAttributePartition]; ok {
@@ -727,6 +712,48 @@ func (d *Driver) validateBlockDeviceSize(devicePath string, requestGiB int64) (i
 	}
 
 	return blockSizeBytes, nil
+}
+
+func getDefaultFsType() string {
+	if runtime.GOOS == "windows" {
+		return defaultWindowsFsType
+	}
+
+	return defaultLinuxFsType
+}
+
+// resolveFSType returns the filesystem type and mount flags to stage a volume with,
+// or an empty fsType for the block access type, which has no filesystem. Values outside
+// the supported set are rejected, except on Windows where the mounters ignore fsType and
+// always format NTFS, so rejecting would break configurations that already worked.
+func resolveFSType(volumeCapability *csi.VolumeCapability, params map[string]string) (string, []string, error) {
+	// IsValidVolumeCapabilities rejects caps with block and mount both set or both nil,
+	// so a nil mount here is the block access type.
+	mnt := volumeCapability.GetMount()
+	if mnt == nil {
+		return "", nil, nil
+	}
+
+	fstype := getDefaultFsType()
+	if mnt.FsType != "" {
+		fstype = mnt.FsType
+	}
+
+	if volContextFSType := azureutils.GetFStype(params); volContextFSType != "" {
+		// respect "fstype" setting in storage class parameters
+		fstype = volContextFSType
+	}
+
+	// fstype is attacker-controllable via volume attributes and ends up in mkfs/mount, so allowlist it
+	normalized, err := azureutils.NormalizeFSType(fstype)
+	if err != nil {
+		if runtime.GOOS != "windows" {
+			return "", nil, err
+		}
+		normalized = getDefaultFsType()
+		klog.Warningf("NodeStageVolume: %v, falling back to %s", err, normalized)
+	}
+	return normalized, mnt.MountFlags, nil
 }
 
 func collectMountOptions(fsType string, mntFlags []string) []string {

--- a/pkg/azuredisk/nodeserver_test.go
+++ b/pkg/azuredisk/nodeserver_test.go
@@ -401,6 +401,96 @@ func TestNodeGetVolumeStats(t *testing.T) {
 	}
 }
 
+// TestResolveFSType runs on every platform, including the Windows CI runner, because it
+// needs no mounter: NewFakeSafeMounter returns a real csi-proxy mounter on Windows, which
+// is why the NodeStageVolume cases below are all skipped there.
+func TestResolveFSType(t *testing.T) {
+	mountCap := func(fsType string, flags ...string) *csi.VolumeCapability {
+		return &csi.VolumeCapability{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{FsType: fsType, MountFlags: flags},
+			},
+		}
+	}
+	blockCap := &csi.VolumeCapability{
+		AccessType: &csi.VolumeCapability_Block{Block: &csi.VolumeCapability_BlockVolume{}},
+	}
+
+	t.Run("block access type has no fsType", func(t *testing.T) {
+		fstype, flags, err := resolveFSType(blockCap, map[string]string{consts.FsTypeField: "vfat"})
+		require.NoError(t, err)
+		assert.Empty(t, fstype)
+		assert.Empty(t, flags)
+	})
+
+	t.Run("default is used when nothing is set", func(t *testing.T) {
+		fstype, _, err := resolveFSType(mountCap(""), nil)
+		require.NoError(t, err)
+		assert.Equal(t, getDefaultFsType(), fstype)
+	})
+
+	t.Run("mount flags are preserved", func(t *testing.T) {
+		_, flags, err := resolveFSType(mountCap("", "barrier=1", "acl"), nil)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"barrier=1", "acl"}, flags)
+	})
+
+	if runtime.GOOS == "windows" {
+		// The Windows mounters ignore fsType and always format NTFS, so an unsupported
+		// value must degrade to the default rather than fail staging.
+		t.Run("unsupported fsType falls back to ntfs", func(t *testing.T) {
+			for _, fsType := range []string{"ext4", "xfs", "btrfs", "vfat", "ext4;rm -rf /"} {
+				fstype, flags, err := resolveFSType(mountCap(fsType, "acl"), nil)
+				require.NoError(t, err, "fsType %q must not fail staging on windows", fsType)
+				assert.Equal(t, defaultWindowsFsType, fstype, "fsType %q", fsType)
+				assert.Equal(t, []string{"acl"}, flags, "fsType %q", fsType)
+			}
+		})
+
+		t.Run("unsupported fsType from volumeAttributes falls back to ntfs", func(t *testing.T) {
+			fstype, _, err := resolveFSType(mountCap("ntfs"), map[string]string{consts.FsTypeField: "ext4"})
+			require.NoError(t, err)
+			assert.Equal(t, defaultWindowsFsType, fstype)
+		})
+
+		t.Run("ntfs is accepted", func(t *testing.T) {
+			fstype, _, err := resolveFSType(mountCap("NTFS"), nil)
+			require.NoError(t, err)
+			assert.Equal(t, defaultWindowsFsType, fstype)
+		})
+	} else {
+		t.Run("unsupported fsType is rejected", func(t *testing.T) {
+			for _, fsType := range []string{"ntfs", "vfat", "ext4;rm -rf /"} {
+				_, _, err := resolveFSType(mountCap(fsType), nil)
+				require.Error(t, err, "fsType %q must be rejected", fsType)
+			}
+		})
+
+		t.Run("volumeAttributes overrides the capability", func(t *testing.T) {
+			fstype, _, err := resolveFSType(mountCap("ext4"), map[string]string{consts.FsTypeField: "xfs"})
+			require.NoError(t, err)
+			assert.Equal(t, "xfs", fstype)
+		})
+
+		t.Run("casing is normalized", func(t *testing.T) {
+			fstype, _, err := resolveFSType(mountCap("XFS"), nil)
+			require.NoError(t, err)
+			assert.Equal(t, "xfs", fstype)
+		})
+	}
+}
+
+// assertMountedXFSWithNouuid checks that the fstype resolved by NodeStageVolume is what
+// actually reached mount, and that collectMountOptions saw it (xfs implies "nouuid").
+func assertMountedXFSWithNouuid(t *testing.T, d FakeDriver) {
+	t.Helper()
+	fake, ok := d.getMounter().Interface.(*mounter.FakeSafeMounter)
+	require.True(t, ok, "expected a FakeSafeMounter")
+	require.Len(t, fake.MountCalls, 1, "expected exactly one mount")
+	assert.Equal(t, "xfs", fake.MountCalls[0].FSType)
+	assert.Contains(t, fake.MountCalls[0].Options, "nouuid")
+}
+
 func TestNodeStageVolume(t *testing.T) {
 	cntl := gomock.NewController(t)
 	defer cntl.Finish()
@@ -423,6 +513,22 @@ func TestNodeStageVolume(t *testing.T) {
 	volumeContextWithPerfProfileField := map[string]string{
 		consts.PerfProfileField: "wrong",
 	}
+	volumeContextWithInvalidFSType := map[string]string{
+		consts.FsTypeField: "vfat",
+	}
+	volumeContextWithXFS := map[string]string{
+		consts.FsTypeField: "xfs",
+	}
+	volumeContextWithNTFS := map[string]string{
+		consts.FsTypeField: "ntfs",
+	}
+
+	// fsType casing is normalized before it reaches mkfs/mount and collectMountOptions.
+	stdVolCapUpperXFS := &csi.VolumeCapability_Mount{
+		Mount: &csi.VolumeCapability_MountVolume{
+			FsType: "XFS",
+		},
+	}
 
 	stdVolCapBlock := &csi.VolumeCapability_Block{
 		Block: &csi.VolumeCapability_BlockVolume{},
@@ -440,6 +546,9 @@ func TestNodeStageVolume(t *testing.T) {
 	blkidAction := func() ([]byte, []byte, error) {
 		return []byte("DEVICE=/dev/sdd\nTYPE=ext4"), []byte{}, nil
 	}
+	xfsBlkidAction := func() ([]byte, []byte, error) {
+		return []byte("DEVICE=/dev/sdd\nTYPE=xfs"), []byte{}, nil
+	}
 	fsckAction := func() ([]byte, []byte, error) {
 		return []byte{}, []byte{}, nil
 	}
@@ -451,13 +560,18 @@ func TestNodeStageVolume(t *testing.T) {
 	}
 
 	tests := []struct {
-		desc          string
-		setupFunc     func(*testing.T, FakeDriver)
-		req           *csi.NodeStageVolumeRequest
-		expectedErr   error
-		skipOnDarwin  bool
-		skipOnWindows bool
-		cleanupFunc   func(*testing.T, FakeDriver)
+		desc        string
+		setupFunc   func(*testing.T, FakeDriver)
+		req         *csi.NodeStageVolumeRequest
+		expectedErr error
+		// expectedCode/expectedErrContains assert on the status code plus message
+		// substrings, for cases where the exact wording is not what's under test.
+		expectedCode        codes.Code
+		expectedErrContains []string
+		skipOnDarwin        bool
+		skipOnWindows       bool
+		validateFunc        func(*testing.T, FakeDriver)
+		cleanupFunc         func(*testing.T, FakeDriver)
 	}{
 		{
 			desc:        "Volume ID missing",
@@ -513,6 +627,81 @@ func TestNodeStageVolume(t *testing.T) {
 				VolumeContext:  volumeContext,
 			},
 			expectedErr: status.Error(codes.Internal, "failed to find disk on lun /dev/01. cannot parse deviceInfo: /dev/01"),
+		},
+		{
+			desc:          "Unsupported fsType",
+			skipOnDarwin:  true,
+			skipOnWindows: true,
+			req: &csi.NodeStageVolumeRequest{VolumeId: "vol_1", StagingTargetPath: sourceTest,
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap,
+					AccessType: stdVolCap},
+				PublishContext: publishContext,
+				VolumeContext:  volumeContextWithInvalidFSType,
+			},
+			expectedCode:        codes.InvalidArgument,
+			expectedErrContains: []string{"vfat", "not supported"},
+		},
+		{
+			// No PublishContext: fsType must be rejected before the LUN is even read, so
+			// that a bad value cannot first trigger a device rescan that polls for minutes.
+			desc:          "invalid fsType rejected before LUN handling",
+			skipOnDarwin:  true,
+			skipOnWindows: true,
+			req: &csi.NodeStageVolumeRequest{VolumeId: "vol_1", StagingTargetPath: sourceTest,
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap,
+					AccessType: stdVolCap},
+				VolumeContext: volumeContextWithInvalidFSType,
+			},
+			expectedCode:        codes.InvalidArgument,
+			expectedErrContains: []string{"vfat", "not supported"},
+		},
+		{
+			// The Linux image ships no NTFS formatter. Windows takes the opposite path and
+			// falls back to the default instead of erroring, which needs a Windows runner.
+			desc:          "ntfs rejected on Linux",
+			skipOnDarwin:  true,
+			skipOnWindows: true,
+			req: &csi.NodeStageVolumeRequest{VolumeId: "vol_1", StagingTargetPath: sourceTest,
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap,
+					AccessType: stdVolCap},
+				PublishContext: publishContext,
+				VolumeContext:  volumeContextWithNTFS,
+			},
+			expectedCode:        codes.InvalidArgument,
+			expectedErrContains: []string{"ntfs", "not supported"},
+		},
+		{
+			// volumeAttributes.fsType overrides the volume capability, so "nouuid" must be
+			// derived from the override rather than from the capability's ext4.
+			desc:          "xfs from volumeAttributes overrides volume capability and gets nouuid",
+			skipOnDarwin:  true,
+			skipOnWindows: true,
+			setupFunc: func(_ *testing.T, d FakeDriver) {
+				d.setNextCommandOutputScripts(xfsBlkidAction, fsckAction, blockSizeAction, xfsBlkidAction, blockSizeAction, xfsBlkidAction)
+			},
+			req: &csi.NodeStageVolumeRequest{VolumeId: "vol_1", StagingTargetPath: sourceTest,
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap,
+					AccessType: stdVolCap},
+				PublishContext: publishContext,
+				VolumeContext:  volumeContextWithXFS,
+			},
+			expectedErr:  nil,
+			validateFunc: assertMountedXFSWithNouuid,
+		},
+		{
+			desc:          "uppercase XFS in volume capability is normalized and gets nouuid",
+			skipOnDarwin:  true,
+			skipOnWindows: true,
+			setupFunc: func(_ *testing.T, d FakeDriver) {
+				d.setNextCommandOutputScripts(xfsBlkidAction, fsckAction, blockSizeAction, xfsBlkidAction, blockSizeAction, xfsBlkidAction)
+			},
+			req: &csi.NodeStageVolumeRequest{VolumeId: "vol_1", StagingTargetPath: sourceTest,
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap,
+					AccessType: stdVolCapUpperXFS},
+				PublishContext: publishContext,
+			},
+			expectedErr:  nil,
+			validateFunc: assertMountedXFSWithNouuid,
 		},
 		{
 			desc:          "Successfully staged",
@@ -659,8 +848,17 @@ func TestNodeStageVolume(t *testing.T) {
 			_, err := d.NodeStageVolume(context.Background(), test.req)
 			if test.desc == "Failed volume mount" {
 				assert.Error(t, err)
+			} else if len(test.expectedErrContains) > 0 {
+				require.Error(t, err)
+				assert.Equal(t, test.expectedCode, status.Code(err), "desc: %s", test.desc)
+				for _, substr := range test.expectedErrContains {
+					assert.Contains(t, status.Convert(err).Message(), substr, "desc: %s", test.desc)
+				}
 			} else if !reflect.DeepEqual(err, test.expectedErr) {
 				t.Errorf("desc: %s\n actualErr: (%v), expectedErr: (%v)", test.desc, err, test.expectedErr)
+			}
+			if test.validateFunc != nil {
+				test.validateFunc(t, d)
 			}
 			if test.cleanupFunc != nil {
 				test.cleanupFunc(t, d)

--- a/pkg/azureutils/azure_disk_utils.go
+++ b/pkg/azureutils/azure_disk_utils.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -332,6 +334,28 @@ func GetFStype(attributes map[string]string) string {
 		}
 	}
 	return ""
+}
+
+// SupportedFSTypes returns the filesystem types this node can actually format and mount.
+// The Linux image ships e2fsprogs/xfsprogs/btrfs-progs but no NTFS formatter, and the
+// Windows mounters ignore fstype and always format NTFS, so the sets are disjoint.
+func SupportedFSTypes() []string {
+	if runtime.GOOS == "windows" {
+		return []string{"ntfs"}
+	}
+	return []string{"btrfs", "ext2", "ext3", "ext4", "xfs"}
+}
+
+// NormalizeFSType lowercases fsType and verifies it is supported on the current OS.
+// The value reaches `mkfs.<fstype>` and `mount -t <fstype>`, so restricting it also
+// prevents untrusted volume attributes from selecting an arbitrary helper binary.
+func NormalizeFSType(fsType string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(fsType))
+	supported := SupportedFSTypes()
+	if !slices.Contains(supported, normalized) {
+		return "", fmt.Errorf("fsType(%q) is not supported on %s, supported fsTypes are %v", normalized, runtime.GOOS, supported)
+	}
+	return normalized, nil
 }
 
 func GetMaxShares(attributes map[string]string) (int, error) {

--- a/pkg/azureutils/azure_disk_utils_test.go
+++ b/pkg/azureutils/azure_disk_utils_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -427,6 +428,52 @@ func TestGetFStype(t *testing.T) {
 		if result != test.expected {
 			t.Errorf("input: %q, GetFStype result: %s, expected: %s", test.options, result, test.expected)
 		}
+	}
+}
+
+func TestNormalizeFSType(t *testing.T) {
+	type testCase struct {
+		fsType      string
+		expected    string
+		expectError bool
+	}
+
+	// Rejected on every platform.
+	tests := []testCase{
+		{"", "", true},
+		{"vfat", "", true},
+		{"ext4;rm -rf /", "", true},
+		{"../../../bin/sh", "", true},
+		{"-t", "", true},
+	}
+
+	// The supported set is disjoint between platforms: the Linux image ships no NTFS
+	// formatter, and the Windows mounters only ever format NTFS.
+	if runtime.GOOS == "windows" {
+		tests = append(tests,
+			testCase{"ntfs", "ntfs", false},
+			testCase{"NTFS", "ntfs", false},
+			testCase{"  ntfs  ", "ntfs", false},
+			testCase{"ext4", "", true},
+			testCase{"xfs", "", true},
+		)
+	} else {
+		tests = append(tests,
+			testCase{"ext4", "ext4", false},
+			testCase{"ext3", "ext3", false},
+			testCase{"ext2", "ext2", false},
+			testCase{"xfs", "xfs", false},
+			testCase{"btrfs", "btrfs", false},
+			testCase{"XFS", "xfs", false},
+			testCase{"  ext4  ", "ext4", false},
+			testCase{"ntfs", "", true},
+		)
+	}
+
+	for _, test := range tests {
+		result, err := NormalizeFSType(test.fsType)
+		assert.Equal(t, test.expectError, err != nil, "input: %q, err: %v", test.fsType, err)
+		assert.Equal(t, test.expected, result, "input: %q", test.fsType)
 	}
 }
 

--- a/pkg/mounter/fake_safe_mounter.go
+++ b/pkg/mounter/fake_safe_mounter.go
@@ -27,10 +27,21 @@ import (
 	testingexec "k8s.io/utils/exec/testing"
 )
 
+// MountCall records the arguments of a single Mount call.
+type MountCall struct {
+	Source  string
+	Target  string
+	FSType  string
+	Options []string
+}
+
 // FakeSafeMounter implements a mount.Interface interface suitable for use in unit tests.
 type FakeSafeMounter struct {
 	mount.FakeMounter
 	testingexec.FakeExec
+
+	// MountCalls records every Mount call in order, for assertions in tests.
+	MountCalls []MountCall
 }
 
 // NewFakeSafeMounter creates a mount.SafeFormatAndMount instance suitable for use in unit tests.
@@ -49,7 +60,14 @@ func NewFakeSafeMounter() (*mount.SafeFormatAndMount, error) {
 }
 
 // Mount overrides mount.FakeMounter.Mount.
-func (f *FakeSafeMounter) Mount(source, target, _ string, _ []string) error {
+func (f *FakeSafeMounter) Mount(source, target, fstype string, options []string) error {
+	f.MountCalls = append(f.MountCalls, MountCall{
+		Source:  source,
+		Target:  target,
+		FSType:  fstype,
+		Options: append([]string(nil), options...),
+	})
+
 	if strings.Contains(source, "error_mount") {
 		return fmt.Errorf("fake Mount: source error")
 	} else if strings.Contains(target, "error_mount") {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Validates fstype against the set the node can actually handle, per OS, and fixes a related mount-option bug found while doing so.
- Linux: ext2, ext3, ext4, xfs, btrfs (what the image's e2fsprogs/xfsprogs/btrfs-progs provide). Anything else is rejected with InvalidArgument.
- Windows: ntfs. Anything else logs a warning and falls back to ntfs rather than erroring, since the Windows mounters already discard fstype and always format NTFS — rejecting would break configs that work today.

- This is hardening, not a privilege-escalation fix. fsType comes from the StorageClass (or a statically provisioned PV), both cluster-admin resources — an unprivileged pod author cannot set it. The value is defense-in-depth against a compromised provisioner and against a malicious mkfs.<x> on the node's PATH, plus a clearer error message for typo'd fstypes.

- It also fixes a real nouuid bug. collectMountOptions was previously called inside the GetMount() block, before volumeAttributes.fsType could override the value and before normalization. So xfs specified via volumeAttributes.fsType — or XFS in any casing — silently did not get the nouuid mount option. That option is what allows a clone or restored snapshot to be mounted alongside its source on the same node; without it the second mount fails on duplicate filesystem UUID. The call now runs on the resolved, normalized fstype.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
