### PR TITLE
chore(deps): bump golang.org/x/crypto to v0.56.0 to fix Trivy CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -137,7 +137,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
-	golang.org/x/crypto v0.55.0 // indirect
+	golang.org/x/crypto v0.56.0 // indirect
 	golang.org/x/exp v0.0.0-20250911091902-df9299821621 // indirect
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -530,8 +530,8 @@ golang.org/x/crypto v0.41.0/go.mod h1:pO5AFd7FA68rFak7rOAGVuygIISepHftHnr8dr6+sU
 golang.org/x/crypto v0.42.0/go.mod h1:4+rDnOTJhQCx2q7/j6rAN5XDw8kPjeaXEUR2eL94ix8=
 golang.org/x/crypto v0.43.0/go.mod h1:BFbav4mRNlXJL4wNeejLpWxB7wMbc79PdRGhWKncxR0=
 golang.org/x/crypto v0.44.0/go.mod h1:013i+Nw79BMiQiMsOPcVCB5ZIJbYkerPrGnOa00tvmc=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=

--- a/vendor/golang.org/x/crypto/ssh/certs.go
+++ b/vendor/golang.org/x/crypto/ssh/certs.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"slices"
 	"sort"
 	"time"
 )
@@ -305,8 +306,11 @@ const sourceAddressCriticalOption = "source-address"
 // minimally, the IsAuthority callback should be set.
 type CertChecker struct {
 	// SupportedCriticalOptions lists the CriticalOptions that the
-	// server application layer understands. These are only used
-	// for user certificates.
+	// application layer understands. A certificate carrying a critical
+	// option that is not listed here is rejected.
+	// CertChecker.Authenticate additionally accepts the source-address
+	// option, which the server enforces on the Permissions that
+	// Authenticate returns.
 	SupportedCriticalOptions []string
 
 	// IsUserAuthority should return true if the key is recognized as an
@@ -369,8 +373,9 @@ func (c *CertChecker) CheckHostKey(addr string, remote net.Addr, key PublicKey) 
 	return c.CheckCert(hostname, cert)
 }
 
