### PR TITLE
cleanup: preserve identity IDs at tail of truncated kube-event messages

### DIFF
--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -1632,15 +1632,23 @@ func inlineVolumeSpecMatchesDisk(driverName, diskURI string, va *storagev1.Volum
 // truncateErrMsg truncates long error messages while preserving both the
 // beginning (context) and end (critical details like permission errors).
 // This ensures that important information at the tail of verbose Azure
-// error messages (e.g., missing permissions) remains visible in kube-events
-// which are limited to 1024 bytes.
+// error messages (e.g., missing role assignments and the ClientId /
+// ObjectId of the identity that needs the permission) remains visible in
+// kube-events which are limited to 1024 bytes.
+//
+// Head/tail split favors the tail because the head is mostly boilerplate
+// ("Attach volume <pvc> to instance <node> failed with rpc error: ...")
+// that the user typically already has from surrounding context, while
+// the tail is where the actionable Azure error details land: the missing
+// action (e.g. "Microsoft.Compute/diskEncryptionSets/read"), the target
+// scope, and the ClientId/ObjectId of the identity that lacks permission.
 func truncateErrMsg(errMsg string) string {
 	if len(errMsg) <= maxErrMsgLength {
 		return errMsg
 	}
-	// Keep head (~40%) for context and tail (~60%) for critical error details.
+	// Keep head (~20%) for context and tail (~80%) for critical error details.
 	const ellipsis = " ... "
-	headLen := (maxErrMsgLength - len(ellipsis)) * 2 / 5
+	headLen := (maxErrMsgLength - len(ellipsis)) / 5
 	tailLen := maxErrMsgLength - headLen - len(ellipsis)
 	return errMsg[:headLen] + ellipsis + errMsg[len(errMsg)-tailLen:]
 }

--- a/pkg/azuredisk/controllerserver_test.go
+++ b/pkg/azuredisk/controllerserver_test.go
@@ -5094,6 +5094,17 @@ func TestTruncateErrMsg(t *testing.T) {
 			wantLen:  maxErrMsgLength,
 			wantTail: "diskEncryptionSets/read' on the linked scope",
 		},
+		{
+			// Regression: verbose DES permission errors end with the
+			// ClientId / ObjectId of the identity that lacks the role
+			// assignment. Those IDs are the actionable part for the
+			// customer (they tell them which managed identity needs the
+			// role) and must survive truncation.
+			name:     "DES permission error preserves ClientId and ObjectId at tail",
+			input:    "Attach volume pvc-abcd-1234 to instance aks-nodepool1-12345678-vmss000000 failed with rpc error: code = Internal desc = " + strings.Repeat("filler junk from long Azure error body ", 30) + "does not have authorization to perform action 'Microsoft.Compute/diskEncryptionSets/read' over scope '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-des/providers/Microsoft.Compute/diskEncryptionSets/my-des' or the scope is invalid. ClientId=11111111-2222-3333-4444-555555555555 ObjectId=66666666-7777-8888-9999-aaaaaaaaaaaa",
+			wantLen:  maxErrMsgLength,
+			wantTail: "ClientId=11111111-2222-3333-4444-555555555555 ObjectId=66666666-7777-8888-9999-aaaaaaaaaaaa",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**

Follow-up to #3673. A customer reported that when AKS lacks a role assignment on a customer-managed `DiskEncryptionSet`, the kube-event now correctly surfaces the DES permission error (thanks to #3673), but the very end of the Azure error — which contains the `ClientId` and `ObjectId` of the managed identity that lacks the permission — is still cut off. Those IDs are the actionable piece: they tell the customer exactly which managed identity to grant the role to.

Root cause: the current head/tail split reserves ~40% of the 990-byte budget for the head and ~60% for the tail. On typical attach-with-DES-permission errors, that leaves the trailing `ClientId=<guid> ObjectId=<guid>` segment just outside the tail window.

**Change:**

Shift the head/tail split from 40/60 to 20/80. The head still keeps ~197 bytes, more than enough for `Attach volume <pvc> to instance <node> failed with rpc error: code = Internal desc =`, which the customer usually already has from surrounding context. The tail keeps ~790 bytes, enough to preserve the missing action, target DES scope, and the `ClientId`/`ObjectId` pair.

Adds a regression test modeling the customer-reported message shape and asserting the `ClientId=<guid> ObjectId=<guid>` suffix survives truncation.

**Which issue(s) this PR fixes:**

Follow-up to #3673 based on customer feedback.

**Release note:**
```release-note
Improve kube-event error truncation so the ClientId/ObjectId of the identity that lacks permission on a DiskEncryptionSet remains visible when attach/detach fails.
```