### PR TITLE
[release-1.34] fix: set success metric on early-success returns; guard nil disk before SKU access

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.24.1 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
+	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect

--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -1056,15 +1056,15 @@ func (d *Driver) ControllerExpandVolume(ctx context.Context, req *csi.Controller
 	if rerr != nil {
 		return nil, status.Errorf(codes.Internal, "GetDiskByURI(%s) failed with error(%v)", diskURI, rerr)
 	}
+	if result == nil || result.Properties == nil || result.Properties.DiskSizeGB == nil {
+		return nil, status.Errorf(codes.Internal, "could not get size of the disk(%s)", diskURI)
+	}
 
 	var diskSku string
 	if result.SKU != nil && result.SKU.Name != nil {
 		diskSku = string(*result.SKU.Name)
 	}
 
-	if result == nil || result.Properties == nil || result.Properties.DiskSizeGB == nil {
-		return nil, status.Errorf(codes.Internal, "could not get size of the disk(%s)", diskURI)
-	}
 	oldSize := *resource.NewQuantity(int64(*result.Properties.DiskSizeGB), resource.BinarySI)
 
 	mc := csiMetrics.NewCSIMetricContext("controller_expand_volume").WithBasicVolumeInfo(d.cloud.ResourceGroup, d.cloud.SubscriptionID, d.Name)

--- a/pkg/azuredisk/controllerserver_test.go
+++ b/pkg/azuredisk/controllerserver_test.go
@@ -2481,6 +2481,32 @@ func TestControllerExpandVolume(t *testing.T) {
 				}
 			},
 		},