-// Authenticate checks a user certificate. Authenticate can be used as
-// a value for ServerConfig.PublicKeyCallback.
+// Authenticate checks a user certificate. Authenticate can be used as a value
+// for ServerConfig.PublicKeyCallback. The source-address critical option is
+// allowed, as it will be enforced by the server.
 func (c *CertChecker) Authenticate(conn ConnMetadata, pubKey PublicKey) (*Permissions, error) {
 	cert, ok := pubKey.(*Certificate)
 	if !ok {
@@ -389,8 +394,11 @@ func (c *CertChecker) Authenticate(conn ConnMetadata, pubKey PublicKey) (*Permis
 	if !c.IsUserAuthority(cert.SignatureKey) {
 		return nil, fmt.Errorf("ssh: certificate signed by unrecognized authority")
 	}
-
-	if err := c.CheckCert(conn.User(), cert); err != nil {
+	// The source-address critical option is enforced by serverAuthenticate,
+	// so it is supported regardless of SupportedCriticalOptions
+	cc := *c
+	cc.SupportedCriticalOptions = append(slices.Clip(cc.SupportedCriticalOptions), sourceAddressCriticalOption)
+	if err := cc.CheckCert(conn.User(), cert); err != nil {
 		return nil, err
 	}
 
@@ -398,27 +406,15 @@ func (c *CertChecker) Authenticate(conn ConnMetadata, pubKey PublicKey) (*Permis
 }
 
 // CheckCert checks CriticalOptions, ValidPrincipals, revocation, timestamp and
-// the signature of the certificate.
+// the signature of the certificate. Critical options that are not listed in
+// SupportedCriticalOptions are rejected.
 func (c *CertChecker) CheckCert(principal string, cert *Certificate) error {
 	if c.IsRevoked != nil && c.IsRevoked(cert) {
 		return fmt.Errorf("ssh: certificate serial %d revoked", cert.Serial)
 	}
 
 	for opt := range cert.CriticalOptions {
-		// sourceAddressCriticalOption will be enforced by
-		// serverAuthenticate
-		if opt == sourceAddressCriticalOption {
-			continue
-		}
-
-		found := false
-		for _, supp := range c.SupportedCriticalOptions {
-			if supp == opt {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !slices.Contains(c.SupportedCriticalOptions, opt) {
 			return fmt.Errorf("ssh: unsupported critical option %q in certificate", opt)
 		}
 	}

--- a/vendor/golang.org/x/crypto/ssh/channel.go
+++ b/vendor/golang.org/x/crypto/ssh/channel.go
@@ -173,6 +173,12 @@ type channel struct {
 	// (for outbound channels) or received (for inbound channels).
 	decided bool
 
+	// established is set to true once the channel is open and may carry normal
+	// channel traffic: for an outbound channel when the peer's open
+	// confirmation is received, for an inbound channel when the local side
+	// accepts it. It is set and read from different goroutines.
+	established atomic.Bool
+
 	// direction contains either channelOutbound, for channels created
 	// locally, or channelInbound, for channels created by the peer.
 	direction channelDirection
@@ -434,10 +440,20 @@ func (ch *channel) responseMessageReceived() error {
 		return errors.New("ssh: duplicate response received for channel")
 	}
 	ch.decided = true
+	ch.established.Store(true)
 	return nil
 }
 
 func (ch *channel) handlePacket(packet []byte) error {
+	// Only the open response is expected before the channel is established.
+	if !ch.established.Load() {
+		switch packet[0] {
+		case msgChannelOpenConfirm, msgChannelOpenFailure:
+		default:
+			return nil
+		}
+	}
+
 	switch packet[0] {
 	case msgChannelData, msgChannelExtendedData:
 		return ch.handleData(packet)
@@ -503,7 +519,8 @@ func (ch *channel) handlePacket(packet []byte) error {
 		default:
 		}
 	default:
-		ch.msg <- msg
+		// No other message type is expected on an established channel.
+		return fmt.Errorf("ssh: unexpected message type %d on channel %d", packet[0], ch.localId)
 	}
 	return nil
 }
@@ -554,6 +571,7 @@ func (ch *channel) Accept() (Channel, <-chan *Request, error) {
 		MaxPacketSize: ch.maxIncomingPayload,
 	}
 	ch.decided = true
+	ch.established.Store(true)
 	if err := ch.sendMessage(confirm); err != nil {
 		return nil, nil, err
 	}

--- a/vendor/golang.org/x/crypto/ssh/transport.go
+++ b/vendor/golang.org/x/crypto/ssh/transport.go
@@ -331,13 +331,19 @@ func exchangeVersions(rw io.ReadWriter, versionLine []byte) (them []byte, err er
 // chars
 const maxVersionStringBytes = 255
 
+// maxPreVersionLines is the maximum number of lines sent by the peer
+// before the version string. Each of these lines is limited to a maximum
+// of maxVersionStringBytes chars. Lines sent before the version string
+// are silently ignored.
+const maxPreVersionLines = 1024
+
 // Read version string as specified by RFC 4253, section 4.2.
 func readVersion(r io.Reader) ([]byte, error) {
 	versionString := make([]byte, 0, 64)
 	var ok bool
 	var buf [1]byte
 
-	for length := 0; length < maxVersionStringBytes; length++ {
+	for lines := 0; len(versionString) < maxVersionStringBytes && lines < maxPreVersionLines; {
 		_, err := io.ReadFull(r, buf[:])
 		if err != nil {
 			return nil, err
@@ -347,9 +353,9 @@ func readVersion(r io.Reader) ([]byte, error) {
 		if buf[0] == '\n' {
 			if !bytes.HasPrefix(versionString, []byte("SSH-")) {
 				// RFC 4253 says we need to ignore all version string lines
-				// except the one containing the SSH version (provided that
-				// all the lines do not exceed 255 bytes in total).
+				// except the one containing the SSH version.
 				versionString = versionString[:0]
+				lines++
 				continue
 			}
 			ok = true

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -569,8 +569,8 @@ go.yaml.in/yaml/v2
 # go.yaml.in/yaml/v3 v3.0.5
 ## explicit; go 1.16
 go.yaml.in/yaml/v3
-# golang.org/x/crypto v0.55.0
-## explicit; go 1.25.0
+# golang.org/x/crypto v0.56.0
+## explicit; go 1.26.0
 golang.org/x/crypto/blowfish
 golang.org/x/crypto/chacha20
 golang.org/x/crypto/cryptobyte


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
Trivy image scans are failing due to two vulnerabilities detected in the vendored `golang.org/x/crypto/ssh` package:

- `CVE-2026-56855`: DoS via deadlock on an established SSH channel
- `CVE-2026-78662`: DoS via deadlock on an undecided SSH channel

Both are fixed upstream in `golang.org/x/crypto v0.56.0`. This PR bumps the dependency to that version via `go get golang.org/x/crypto@v0.56.0 && go mod tidy && go mod vendor`.

Note: `golang.org/x/crypto v0.56.0` requires `go >= 1.26.0`, so the module's `go` directive is bumped from `1.25.0` to `1.26.0` accordingly. `golang.org/x/tools`, `golang.org/x/mod`, and `golang.org/x/text` are also bumped transitively to satisfy `go mod tidy`.

**Which issue(s) this PR fixes**:
Fixes failing Trivy CI scan (2 UNKNOWN-severity vulnerabilities in `azurediskplugin` gobinary target).

**Special notes for your reviewer**:
- `go build ./...`, `go vet ./pkg/...` pass cleanly.
- `go test ./pkg/azuredisk/... ./pkg/azureutils/...` passes except for one pre-existing, environment-specific failure unrelated to this change (OS-dependent mount error message text).
- No functional code changes outside `go.mod`/`go.sum`/`vendor/`.

```
┌─────────────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────┐
│ Library             │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │ Title                                            │
├─────────────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────┤
│ golang.org/x/crypto │ CVE-2026-56855 │ UNKNOWN  │ fixed  │ v0.55.0           │ 0.56.0        │ Prevent DoS on deadlocked established channel in │
│                     │                │          │        │                   │               │ golang.org/x/crypto/ssh                          │
│                     │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2026-56855      │
│                     ├────────────────┤          │        │                   │               ├──────────────────────────────────────────────────┤
│                     │ CVE-2026-78662 │          │        │                   │               │ Prevent DoS on deadlocked undecided channel in   │
│                     │                │          │        │                   │               │ golang.org/x/crypto/ssh                          │
│                     │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2026-78662      │
└─────────────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────┘
```