+		{
+			// Regression guard for the nil-dereference fix in this PR: the
+			// disk client can legitimately return (nil, nil) (e.g. NotFound
+			// mapped to a nil result with a nil error). Before the fix, the
+			// controller dereferenced result.SKU before the nil check and
+			// panicked; now it must return an Internal error naming the disk.
+			name: "disk client returns (nil, nil) - no panic, Internal error",
+			testFunc: func(t *testing.T) {
+				req := &csi.ControllerExpandVolumeRequest{
+					VolumeId:      testVolumeID,
+					CapacityRange: stdCapRange,
+				}
+				ctx := context.Background()
+				cntl := gomock.NewController(t)
+				defer cntl.Finish()
+				d, _ := NewFakeDriver(cntl)
+				diskClient := mock_diskclient.NewMockInterface(cntl)
+				d.getClientFactory().(*mock_azclient.MockClientFactory).EXPECT().GetDiskClientForSub(gomock.Any()).Return(diskClient, nil).AnyTimes()
+				diskClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+				expectedErr := status.Errorf(codes.Internal, "could not get size of the disk(/subscriptions/subs/resourceGroups/rg/providers/Microsoft.Compute/disks/unit-test-volume)")
+				_, err := d.ControllerExpandVolume(ctx, req)
+				if !reflect.DeepEqual(err, expectedErr) {
+					t.Errorf("actualErr: (%v), expectedErr: (%v)", err, expectedErr)
+				}
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, tc.testFunc)

--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -127,6 +127,7 @@ func (d *Driver) NodeStageVolume(_ context.Context, req *csi.NodeStageVolumeRequ
 	// If the access type is block, do nothing for stage
 	switch req.GetVolumeCapability().GetAccessType().(type) {
 	case *csi.VolumeCapability_Block:
+		isOperationSucceeded = true
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
 
@@ -136,6 +137,7 @@ func (d *Driver) NodeStageVolume(_ context.Context, req *csi.NodeStageVolumeRequ
 	}
 	if mnt {
 		klog.V(2).Infof("NodeStageVolume: already mounted on target %s", target)
+		isOperationSucceeded = true
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
 
@@ -280,6 +282,7 @@ func (d *Driver) NodePublishVolume(_ context.Context, req *csi.NodePublishVolume
 		}
 		if mnt {
 			klog.V(2).Infof("NodePublishVolume: already mounted on target %s", target)
+			isOperationSucceeded = true
 			return &csi.NodePublishVolumeResponse{}, nil
 		}
 	}

--- a/pkg/azuredisk/nodeserver_metrics_test.go
+++ b/pkg/azuredisk/nodeserver_metrics_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azuredisk
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"k8s.io/component-base/metrics/legacyregistry"
+
+	consts "sigs.k8s.io/azuredisk-csi-driver/pkg/azureconstants"
+	"sigs.k8s.io/azuredisk-csi-driver/pkg/mounter"
+)
+
+// These tests are regression guards for the metric-emission fix in
+// https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/3789.
+//
+// Before the fix, several early-success return paths in NodeStageVolume and
+// NodePublishVolume bypassed the `isOperationSucceeded = true` assignment,
+// so the deferred ObserveWithLabels recorded success="false" for what were
+// semantically successful CSI calls. The existing table-driven tests only
+// checked the returned error and never asserted on the emitted metric, which
+// is why the regression could be introduced in the first place.
+//
+// Each test resets the operation counter, drives the exact early-success
+// return path being covered, and asserts a single sample with
+// success="true" for the corresponding CSI operation.
+
+// countOperationSamples returns the total number of samples recorded in the
+// azuredisk_csi_driver_operations_total counter for a given (operation,
+// success) label combination.
+func countOperationSamples(t *testing.T, operation, success string) float64 {
+	t.Helper()
+	families, err := legacyregistry.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	var total float64
+	for _, family := range families {
+		if family.GetName() != "azuredisk_csi_driver_operations_total" {
+			continue
+		}
+		for _, m := range family.GetMetric() {
+			var gotOp, gotSuccess string
+			for _, lp := range m.GetLabel() {
+				switch lp.GetName() {
+				case "operation":
+					gotOp = lp.GetValue()
+				case "success":
+					gotSuccess = lp.GetValue()
+				}
+			}
+			if gotOp == operation && gotSuccess == success {
+				total += counterValue(m)
+			}
+		}
+	}
+	return total
+}
+
+func counterValue(m *dto.Metric) float64 {
+	if c := m.GetCounter(); c != nil {
+		return c.GetValue()
+	}
+	return 0
+}
+
+// TestNodeStageVolume_BlockAccessType_EmitsSuccessMetric guards the
+// success-metric fix on the block-access-type early return in
+// NodeStageVolume (pkg/azuredisk/nodeserver.go line ~130 in the PR diff).
+func TestNodeStageVolume_BlockAccessType_EmitsSuccessMetric(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		// findDiskByLun is only wired up for Linux (Windows uses safe_mounter
+		// host-process CIM APIs; Darwin returns "findDiskByLun not implemented").
+		// The block-access-type early return this test guards is OS-agnostic,
+		// so Linux-only coverage where the fake IOHandler resolves LUN 1 is
+		// sufficient.
+		t.Skip("skipping on non-Linux: fake LUN resolution not supported")
+	}
+	cntl := gomock.NewController(t)
+	defer cntl.Finish()
+	d, _ := NewFakeDriver(cntl)
+	fakeMounter, err := mounter.NewFakeSafeMounter()
+	require.NoError(t, err)
+	d.setMounter(fakeMounter)
+
+	before := countOperationSamples(t, "node_stage_volume", "true")
+
+	req := &csi.NodeStageVolumeRequest{
+		VolumeId:          "vol_1",
+		StagingTargetPath: sourceTest,
+		PublishContext: map[string]string{
+			consts.LUN: "/dev/disk/azure/scsi1/lun1",
+		},
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{Mode: 2},
+			AccessType: &csi.VolumeCapability_Block{
+				Block: &csi.VolumeCapability_BlockVolume{},
+			},
+		},
+	}
+	_, err = d.NodeStageVolume(context.Background(), req)
+	require.NoError(t, err, "block-access-type NodeStageVolume should short-circuit successfully")
+
+	after := countOperationSamples(t, "node_stage_volume", "true")
+	assert.InDelta(t, before+1, after, 0.0001,
+		"NodeStageVolume block-access-type early return must record success=\"true\" on node_stage_volume counter")
+}
+
+// TestNodePublishVolume_AlreadyMounted_EmitsSuccessMetric guards the
+// success-metric fix on the already-mounted early return in
+// NodePublishVolume (pkg/azuredisk/nodeserver.go line ~285 in the PR diff).
+//
+// Uses the same guard as TestNodePublishVolumeIdempotentMount: this path
+// requires the real mounter and root privileges to reach the
+// ensureMountPoint(target) == already-mounted branch.
+func TestNodePublishVolume_AlreadyMounted_EmitsSuccessMetric(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Getuid() != 0 {
+		t.Skip("requires root on Linux to exercise the already-mounted early return")
+	}
+	cntl := gomock.NewController(t)
+	defer cntl.Finish()
+	d, _ := NewFakeDriver(cntl)
+
+	_ = makeDir(sourceTest)
+	_ = makeDir(targetTest)
+	defer func() {
+		_ = d.getMounter().Unmount(targetTest)
+		_ = d.getMounter().Unmount(targetTest)
+		_ = os.RemoveAll(sourceTest)
+		_ = os.RemoveAll(targetTest)
+	}()
+
+	stdVolCap := &csi.VolumeCapability_Mount{
+		Mount: &csi.VolumeCapability_MountVolume{FsType: defaultLinuxFsType},
+	}
+	req := &csi.NodePublishVolumeRequest{
+		VolumeId:          "vol_1",
+		StagingTargetPath: sourceTest,
+		TargetPath:        targetTest,
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
+			AccessType: stdVolCap,
+		},
+		Readonly: true,
+	}
+
+	// First publish performs the initial mount.
+	_, err := d.NodePublishVolume(context.Background(), req)
+	require.NoError(t, err)
+
+	before := countOperationSamples(t, "node_publish_volume", "true")
+
+	// Second publish hits the "already mounted" early return.
+	_, err = d.NodePublishVolume(context.Background(), req)
+	require.NoError(t, err, "already-mounted NodePublishVolume should short-circuit successfully")
+
+	after := countOperationSamples(t, "node_publish_volume", "true")
+	assert.GreaterOrEqual(t, after, before+1,
+		"NodePublishVolume already-mounted early return must record success=\"true\" on node_publish_volume counter")
+}


### PR DESCRIPTION
Cherry-pick of #3789 to release-1.34.

**What this PR does:**
- Set `isOperationSucceeded = true` on early-success returns in `NodeStageVolume` and `NodePublishVolume` (block-access-type and already-mounted paths)
- Reorder nil guard before SKU access in `ControllerExpandVolume` to prevent potential nil-pointer panic

**Original PR:** https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/3789